### PR TITLE
Remove eps_h, eps_he and eps_z from argument lists of mesh adjustment routines

### DIFF
--- a/star/other/other_mesh_delta_coeff_factor.f90
+++ b/star/other/other_mesh_delta_coeff_factor.f90
@@ -39,9 +39,8 @@
       contains
       
       
-      subroutine default_other_mesh_delta_coeff_factor(id, eps_h, eps_he, eps_z, ierr)
+      subroutine default_other_mesh_delta_coeff_factor(id, ierr)
          integer, intent(in) :: id
-         real(dp), intent(in), dimension(:) :: eps_h, eps_he, eps_z
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          integer :: k

--- a/star/private/adjust_mesh.f90
+++ b/star/private/adjust_mesh.f90
@@ -64,7 +64,7 @@
             mesh_max_allowed_ratio, tmp, J_tot1, J_tot2, center_logT, alfa, beta, &
             d_dlnR00, d_dlnRp1, d_dv00, d_dvp1
          real(dp), pointer, dimension(:) :: &
-            delta_gval_max, eps_h, eps_he, eps_z, specific_PE, specific_KE, &
+            delta_gval_max, specific_PE, specific_KE, &
             xq_old, xq_new, dq_new
          real(dp), pointer :: gvals(:,:), gvals1(:)
          integer, pointer :: which_gval(:) , comes_from(:), cell_type(:)
@@ -143,10 +143,6 @@
          end if
 
          do k=1,nz
-            eps_h(k) = s% eps_nuc_categories(ipp,k) + &
-                       s% eps_nuc_categories(icno,k)
-            eps_he(k) = s% eps_nuc_categories(i3alf,k)
-            eps_z(k) = s% eps_nuc(k) - (eps_h(k) + eps_he(k))
             specific_PE(k) = cell_specific_PE(s,k,d_dlnR00,d_dlnRp1)
             specific_KE(k) = cell_specific_KE(s,k,d_dv00,d_dvp1)
          end do
@@ -258,7 +254,7 @@
 
          call get_gval_info( &
                s, delta_gval_max, gvals1, nz, &
-               eps_h, eps_he, eps_z, num_gvals, gval_names, &
+               num_gvals, gval_names, &
                gval_is_xa_function, gval_is_logT_function, ierr)
          if (ierr /= 0) then
             s% termination_code = t_adjust_mesh_failed
