### PR TITLE
[ci skip] Changed mixing_type logic to use rotation_mixing if that co…

### DIFF
--- a/star/private/mix_info.f90
+++ b/star/private/mix_info.f90
@@ -295,7 +295,7 @@
             do k = 2, nz
                if (s% D_mix(k) < 1d-10) s% D_mix(k) = 0d0
                s% cdc(k) = s% D_mix(k)*cdc_factor(k)
-               if (s% D_mix(k) /= 0 .and. s% mixing_type(k) == no_mixing) then
+               if (s% D_mix(k) /= 0 .and. s% D_mix_non_rotation(k) < s% D_mix_rotation(k)) then
                   s% mixing_type(k) = rotation_mixing
                end if
             end do


### PR DESCRIPTION
This is my attempt to resolve issue #180. As far as I can tell the logic for setting mixing_type has two stages:

1. First the answer from MLT is set. This includes convective, overshoot, thermohaline, and `no_mixing`.
2. If the answer from MLT is `no_mixing` then it considers setting the type to `rotation_mixing`.

The changes in this branch allow the type to be set to `rotation_mixing` even if MLT has set something else, so long as the rotational mixing exceeds the non-rotational mixing.