### PR TITLE
Remove most pointers from pgstar code

### DIFF
--- a/star/other/sample_pgstar_plot.f90
+++ b/star/other/sample_pgstar_plot.f90
@@ -218,7 +218,7 @@
          real :: windy, xmargin
          real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy
          integer :: grid_min, grid_max, npts, nz
-         real, pointer, dimension(:) :: xvec, yvec, yvec2, yvec3
+         real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
          
          logical :: dbg = .false.
          

--- a/star/private/pgstar_abundance.f90
+++ b/star/private/pgstar_abundance.f90
@@ -100,7 +100,7 @@
          integer, intent(out) :: ierr
 
          character (len=strlen) :: str
-         real, pointer, dimension(:) :: xvec, yvec
+         real, allocatable, dimension(:) :: xvec, yvec
          real :: xmin, xmax, xleft, xright, dx, dylbl, chScale, windy, xmargin, &
             ymin, ymax, legend_xmin, legend_xmax, legend_ymin, legend_ymax
          integer :: lw, lw_sav, grid_min, grid_max, npts, i, nz

--- a/star/private/pgstar_color_magnitude.f90
+++ b/star/private/pgstar_color_magnitude.f90
@@ -637,9 +637,9 @@
          character (len=strlen) :: yname, other_yname
          character (len=strlen) :: yname1,yname2, &
             other_yname1,other_yname2
-         real, pointer, dimension(:) :: xvec1,xvec2, yvec1,yvec2,&
+         real, allocatable, dimension(:) :: xvec1,xvec2, yvec1,yvec2,&
             other_yvec1,other_yvec2
-         real, pointer, dimension(:) :: xvec, yvec, other_yvec
+         real, allocatable, dimension(:) :: xvec, yvec, other_yvec
 
          integer :: i, ii, n, j, k, max_width, step_min, step_max, &
             y_color, other_y_color, yaxis_id, other_yaxis_id, &
@@ -876,7 +876,7 @@
 
          logical function get1_yvec(name, vec)
             character (len=*) :: name
-            real, dimension(:), pointer :: vec
+            real, dimension(:), allocatable :: vec
             get1_yvec = get1_hist_yvec(s, step_min, step_max, n, name, vec)
          end function get1_yvec
 

--- a/star/private/pgstar_dynamo.f90
+++ b/star/private/pgstar_dynamo.f90
@@ -130,7 +130,7 @@
          real :: windy, xmargin
          real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy
          integer :: grid_min, grid_max, npts, nz
-         real, pointer, dimension(:) :: xvec, yvec, yvec2, yvec3
+         real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
 
          include 'formats'
          ierr = 0

--- a/star/private/pgstar_full.f90
+++ b/star/private/pgstar_full.f90
@@ -1630,7 +1630,7 @@
          type (star_info), pointer :: s
          character (len=*), intent(in) :: xaxis_by
          real, intent(in) :: win_xmin_in, win_xmax_in, xmargin
-         real, pointer, dimension(:) :: xvec
+         real, allocatable, dimension(:) :: xvec
          real, intent(out) :: xmin, xmax, xleft, xright, dx
          integer, intent(out) :: grid_min, grid_max, npts
          integer, intent(out) :: ierr
@@ -1683,11 +1683,10 @@
          contains 
          
          subroutine dealloc(x)
-            real, dimension(:), pointer :: x
+            real, dimension(:), allocatable :: x
             
-            if(associated(x))then
+            if(allocated(x))then
                deallocate(x)
-               nullify(x)
             end if
          
          end subroutine dealloc

--- a/star/private/pgstar_hist_track.f90
+++ b/star/private/pgstar_hist_track.f90
@@ -650,12 +650,12 @@
          real :: xmin, xmax, ymin, ymax, xleft, xright, ybot, ytop
          integer :: i, j, j_min, j_max, step_min, step_max
          real :: dx, dy, xplus, xminus, yplus, yminus
