### PR TITLE
Turn off screening at low temperatures

### DIFF
--- a/net/private/net_screen.f90
+++ b/net/private/net_screen.f90
@@ -229,7 +229,7 @@
                call screen_pair( &
                   sc, a1, z1, a2, z2, screening_mode, &
                   g% zs13(jscr), g% zhat(jscr), g% zhat2(jscr), g% lzav(jscr), &
-                  g% aznut(jscr), g% zs13inv(jscr), &
+                  g% aznut(jscr), g% zs13inv(jscr), g% logTcut_lo, &
                   scor, scordt, scordd, ierr) 
                if (ierr /= 0) write(*,*) 'screen_pair failed in screening_pair ' // &
                      trim(reaction_name(ir)) 

--- a/rates/public/rates_lib.f90
+++ b/rates/public/rates_lib.f90
@@ -869,7 +869,7 @@
       ! make calls in exactly the same order as for screen_init_AZ_info   
       subroutine screen_pair( &
                sc, a1, z1, a2, z2, screening_mode, &
-               zs13, zhat, zhat2, lzav, aznut, zs13inv, &
+               zs13, zhat, zhat2, lzav, aznut, zs13inv, low_logT_lim, &
                scor, scordt, scordd, ierr)
          use rates_def
          use screen5, only: fxt_screen5
@@ -880,12 +880,20 @@
          integer, intent(in) :: screening_mode ! see screen_def.
          ! cached info
          real(dp), intent(in) :: zs13, zhat, zhat2, lzav, aznut, zs13inv
+         real(dp), intent(in) :: low_logT_lim ! scor==0 for T < low_logT_lim
          ! outputs
          real(dp), intent(out) :: scor ! screening factor
          real(dp), intent(out) :: scordt ! partial wrt temperature
          real(dp), intent(out) :: scordd ! partial wrt density
          integer, intent(out) :: ierr
          
+         if(sc% logT < low_logT_lim ) then
+            scor = 0d0
+            scordt=0d0
+            scordd=0d0
+            return
+         end if
+
          if (screening_mode == extended_screening) then
             call fxt_screen5( &
                sc, zs13, zhat, zhat2, lzav, aznut, zs13inv,  &

--- a/rates/test/src/test_screen.f90
+++ b/rates/test/src/test_screen.f90
@@ -189,7 +189,7 @@ module test_screen
             chem_isos% W(i1), dble(chem_isos% Z(i1)),  &
             chem_isos% W(i2), dble(chem_isos% Z(i2)),  &
             sc_mode, &
-            zs13, zhat, zhat2, lzav, aznut, zs13inv, &
+            zs13, zhat, zhat2, lzav, aznut, zs13inv, rattab_tlo,&
             sc1a, sc1adt, sc1add, ierr)
          if (ierr /= 0) return
 


### PR DESCRIPTION
We zero out the rate anyway below rattab_tlo so there is no point
computing the screening factor just to throw it away.

We don't need a blend here as the rate code already handles blending between
rattab_lo and  logTcut_lim (net_screen)