### PR TITLE
Remove some old approaches to calculating brunt B term

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -7502,18 +7502,6 @@
     threshold_for_smooth_brunt_B = 0d0
 
 
-      ! use_brunt_gradmuX_form
-      ! ~~~~~~~~~~~~~~~~~~~~~~
-
-      ! For comparison to older codes.
-      ! Assumes ideal gas plus radiation for ``brunt_B``.
-      ! Uses hydrogen mass fraction to estimate dlnmu = dX/(X + 0.6).
-
-      ! ::
-
-    use_brunt_gradmuX_form = .false.
-
-
       ! min_magnitude_brunt_B
       ! ~~~~~~~~~~~~~~~~~~~~~
 

--- a/star/private/brunt.f90
+++ b/star/private/brunt.f90
@@ -63,12 +63,6 @@
                 s% retry_message = 'failed in other_brunt'
                 if (s% report_ierr) write(*, *) s% retry_message
             end if
-         else if (s% use_brunt_gradmuX_form) then
-            call do_brunt_B_gradmuX_form(s,ierr)
-            if (ierr /= 0) then
-                s% retry_message = 'failed in do_brunt_B_gradmuX_form'
-                if (s% report_ierr) write(*, *) s% retry_message
-            end if
          else
             call do_brunt_B_MHM_form(s,ierr)
             if (ierr /= 0) then
@@ -400,114 +394,6 @@
          end if
 
       end subroutine get_brunt_B
-
-
-      ! dlnRho_form
-
-      !   A = (1/gamma1)*(dlnP/dlnR) - (dlnRho/dlnR)
-      !   N2 = A*g/r
-      !
-      !   N2 = g^2 * (rho/P)*(chiT/chiRho) * (B - (gradT_sub_grada))
-      !
-      !   B = gradT_sub_grada + N2/(g^2 * (rho/P)*(chiT/chiRho))
-
-      ! treat gamma1, lnP, and lnd as values at rmid
-      ! interpolate to r at edge to get gamma1_edge, lnP_edge, lnd_edge
-      ! using lnR as x, interpolate to get slopes dlnP/dlnR and dlnd/dlnR at edges
-      ! combine those results to get A.  then N2 from A.
-      ! interpolate in m to get (rho/P)*(chiT/chiRho) at edge.
-      ! use that with N2 to get B for use with Ledoux
-
-      subroutine do_brunt_B_dlnRho_form(s,rho_P_chiT_chiRho_face,ierr)
-
-         type (star_info), pointer :: s
-         real(dp), intent(in) :: rho_P_chiT_chiRho_face(:)
-         integer, intent(out) :: ierr
-
-         real(dp) :: alfa, beta, gamma1_face, P_face, dr, dlnd_dr, &
-            dlnP_dr, brunt_N2
-         integer :: nz, k, species
-         logical, parameter :: dbg = .false.
-
-         include 'formats'
-
-         ierr = 0
-         nz = s% nz
-         species = s% species
-
-         !   A = (1/gamma1)*(dlnP/dlnR) - (dlnRho/dlnR)
-         !   N2 = A*g/r = g*((dlnP/dr)/gamma1 - (dlnRho/dr))
-         !   N2 = g^2 * (rho/P)*(chiT/chiRho) * (B - (gradT_sub_grada))
-         !   B = gradT_sub_grada + N2/(g^2 * (rho/P)*(chiT/chiRho))
-
-         do k=2,nz
-            alfa = s% dq(k-1)/(s% dq(k-1) + s% dq(k))
-            beta = 1 - alfa
-            gamma1_face = alfa*s% gamma1(k) + beta*s% gamma1(k-1)
-            P_face = alfa*s% P(k) + beta*s% P(k-1)
-            dr = s% rmid(k-1) - s% rmid(k)
-            dlnd_dr = (s% lnd(k-1) - s% lnd(k))/dr
-            dlnP_dr = (s% P(k-1) - s% P(k))/(P_face*dr)
-            brunt_N2 = s% grav(k)*(dlnP_dr/gamma1_face - dlnd_dr)
-            !s% profile_extra(k,1) = brunt_N2
-            s% brunt_B(k) = s% gradT_sub_grada(k) + &
-               brunt_N2/(s% grav(k)*s% grav(k)*rho_P_chiT_chiRho_face(k))
-         end do
-         s% brunt_B(1) = s% brunt_B(2)
-         !s% profile_extra(1,1) = 0
-         !s% profile_extra_name(1) = 'brunt_N2_dlnRho_form'
-
-      end subroutine do_brunt_B_dlnRho_form
-
-
-      subroutine do_brunt_B_gradmuX_form(s,ierr)
-         use chem_def, only: ih1
-         type (star_info), pointer :: s
-         integer, intent(out) :: ierr
-
-         integer :: nz, h1, k
-         real(dp) :: A, B, beta_face, beta_factor, dlnmu_X, dlnP, x_face
-
-         include 'formats'
-
-         ierr = 0
-         nz = s% nz
-         h1 = s% net_iso(ih1)
-         if (h1 <= 0) then
-            s% brunt_B(1:nz) = 0
-            return
-         end if
-
-         do k = 2, nz
-            A = s% dq(k-1)/(s% dq(k-1) + s% dq(k))
-            B = 1 - A
-            beta_face = A*s% Pgas(k)/s% P(k) + B*s% Pgas(k-1)/s% P(k-1)
-            beta_factor = beta_face/(4d0 - 3d0*beta_face)
-            x_face = A*s% xa(h1,k) + B*s% xa(h1,k-1)
-            dlnmu_X = -(s% xa(h1,k-1) - s% xa(h1,k))/(x_face + 0.6d0)
-            dlnP = s% lnP(k-1) - s% lnP(k)
-            if (dlnP > -1d-50) then
-               !dlnP = -1d-50
-               s% brunt_B(k) = 0
-               cycle
-            end if
-            s% brunt_B(k) = beta_factor*dlnmu_X/dlnP
-            if (s% brunt_B(k) < -1d10 .and. k == 1496) then
-               write(*,2) 's% brunt_B(k)', k, s% brunt_B(k)
-               write(*,2) 'beta_factor', k, beta_factor
-               write(*,2) 'dlnmu_X', k, dlnmu_X
-               write(*,2) 'dlnP', k, dlnP
-               write(*,2) 's% xa(h1,k-1)', k-1, s% xa(h1,k-1)
-               write(*,2) 's% xa(h1,k)', k, s% xa(h1,k)
-               write(*,2) 's% lnP(k-1)', k-1, s% lnP(k-1)
-               write(*,2) 's% lnP(k)', k, s% lnP(k)
-               write(*,2) 's% lnP(k-1) - s% lnP(k)', k, s% lnP(k-1) - s% lnP(k)
-               stop
-            end if
-         end do
-         s% brunt_B(1) = s% brunt_B(2)
-
-      end subroutine do_brunt_B_gradmuX_form
 
 
       end module brunt

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -161,7 +161,7 @@
     max_v_for_convection, max_q_for_convection_with_hydro_on, alpha_RTI_src_max_q, &
     max_v_div_cs_for_convection, max_abs_du_div_cs_for_convection, RSP_max_dt, RSP_relax_dm_tolerance, &
     calculate_Brunt_N2, brunt_N2_coefficient, num_cells_for_smooth_brunt_B, &
