### PR TITLE
Close root group after reading AESOPUS opacity data

### DIFF
--- a/kap/private/kap_aesopus.f90
+++ b/kap/private/kap_aesopus.f90
@@ -379,6 +379,10 @@ contains
 
     end do
 
+    ! close root group
+    call h5gclose_f(group_id, ierr)
+    if (ierr /= 0) return
+
     ! close file
     call h5fclose_f(file_id, ierr)
     if (ierr /= 0) return


### PR DESCRIPTION
Title says it all. I've tested `c13_pocket` and `R_CrB_star` locally and the results look unchanged. Those are the only two tests in `star` that appear to use AESOPUS opacities.

TestHub results for the first commit on the branch are [here](https://testhub.mesastar.org/whb/aesopus-h5-close-root/commits/aaece43).

Memory and the old SVN logs suggest that @jschwab "owns" AESOPUS, so I wouldn't merge this until he's approved.