### PR TITLE
Update the documentation for new_net_name in star_job.defaults to point to list of net names

### DIFF
--- a/star/defaults/star_job.defaults
+++ b/star/defaults/star_job.defaults
@@ -2386,7 +2386,7 @@
       ! ~~~~~~~~~~~~~~~~~~
 
       ! For switching reaction networks.
-      ! ``new_net_name`` only used if ``change_net`` if true.
+      ! ``new_net_name`` only used if ``change_net`` if true. The list of network names can be found in `$MESA_DIR/data/net_data/nets`. 
 
       ! ::
 


### PR DESCRIPTION
One can find similar documentation in the [https://docs.mesastar.org/en/latest/reference/controls.html#default-net-name](controls docs). 