-         real, dimension(:), pointer :: xvec, yvec
+         real, dimension(:), allocatable :: xvec, yvec
          character (len=strlen) :: str
          integer :: k, n
          integer :: ix, iy
          integer :: file_data_len
-         real, pointer, dimension(:) :: file_data_xvec, file_data_yvec
+         real, allocatable, dimension(:) :: file_data_xvec, file_data_yvec
 
          logical, parameter :: dbg = .false.
 

--- a/star/private/pgstar_history_panels.f90
+++ b/star/private/pgstar_history_panels.f90
@@ -642,9 +642,9 @@
          procedure(pgstar_decorator_interface), pointer :: pgstar_decorator
 
          character (len=strlen) :: yname, other_yname, hist_xaxis_name
-         real, pointer, dimension(:) :: xvec, yvec, other_yvec
-         real, pointer, dimension(:) :: yfile_xdata, other_yfile_xdata
-         real, pointer, dimension(:) :: yfile_ydata, other_yfile_ydata
+         real, allocatable, dimension(:) :: xvec, yvec, other_yvec
+         real, allocatable, dimension(:) :: yfile_xdata, other_yfile_xdata
+         real, allocatable, dimension(:) :: yfile_ydata, other_yfile_ydata
          integer :: i, ii, n, j, k, max_width, step_min, step_max, &
             y_color, other_y_color, yaxis_id, other_yaxis_id, &
             clr_sav, npts, yfile_data_len, other_yfile_data_len
@@ -872,7 +872,6 @@
                   call pgline( &
                      other_yfile_data_len, other_yfile_xdata, other_yfile_ydata)
                   deallocate(other_yfile_xdata, other_yfile_ydata)
-                  nullify(other_yfile_xdata, other_yfile_ydata)
                else
                   call pgline(n, xvec, other_yvec)
                end if
@@ -943,7 +942,6 @@
                   call pgline(yfile_data_len, yfile_xdata, yfile_ydata)
                   call pgsls(1)
                   deallocate(yfile_xdata, yfile_ydata)
-                  nullify(yfile_xdata, yfile_ydata)
                else
                   call pgsls(s% pgstar_history_line_style)
                   call pgline(n, xvec, yvec)
@@ -971,7 +969,7 @@
 
          logical function get1_yvec(name, vec)
             character (len=*) :: name
-            real, dimension(:), pointer :: vec
+            real, dimension(:), allocatable :: vec
             get1_yvec = get1_hist_yvec(s, step_min, step_max, n, name, vec)
          end function get1_yvec
 

--- a/star/private/pgstar_kipp.f90
+++ b/star/private/pgstar_kipp.f90
@@ -75,7 +75,7 @@
          integer :: i, ii, n, step_min, step_max
          real :: xmin, xmax, ymin_L_axis, ymax_L_axis, &
             ymin_mass_axis, ymax_mass_axis, dx, burn_type_cutoff
-         real, pointer, dimension(:) :: xvec, &
+         real, allocatable, dimension(:) :: xvec, &
             log_L, &
             log_Lneu, &
             log_LH, &
@@ -355,7 +355,7 @@
 
          logical function get1_yvec(name, vec)
             character (len=*) :: name
-            real, dimension(:), pointer :: vec
+            real, dimension(:), allocatable :: vec
             get1_yvec = get1_hist_yvec(s, step_min, step_max, n, name, vec)
          end function get1_yvec
 

--- a/star/private/pgstar_mixing_ds.f90
+++ b/star/private/pgstar_mixing_ds.f90
@@ -153,7 +153,7 @@
          real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax
          integer :: grid_min, grid_max, npts, nz, number_of_legend_lines
-         real, pointer, dimension(:) :: &
+         real, allocatable, dimension(:) :: &
             xvec, yvec, y_conv, y_left, y_sc, y_ovr, y_th, y_min_mix, y_RTI_mix
 
          include 'formats'