-    threshold_for_smooth_brunt_B, use_brunt_gradmuX_form, min_magnitude_brunt_B, RSP_max_dt_times_min_rad_diff_time, &
+    threshold_for_smooth_brunt_B, min_magnitude_brunt_B, RSP_max_dt_times_min_rad_diff_time, &
     min_overshoot_q, overshoot_alpha, RSP_target_steps_per_cycle, &
     RSP_max_num_periods, RSP_min_max_R_for_periods, &
     RSP_min_PERIOD_div_PERIODLIN, RSP_report_limit_dt, RSP_mode_for_setting_PERIODLIN, RSP_initial_dt_factor, &
@@ -1131,7 +1131,6 @@
  s% brunt_N2_coefficient = brunt_N2_coefficient
  s% num_cells_for_smooth_brunt_B = num_cells_for_smooth_brunt_B
  s% threshold_for_smooth_brunt_B = threshold_for_smooth_brunt_B
- s% use_brunt_gradmuX_form = use_brunt_gradmuX_form
  s% min_magnitude_brunt_B = min_magnitude_brunt_B
 
  s% min_overshoot_q = min_overshoot_q
@@ -2748,7 +2747,6 @@
  calculate_Brunt_N2 = s% calculate_Brunt_N2
  brunt_N2_coefficient = s% brunt_N2_coefficient
  threshold_for_smooth_brunt_B = s% threshold_for_smooth_brunt_B
- use_brunt_gradmuX_form = s% use_brunt_gradmuX_form
  min_magnitude_brunt_B = s% min_magnitude_brunt_B
 
  min_overshoot_q = s% min_overshoot_q

--- a/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness
+++ b/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness
@@ -77,7 +77,6 @@
       
       
       num_cells_for_smooth_brunt_B = 0
-      !use_brunt_gradmuX_form = .true.
       
       !show_diffusion_info = .true. ! terminal output for diffusion
          !show_diffusion_substep_info = .true.         

--- a/star/test_suite/diffusion_smoothness/inlist_zams
+++ b/star/test_suite/diffusion_smoothness/inlist_zams
@@ -55,7 +55,6 @@
       
       
       num_cells_for_smooth_brunt_B = 0
-      !use_brunt_gradmuX_form = .true.
       
       photo_interval = 50
       profile_interval = 100

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -362,7 +362,7 @@
          integer :: RTI_smooth_iterations
 
       ! brunt
-         logical :: calculate_Brunt_N2, use_brunt_gradmuX_form
+         logical :: calculate_Brunt_N2
          real(dp) :: min_magnitude_brunt_B, brunt_N2_coefficient
          integer :: num_cells_for_smooth_brunt_B
          real(dp) :: threshold_for_smooth_brunt_B


### PR DESCRIPTION
This removes the option use_brunt_gradmuX_form and its routine
do_brunt_B_gradmux_form.  This also removes the unused routine
do_brunt_B_dlnRho_form.