@@ -435,7 +431,7 @@
             call write_plot_data_for_mesh_plan( &
                s, nz_old, nz, prv% xh, prv% xa, &
                prv% lnd, prv% lnT, prv% lnPgas, prv% lnE, prv% eturb, &
-               eps_h, eps_he, eps_z, prv% D_mix, prv% mixing_type, &
+               prv% D_mix, prv% mixing_type, &
                prv% dq, prv% q, xq_old, prv% q, &
                s% species, s% i_lnR, s% i_lum, s% i_v, s% i_u, comes_from, &
                num_gvals, gval_names, gvals, delta_gval_max, &
@@ -552,7 +548,7 @@
          if (dumping) then
             call write_plot_data_for_new_mesh( &
                s, nz, nz_old, prv% xh, prv% xa, &
-               eps_h, eps_he, eps_z, prv% D_mix, prv% q, &
+               prv% D_mix, prv% q, &
                s% xh, s% xa, s% dq, s% q, xq_new, s% species, s% net_iso, &
                num_gvals, gval_names, gvals, &
                which_gval, comes_from, cell_type, delta_gval_max, &
@@ -654,7 +650,7 @@
 
          subroutine nullify_work_ptrs
             nullify( &
-               eps_h, eps_he, which_gval, xq_old, xq_new, dq_new, comes_from, &
+               which_gval, xq_old, xq_new, dq_new, comes_from, &
                delta_gval_max, do_not_split, gvals, cell_type)
          end subroutine nullify_work_ptrs
 
@@ -683,15 +679,6 @@
             integer, intent(out) :: ierr
             logical, parameter :: crit = .false.
             ierr = 0
-            call work_array(s, alloc_flag, crit, &
-               eps_h, nz, nz_alloc_extra, 'adjust_mesh', ierr)
-            if (ierr /= 0) return
-            call work_array(s, alloc_flag, crit, &
-               eps_he, nz, nz_alloc_extra, 'adjust_mesh', ierr)
-            if (ierr /= 0) return
-            call work_array(s, alloc_flag, crit, &
-               eps_z, nz, nz_alloc_extra, 'adjust_mesh', ierr)
-            if (ierr /= 0) return
             call work_array(s, alloc_flag, crit, &
                specific_PE, nz, nz_alloc_extra, 'adjust_mesh', ierr)
             if (ierr /= 0) return

--- a/star/private/adjust_mesh_plot.f90
+++ b/star/private/adjust_mesh_plot.f90
@@ -36,7 +36,7 @@
 
       subroutine write_plot_data_for_new_mesh( &
             s, nz, nz_old, xh_old, xa_old, &
-            eps_h, eps_he, eps_z, D_mix, q_old, &
+            D_mix, q_old, &
             xh, xa, dq, q, xq, species, net_iso, &
             num_gvals, gval_names, gvals, &
             which_gval, comes_from, cell_type, &
@@ -52,7 +52,7 @@
          integer, dimension(:), pointer :: net_iso
          real(dp), intent(in) :: xmstar
          real(dp), dimension(:), pointer :: &
-            q_old, dq, q, xq, eps_h, eps_he, eps_z, D_mix
+            q_old, dq, q, xq, D_mix
          real(dp), dimension(:), pointer :: delta_gval_max
          real(dp), dimension(:,:), pointer :: xh_old, xa_old
          real(dp), dimension(:,:), pointer :: xh, xa
@@ -67,7 +67,7 @@
          real(dp) :: v, u, ratio, lum, min_ratio, mstar, lgRho, lgT
          real(dp), pointer :: v_old(:), v_new(:,:), work(:)
          integer :: k, nwork, num_vals, iounit, k_min_ratio, d_comes_from_dk, &
-            jeps_h, jeps_he, jeps_z, jD_mix, jgval_factor, jgval_max1, &
+            jD_mix, jgval_factor, jgval_max1, &
             jlogR, jFL, jv, ju, j, &
             i_lum, i_lnd, i_lnT, i_v, i_u, i_lnR
          character (len=100) :: filename, name
@@ -96,9 +96,6 @@
          nwork = mp_work_size
          j = 0
          j = j+1; jgval_max1 = j
-         j = j+1; jeps_h = j
-         j = j+1; jeps_he = j
-         j = j+1; jeps_z = j
          j = j+1; jD_mix = j
          j = j+1; jlogR = j
          j = j+1; jFL = j
@@ -115,30 +112,6 @@
          end if
 
          ! interpolate from old values to new points for comparison
-
-         do k=1,nz_old
-            v_old(k) = safe_log10(eps_h(k))
-         end do
-         call interpolate_vector( &
-               nz_old, q_old, nz, q, v_old, v_new(:,jeps_h), interp_m3q, nwork, work, &
-               'write_plot_data_for_new_mesh', ierr)
-         v_new(:,jeps_h) = max(-99d0, v_new(:,jeps_h))
-
-         do k=1,nz_old
-            v_old(k) = safe_log10(eps_he(k))
-         end do
-         call interpolate_vector( &
-               nz_old, q_old, nz, q, v_old, v_new(:,jeps_he), interp_m3q, nwork, work, &
-               'write_plot_data_for_new_mesh', ierr)
-         v_new(:,jeps_he) = max(-99d0, v_new(:,jeps_he))
-
-         do k=1,nz_old
-            v_old(k) = safe_log10(eps_z(k))
-         end do
-         call interpolate_vector( &
-               nz_old, q_old, nz, q, v_old, v_new(:,jeps_z), interp_m3q, nwork, work, &
-               'write_plot_data_for_new_mesh', ierr)
-         v_new(:,jeps_z) = max(-99d0, v_new(:,jeps_z))
 
          do k=1,nz_old
             v_old(k) = safe_log10(D_mix(k))
@@ -218,7 +191,7 @@
             write(iounit, fmt='(a27, 1x)', advance='no') trim(name)
          end do
          write(iounit, fmt='(99(a27, 1x))', advance='no') &
-            'log_eps_h', 'log_eps_he', 'log_eps_z', 'log_D', &
+            'log_D', &
             'mass', 'xq', 'radius', 'logR', 'logT', 'logRho', 'logPgas', &
             'lum', 'v'
          do j=1,num_gvals
@@ -278,7 +251,7 @@
                write(iounit, fmt='(99(1pes27.16e3,1x))', advance='no') v_new(k,jgval_factor+j)
             end do
             write(iounit, fmt='(99(1pes27.16e3,1x))', advance='no') &
-               v_new(k,jeps_h), v_new(k,jeps_he), v_new(k,jeps_z), v_new(k,jD_mix), &
+               v_new(k,jD_mix), &
                s% m(k)/Msun, xq(k), exp(xh(i_lnR,k))/Rsun, &
                xh(i_lnR,k)/ln10, lgT, lgRho, lum/Lsun, v
             do j=1,num_gvals
@@ -314,7 +287,7 @@
       subroutine write_plot_data_for_mesh_plan( &
             s, nz_old, nz_new, xh_old, xa_old, &
             lnd_old, lnT_old, lnPgas_old, lnE_old, wturb_old, &
-            eps_h, eps_he, eps_z, D_mix, mixing_type, &
+            D_mix, mixing_type, &
             dq_old, q_old, xq_old, q_new, &
             species, i_lnR, i_lum, i_v, i_u, comes_from, &
             num_gvals, gval_names, gvals, delta_gval_max, &
@@ -332,7 +305,7 @@
          real(dp), dimension(:), pointer :: &
             dq_old, q_old, xq_old, q_new, &
             lnd_old, lnT_old, lnPgas_old, lnE_old, wturb_old, &
-            eps_h, eps_he, eps_z, D_mix
+            D_mix
          real(dp), dimension(:, :), pointer :: xh_old, xa_old
 
          integer, intent(in) :: num_gvals
@@ -381,7 +354,7 @@
             write(iounit, fmt='(a27, 1x)', advance='no') 'd_dk_' // trim(name)
          end do
          write(iounit, fmt='(99(a27, 1x))', advance='no') &
-            'log_eps_h', 'log_eps_he', 'log_eps_z', 'log_D', 'mixing_type', 'mass', &
+            'log_D', 'mixing_type', 'mass', &
             'xq', 'radius', 'logR', 'logRho', 'logT', 'logP', 'logPgas', &
             'logE', 'wturb', 'lum', 'v', 'u'
          write(iounit,*)
@@ -417,7 +390,6 @@
                end if
             end do
             write(iounit, fmt='(99(1pes27.16e3,1x))', advance='no') &
-               safe_log10(eps_h(k)), safe_log10(eps_he(k)), safe_log10(eps_z(k)), &
                log10(max(1d0,D_mix(k))), dble(mixing_type(k)), &
                (s% M_center + xmstar*q_old(k))/Msun, xq_old(k), exp(xh_old(i_lnR,k))/Rsun, &
                xh_old(i_lnR,k)/ln10, lnd_old(k)/ln10, lnT_old(k)/ln10, &

--- a/star/private/adjust_mesh_support.f90
+++ b/star/private/adjust_mesh_support.f90
@@ -40,7 +40,7 @@
 
       subroutine get_gval_info( &
             s, delta_gval_max, gvals1, nz, &
-            eps_h, eps_he, eps_z, num_gvals, gval_names, &
+            num_gvals, gval_names, &
             gval_is_xa_function, gval_is_logT_function, ierr)
          use chem_def
          use num_lib, only: find0
@@ -48,7 +48,7 @@
          use alloc
          use mesh_functions, only: set_mesh_function_data, max_allowed_gvals
          type (star_info), pointer :: s
-         real(dp), dimension(:), pointer :: eps_h, eps_he, eps_z, delta_gval_max
+         real(dp), dimension(:), pointer :: delta_gval_max
          real(dp), dimension(:), pointer :: gvals1
          integer, intent(in) :: nz, num_gvals
          integer, intent(out) :: ierr
@@ -126,7 +126,7 @@
                do k=1,nz
                   s% mesh_delta_coeff_factor(k) = delta_gval_max(k)
                end do
-               call s% other_mesh_delta_coeff_factor(s% id, eps_h, eps_he, eps_z, ierr)
+               call s% other_mesh_delta_coeff_factor(s% id, ierr)
                if (ierr /= 0) then
                   write(*,*) 'other_mesh_delta_coeff_factor returned ierr', ierr
                   return

--- a/star/test_suite/other_physics_hooks/src/xtrans_mesh_factor/xtrans_mesh_factor.inc
+++ b/star/test_suite/other_physics_hooks/src/xtrans_mesh_factor/xtrans_mesh_factor.inc
@@ -34,9 +34,8 @@
       end subroutine read_inlist_xtrans_mesh_factor
 
       
-      subroutine other_mesh_delta_coeff_factor(id, eps_h, eps_he, eps_z, ierr)
+      subroutine other_mesh_delta_coeff_factor(id, ierr)
          integer, intent(in) :: id
-         real(dp), intent(in), dimension(:) :: eps_h, eps_he, eps_z
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          integer :: k, nz, prev_jmax, jmax

--- a/star_data/public/star_data_def.inc
+++ b/star_data/public/star_data_def.inc
@@ -804,10 +804,9 @@
          end subroutine other_overshooting_scheme_interface
       
       
-         subroutine other_mesh_delta_coeff_factor_interface(id, eps_h, eps_he, eps_z, ierr)
+         subroutine other_mesh_delta_coeff_factor_interface(id, ierr)
             use const_def, only: dp
             integer, intent(in) :: id
-            real(dp), intent(in), dimension(:) :: eps_h, eps_he, eps_z
             integer, intent(out) :: ierr
          end subroutine other_mesh_delta_coeff_factor_interface
       


### PR DESCRIPTION
While experimenting with `other_mesh_delta_coeff_factor`, I noticed it has the arguments `eps_h`, `eps_he` and `eps_z`, which seemed redundant because they can be extracted from the star pointer anyway. I had a look through the mesh spacing routines that call `other_mesh_delta_coeff_factor` and they don't use the `eps_{h,he,z}` arguments themselves: they only pass them to `other_...`. So I presume they're left over from something that was removed. This PR simplifies the mesh interfaces by removing `eps_{h,he,z}`.

I have **not** specifically tested the routines that dump the mesh data (see `star/private/adjust_mesh_plot.f90`) and I don't think anything in the test suite does.

The only test case that uses these arrays in a non-trivial way is `1M_pre_ms_to_wd`. I had a look at how they were being used and replaced them with a slightly simpler arrangement based on the removed code. Whoever is responsible/interested in `1M_pre_ms_to_wd` should review this but I compared the `./rn` output before and after this change and it appears to be identical.

 `svn blame` says Bill P added those lines back in r13095. The message was:
````
remove agb test case since is now redundant with modified 1M_pre_ms_to_wd
````
so they might actually go back to the now-removed `agb` test.

Not sure what the consensus is on how to present this yet but this PR is [currently passing](https://testhub.mesastar.org/remove-mesh-eps-args/commits/b2840d6).