--- a/star/private/pgstar_mode_prop.f90
+++ b/star/private/pgstar_mode_prop.f90
@@ -97,7 +97,7 @@
          integer, intent(out) :: ierr
 
          character (len=strlen) :: str
-         real, pointer, dimension(:) :: xvec, log_brunt_nu, &
+         real, allocatable, dimension(:) :: xvec, log_brunt_nu, &
             log_lamb_Sl1, log_lamb_Sl2, log_lamb_Sl3, temp_vec
          real :: xmin, xmax, xleft, xright, dx, chScale, windy, &
             ymin, ymax, exp10_ymin, xmargin, &

--- a/star/private/pgstar_power.f90
+++ b/star/private/pgstar_power.f90
@@ -101,7 +101,7 @@
          integer, intent(out) :: ierr
 
          character (len=strlen) :: str
-         real, pointer, dimension(:) :: xvec, yvec
+         real, allocatable, dimension(:) :: xvec, yvec
          real :: xmin, xmax, xleft, xright, dx, chScale, windy, &
             ymin, ymax, exp10_ymin, xmargin, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax

--- a/star/private/pgstar_profile_panels.f90
+++ b/star/private/pgstar_profile_panels.f90
@@ -598,9 +598,9 @@
          real(dp) :: cs, x00, xp1, ms, photosphere_logxm, xshock
          character (len=strlen) :: str, xname, yname, other_yname
          logical :: found_shock
-         real, pointer, dimension(:) :: xvec, yvec, other_yvec, unshifted_xvec
-         real, pointer, dimension(:) :: yfile_xdata, other_yfile_xdata
-         real, pointer, dimension(:) :: yfile_ydata, other_yfile_ydata
+         real, allocatable, dimension(:) :: xvec, yvec, other_yvec, unshifted_xvec
+         real, allocatable, dimension(:) :: yfile_xdata, other_yfile_xdata
+         real, allocatable, dimension(:) :: yfile_ydata, other_yfile_ydata
          integer :: yfile_data_len, other_yfile_data_len, xaxis_id
 
          include 'formats'
@@ -937,7 +937,6 @@
                   call pgline( &
                      other_yfile_data_len, other_yfile_xdata, other_yfile_ydata)
                   deallocate(other_yfile_xdata, other_yfile_ydata)
-                  nullify(other_yfile_xdata, other_yfile_ydata)
                else
                   call pgline(npts, xvec, other_yvec)
                   if (panels_show_grid) then
@@ -980,7 +979,6 @@
                call pgline(yfile_data_len, yfile_xdata, yfile_ydata)
                call pgsls(1)
                deallocate(yfile_xdata, yfile_ydata)
-               nullify(yfile_xdata, yfile_ydata)
             else
                call pgsls(s% pgstar_profile_line_style)
                call pgline(npts, xvec, yvec)

--- a/star/private/pgstar_rti.f90
+++ b/star/private/pgstar_rti.f90
@@ -75,7 +75,7 @@
          integer :: i, ii, n, step_min, step_max
          real :: xmin, xmax, ymin_L_axis, ymax_L_axis, &
             ymin_mass_axis, ymax_mass_axis, dx
-         real, pointer, dimension(:) :: xvec, star_mass, star_M_center, log_xmstar, &
+         real, allocatable, dimension(:) :: xvec, star_mass, star_M_center, log_xmstar, &
             he_core_mass, &
             c_core_mass, &
             o_core_mass, &
@@ -324,7 +324,7 @@
 
          logical function get1_yvec(name, vec)
             character (len=*) :: name
-            real, dimension(:), pointer :: vec
+            real, dimension(:), allocatable :: vec
             get1_yvec = get1_hist_yvec(s, step_min, step_max, n, name, vec)
          end function get1_yvec
 

--- a/star/private/pgstar_stub.f90
+++ b/star/private/pgstar_stub.f90
@@ -99,7 +99,7 @@
          type (star_info), pointer :: s
          character (len=*), intent(in) :: xaxis_by
          real, intent(in) :: win_xmin_in, win_xmax_in, xmargin
