### PR TITLE
Eliminate 5 multiplications and one parameter in eosdt_support:Do_EoS_Interpolations

### DIFF
--- a/eos/private/eosdt_support.f90
+++ b/eos/private/eosdt_support.f90
@@ -51,7 +51,6 @@
          real(dp), intent(inout), dimension(nv) :: fval, df_dx, df_dy
          integer, intent(out) :: ierr
    
-         real(dp), parameter :: z36th = 1d0/36d0
          real(dp) :: xp, xpi, xp2, xpi2, ax, axbar, bx, bxbar, cx, cxi, hx2, cxd, cxdi, hx, hxi
          real(dp) :: yp, ypi, yp2, ypi2, ay, aybar, by, bybar, cy, cyi, hy2, cyd, cydi, hy, hyi
          real(dp) :: sixth_hx2, sixth_hy2, z36th_hx2_hy2
@@ -111,15 +110,15 @@
                   
          sixth_hx2 = one_sixth*hx2
          sixth_hy2 = one_sixth*hy2
-         z36th_hx2_hy2 = z36th*hx2*hy2
+         z36th_hx2_hy2 = sixth_hx2*sixth_hy2
          
          sixth_hx = one_sixth*hx
-         sixth_hxi_hy2 = one_sixth*hxi*hy2
-         z36th_hx_hy2 = z36th*hx*hy2
+         sixth_hxi_hy2 = sixth_hy2*hxi
+         z36th_hx_hy2 = sixth_hx*sixth_hy2
          
-         sixth_hx2_hyi = one_sixth*hx2*hyi
+         sixth_hx2_hyi = sixth_hx2*hyi
          sixth_hy = one_sixth*hy
-         z36th_hx2_hy = z36th*hx2*hy
+         z36th_hx2_hy = sixth_hx2*sixth_hy
          
          ip1 = i+1
          jp1 = j+1


### PR DESCRIPTION
In my wandering around the code, I stumbled upon this routine for bicubic spline interpolation in `eos` and noticed that 5 multiplications and one parameter (for 1/36) can be eliminated by re-using some numbers that are already being computed.

This commit (19378a3) is [passing](https://testhub.mesastar.org/eos-interp-tweak/commits/19378a3). I looked around at some runtimes and saw a general mix of small losses and gains, except that `20M_z2m2_high_rotation` now takes about 50% more steps and took a similarly longer time to finish on `helios`.

I wasn't sure if a PR for six lines was overkill but this presumably affects a lot of models.