### PR TITLE
Add T(τ) relation by Ball (2021, RNAAS 5, 7)

### DIFF
--- a/atm/public/atm_def.f90
+++ b/atm/public/atm_def.f90
@@ -41,6 +41,7 @@ module atm_def
   integer, parameter :: ATM_T_TAU_EDDINGTON = 1
   integer, parameter :: ATM_T_TAU_SOLAR_HOPF = 2
   integer, parameter :: ATM_T_TAU_KRISHNA_SWAMY = 3
+  integer, parameter :: ATM_T_TAU_TRAMPEDACH_SOLAR = 4
 
   ! Tables
 

--- a/atm/test/src/test_atm_support.f
+++ b/atm/test/src/test_atm_support.f
@@ -58,6 +58,7 @@ contains
     call test_T_tau_varying(ATM_T_TAU_EDDINGTON, 'Eddington', -1._dp)
     call test_T_tau_varying(ATM_T_TAU_KRISHNA_SWAMY, 'Krishna-Swamy', -1._dp)
     call test_T_tau_varying(ATM_T_TAU_SOLAR_HOPF, 'solar Hopf', -1._dp)
+    call test_T_tau_varying(ATM_T_TAU_TRAMPEDACH_SOLAR, 'Trampedach solar', -1._dp)
     call test_T_tau_varying(ATM_T_TAU_EDDINGTON, 'Eddington', 100._dp)
 
     call test_T_tau_uniform('fixed', 100._dp)

--- a/atm/test/test_output
+++ b/atm/test/test_output
@@ -59,6 +59,12 @@
             5776      3.76162718      4.83676375      1.00000000      1.00277250      0.70000000      0.02000000
 
 
+ test_T_tau_varying: Trampedach solar
+
+               T           log T           log P          M/Msun          L/Lsun               X               Z
+            5776      3.76162762      4.89369975      1.00000000      1.00277250      0.70000000      0.02000000
+
+
  test_T_tau_varying: Eddington
 
                T           log T           log P          M/Msun          L/Lsun               X               Z

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4171,6 +4171,10 @@
       ! + ``'Krishna_Swamy'`` :
       ! use the grey T(tau) relation described by K.S. Krishna-Swamy, ApJ 145,
       ! 174–194 (1966).
+      ! + ``'Trampedach_solar'`` :
+      ! use the analytic fit by Ball (2021, RNAAS 5, 7) to the Hopf
+      ! function for the solar simulation by Trampedach et al. (2014,
+      ! MNRAS 442, 805–820)
 
       ! ::
 

--- a/star/private/atm_support.f90
+++ b/star/private/atm_support.f90
@@ -430,7 +430,8 @@ contains
     use atm_def, only: &
          ATM_T_TAU_EDDINGTON, &
          ATM_T_TAU_SOLAR_HOPF, &
-         ATM_T_TAU_KRISHNA_SWAMY
+         ATM_T_TAU_KRISHNA_SWAMY, &
+         ATM_T_TAU_TRAMPEDACH_SOLAR
     
     character(*), intent(in) :: T_tau_relation
     integer, intent(out)     :: T_tau_id
@@ -447,6 +448,8 @@ contains
        T_tau_id = ATM_T_TAU_SOLAR_HOPF
     case ('Krishna_Swamy')
        T_tau_id = ATM_T_TAU_KRISHNA_SWAMY
+    case ('Trampedach_solar')
+       T_tau_id = ATM_T_TAU_TRAMPEDACH_SOLAR
     case default
        write(*,*) 'Unknown value for atm_T_tau_relation: ' // trim(T_tau_relation)
        stop 'Please amend your inlist file to correct this problem'

--- a/star/test_suite/T_tau_gradr/src/run_star_extras.f90
+++ b/star/test_suite/T_tau_gradr/src/run_star_extras.f90
@@ -31,7 +31,8 @@
       use atm_def, only: &
          ATM_T_TAU_EDDINGTON, &
          ATM_T_TAU_SOLAR_HOPF, &
-         ATM_T_TAU_KRISHNA_SWAMY
+         ATM_T_TAU_KRISHNA_SWAMY, &
+         ATM_T_TAU_TRAMPEDACH_SOLAR
       
       implicit none
 
@@ -140,6 +141,8 @@
             case ('solar_Hopf')
                s% atm_T_tau_relation = 'Krishna_Swamy'
             case ('Krishna_Swamy')
+               s% atm_T_tau_relation = 'Trampedach_solar'
+            case ('Trampedach_solar')
                s% atm_T_tau_relation = 'Eddington'
             case default
                write(*,*) 'Invalid atm_T_tau_relation: ', s% atm_T_tau_relation
@@ -222,6 +225,8 @@
          character(*), intent(in) :: name
          real(dp), intent(in) :: tau
 
+         real(dp) :: x
+
          select case (name)
          case ('Eddington')
             q = two_thirds
@@ -231,6 +236,10 @@
          case ('Krishna_Swamy')
             q = 1.39_dp - 0.815_dp*exp(-2.54_dp*tau) &
                   - 0.025_dp*exp(-30.0_dp*tau)
+         case ('Trampedach_solar')
+            x = log10(tau)
+            q = 0.6887302005929656_dp + 0.0668697860833449_dp*(x-0.1148742902769433_dp) &
+                  + 0.7657856893402466_dp*exp((x-0.9262126497691250_dp)/0.7657856893402466_dp)
          case default
             write(*,*) 'Invalid name in q: ', name
             call mesa_error(__FILE__,__LINE__)


### PR DESCRIPTION
This adds the new T(τ) relation I published in [Ball (2021, RNAAS 5, 7)](https://iopscience.iop.org/article/10.3847/2515-5172/abd9cb), which is a fit to the solar simulation by [Trampedach et al. (2014, MNRAS 442, 805)](https://ui.adsabs.harvard.edu/abs/2014MNRAS.442..805T). Note that I use the approximate form of the Hopf function q(τ) so emit a warning if this is evaluated at optical depths greater than the range of validity I define in the Note (i.e. x = log₁₀τ < 0.071).

The implementation is included in the unit tests and is tested by the `T_tau_gradr` test case.