### PR TITLE
[ci skip] Defined euler’s number

### DIFF
--- a/const/public/const_def.f90
+++ b/const/public/const_def.f90
@@ -50,6 +50,7 @@
       real(dp), parameter :: pi2 = pi * pi
       real(dp), parameter :: pi4 = 4*pi
       real(dp), parameter :: eulercon = 0.577215664901532861d0
+      real(dp), parameter :: eulernum = 2.71828182845904523536028747135266249d0
       real(dp), parameter :: ln2 = 6.9314718055994529D-01 ! = log(2d0)
       real(dp), parameter :: ln3 = 1.0986122886681096D+00 ! = log(3d0)
       real(dp), parameter :: lnPi = 1.14472988584940017414343_dp ! = log(pi)


### PR DESCRIPTION
Some new terms I'd like to add to Skye make use of `e` (Euler's number, ~ 2.71828...). I could define it locally, but this seems like something better put in const_def. Unfortunately `eulercon` is already defined as the Euler-Mascheroni constant, so to avoid changing that I've introduced `e` as `eulernum` (because Wikipedia calls it "Euler's number" :-)