-         real, pointer, dimension(:) :: xvec
+         real, allocatable, dimension(:) :: xvec
          real, intent(out) :: xmin, xmax, xleft, xright, dx
          integer, intent(out) :: grid_min, grid_max, npts
          integer, intent(out) :: ierr

--- a/star/private/pgstar_summary_burn.f90
+++ b/star/private/pgstar_summary_burn.f90
@@ -75,7 +75,7 @@
 
          character (len=strlen) :: yname, xaxis_name, str
          logical :: xaxis_reversed
-         real, pointer, dimension(:) :: xvec, yvec, yvec2, yvec3
+         real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
          real :: xmin, xmax, xleft, xright, dx, windy, dy, &
             ymin, ymax, xaxis_min, xaxis_max, xmargin, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax

--- a/star/private/pgstar_summary_history.f90
+++ b/star/private/pgstar_summary_history.f90
@@ -76,7 +76,7 @@
          integer, intent(out) :: ierr
 
          character (len=strlen) :: yname
-         real, pointer, dimension(:) :: xvec, yvec
+         real, allocatable, dimension(:) :: xvec, yvec
          real :: xmin, xmax, windy, ymin, ymax, xmargin, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax
          integer :: lw, lw_sav, num_lines, &
@@ -245,7 +245,7 @@
 
          logical function get1_yvec(name, vec)
             character (len=*) :: name
-            real, dimension(:), pointer :: vec
+            real, dimension(:), allocatable :: vec
             get1_yvec = get1_hist_yvec(s, step_min, step_max, npts, name, vec)
          end function get1_yvec
 

--- a/star/private/pgstar_summary_profile.f90
+++ b/star/private/pgstar_summary_profile.f90
@@ -98,7 +98,7 @@
          integer, intent(out) :: ierr
 
          character (len=strlen) :: yname
-         real, pointer, dimension(:) :: xvec, yvec, unshifted_xvec
+         real, allocatable, dimension(:) :: xvec, yvec, unshifted_xvec
          real :: xmin, xmax, xleft, xright, dx, windy, &
             ymin, ymax, xmargin, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax

--- a/star/private/pgstar_trho_profile.f90
+++ b/star/private/pgstar_trho_profile.f90
@@ -72,7 +72,7 @@
          integer :: nz, k
          real :: xmin, xmax, ymin, ymax, xpos, ypos, dx, dy, &
             txt_scale, vpxmin, vpxmax, vpymin, vpymax, vpymargin, vpwinheight, lgT1, lgT2
-         real, pointer, dimension(:) :: xvec, yvec
+         real, allocatable, dimension(:) :: xvec, yvec
          character (len=128) :: str
          real, parameter :: lgrho1 = -8, lgrho2 = 5
 
@@ -526,7 +526,7 @@
 
 
          subroutine write_burn_line(logRho, logT, label)
-            real, dimension(:), pointer :: logRho, logT
+            real, dimension(:), allocatable :: logRho, logT
             character (len=*), intent(in) :: label
             integer :: sz
             real :: xpos, ypos

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -2801,7 +2801,7 @@
          type (star_info), pointer :: s
          character (len=*), intent(in) :: xaxis_by
          real, intent(in) :: win_xmin_in, win_xmax_in, xmargin
-         real, pointer, dimension(:) :: xvec
+         real, allocatable, dimension(:) :: xvec
          real, intent(out) :: xmin, xmax, xleft, xright, dx
          integer, intent(out) :: grid_min, grid_max, npts
          integer, intent(out) :: ierr


### PR DESCRIPTION
There are a number of possible memory links, as we do not deallocate
arrays properly when we hit an error condition. So switch to allocatables
which will be deallocated when we leave a function

Found using gcc's -fanalyzer option which does static anaylsis on the code.