### PR TITLE
Expand stub versions of `run_star_extras.f90` in `gyre_in_mesa_*` to run evolution

### DIFF
--- a/star/test_suite/gyre_in_mesa_bcep/src/run_star_extras_stub.f90
+++ b/star/test_suite/gyre_in_mesa_bcep/src/run_star_extras_stub.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2010-2019  Bill Paxton & The MESA Team
+!   Copyright (C) 2018-2019  Rich Townsend, Bill Paxton & The MESA Team
 !
 !   this file is part of mesa.
 !
@@ -19,32 +19,100 @@
 !   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
 !
 ! ***********************************************************************
- 
-      module run_star_extras
 
-      use star_lib
-      use star_def
-      use const_def
-      
-      implicit none
-      
-      ! these routines are called by the standard run_star check_model
-      contains
-      
-      subroutine extras_controls(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-            
-         write(*,*) 'matched target'
-         write(*,*) 'GYRE not installed, pretending to pass'
-         write(*,*) 'this test was intentionally skipped'
-         ierr = -1
-         
-      end subroutine extras_controls
+module run_star_extras
 
-      end module run_star_extras
-      
+  ! Uses
+
+  use star_lib
+  use star_def
+  use const_def
+  use math_lib
+
+  ! No implicit typing
+
+  implicit none
+  include "test_suite_extras_def.inc"
+
+  ! Procedures
+
+contains
+
+  include "test_suite_extras.inc"
+
+  subroutine extras_controls(id, ierr)
+
+    integer, intent(in) :: id
+    integer, intent(out) :: ierr
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'GYRE is not installed: this test will run without '
+    write(*,*) 'calling GYRE and pretend to pass'
+
+    ! Set up hooks
+
+    s% extras_startup => extras_startup
+    s% extras_finish_step => extras_finish_step
+    s% extras_after_evolve => extras_after_evolve
+
+    s% job% warn_run_star_extras =.false.
+
+  end subroutine extras_controls
+
+  !****
+
+  subroutine extras_startup(id, restart, ierr)
+
+    integer, intent(in)  :: id
+    logical, intent(in)  :: restart
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+    call test_suite_startup(s, restart, ierr)
+
+  end subroutine extras_startup
+
+  !****
+
+  integer function extras_finish_step(id)
+    integer, intent(in) :: id
+    integer :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    extras_finish_step = keep_going
+
+  end function extras_finish_step
+
+  !****
+
+  subroutine extras_after_evolve(id, ierr)
+
+    integer, intent(in)  :: id
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'matched target'
+
+    call test_suite_after_evolve(s, ierr)
+
+  end subroutine extras_after_evolve
+
+end module run_star_extras

--- a/star/test_suite/gyre_in_mesa_envelope/src/run_star_extras_stub.f90
+++ b/star/test_suite/gyre_in_mesa_envelope/src/run_star_extras_stub.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2010-2019  Bill Paxton & The MESA Team
+!   Copyright (C) 2018-2019  Rich Townsend, Bill Paxton & The MESA Team
 !
 !   this file is part of mesa.
 !
@@ -19,32 +19,100 @@
 !   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
 !
 ! ***********************************************************************
- 
-      module run_star_extras
 
-      use star_lib
-      use star_def
-      use const_def
-      
-      implicit none
-      
-      ! these routines are called by the standard run_star check_model
-      contains
-      
-      subroutine extras_controls(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-            
-         write(*,*) 'matched target'
-         write(*,*) 'GYRE not installed, pretending to pass'
-         write(*,*) 'this test was intentionally skipped'
-         ierr = -1
-         
-      end subroutine extras_controls
+module run_star_extras
 
-      end module run_star_extras
-      
+  ! Uses
+
+  use star_lib
+  use star_def
+  use const_def
+  use math_lib
+
+  ! No implicit typing
+
+  implicit none
+  include "test_suite_extras_def.inc"
+
+  ! Procedures
+
+contains
+
+  include "test_suite_extras.inc"
+
+  subroutine extras_controls(id, ierr)
+
+    integer, intent(in) :: id
+    integer, intent(out) :: ierr
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'GYRE is not installed: this test will run without '
+    write(*,*) 'calling GYRE and pretend to pass'
+
+    ! Set up hooks
+
+    s% extras_startup => extras_startup
+    s% extras_finish_step => extras_finish_step
+    s% extras_after_evolve => extras_after_evolve
+
+    s% job% warn_run_star_extras =.false.
+
+  end subroutine extras_controls
+
+  !****
+
+  subroutine extras_startup(id, restart, ierr)
+
+    integer, intent(in)  :: id
+    logical, intent(in)  :: restart
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+    call test_suite_startup(s, restart, ierr)
+
+  end subroutine extras_startup
+
+  !****
+
+  integer function extras_finish_step(id)
+    integer, intent(in) :: id
+    integer :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    extras_finish_step = keep_going
+
+  end function extras_finish_step
+
+  !****
+
+  subroutine extras_after_evolve(id, ierr)
+
+    integer, intent(in)  :: id
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'matched target'
+
+    call test_suite_after_evolve(s, ierr)
+
+  end subroutine extras_after_evolve
+
+end module run_star_extras

--- a/star/test_suite/gyre_in_mesa_ms/src/run_star_extras_stub.f90
+++ b/star/test_suite/gyre_in_mesa_ms/src/run_star_extras_stub.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2010-2019  Bill Paxton & The MESA Team
+!   Copyright (C) 2018-2019  Rich Townsend, Bill Paxton & The MESA Team
 !
 !   this file is part of mesa.
 !
@@ -19,32 +19,100 @@
 !   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
 !
 ! ***********************************************************************
- 
-      module run_star_extras
 
-      use star_lib
-      use star_def
-      use const_def
-      
-      implicit none
-      
-      ! these routines are called by the standard run_star check_model
-      contains
-      
-      subroutine extras_controls(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-            
-         write(*,*) 'matched target'
-         write(*,*) 'GYRE not installed, pretending to pass'
-         write(*,*) 'this test was intentionally skipped'
-         ierr = -1
-         
-      end subroutine extras_controls
+module run_star_extras
 
-      end module run_star_extras
-      
+  ! Uses
+
+  use star_lib
+  use star_def
+  use const_def
+  use math_lib
+
+  ! No implicit typing
+
+  implicit none
+  include "test_suite_extras_def.inc"
+
+  ! Procedures
+
+contains
+
+  include "test_suite_extras.inc"
+
+  subroutine extras_controls(id, ierr)
+
+    integer, intent(in) :: id
+    integer, intent(out) :: ierr
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'GYRE is not installed: this test will run without '
+    write(*,*) 'calling GYRE and pretend to pass'
+
+    ! Set up hooks
+
+    s% extras_startup => extras_startup
+    s% extras_finish_step => extras_finish_step
+    s% extras_after_evolve => extras_after_evolve
+
+    s% job% warn_run_star_extras =.false.
+
+  end subroutine extras_controls
+
+  !****
+
+  subroutine extras_startup(id, restart, ierr)
+
+    integer, intent(in)  :: id
+    logical, intent(in)  :: restart
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+    call test_suite_startup(s, restart, ierr)
+
+  end subroutine extras_startup
+
+  !****
+
+  integer function extras_finish_step(id)
+    integer, intent(in) :: id
+    integer :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    extras_finish_step = keep_going
+
+  end function extras_finish_step
+
+  !****
+
+  subroutine extras_after_evolve(id, ierr)
+
+    integer, intent(in)  :: id
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'matched target'
+
+    call test_suite_after_evolve(s, ierr)
+
+  end subroutine extras_after_evolve
+
+end module run_star_extras

--- a/star/test_suite/gyre_in_mesa_rsg/src/run_star_extras_stub.f90
+++ b/star/test_suite/gyre_in_mesa_rsg/src/run_star_extras_stub.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2010-2019  Bill Paxton & The MESA Team
+!   Copyright (C) 2018-2019  Rich Townsend, Bill Paxton & The MESA Team
 !
 !   this file is part of mesa.
 !
@@ -19,32 +19,100 @@
 !   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
 !
 ! ***********************************************************************
- 
-      module run_star_extras
 
-      use star_lib
-      use star_def
-      use const_def
-      
-      implicit none
-      
-      ! these routines are called by the standard run_star check_model
-      contains
-      
-      subroutine extras_controls(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-            
-         write(*,*) 'matched target'
-         write(*,*) 'GYRE not installed, pretending to pass'
-         write(*,*) 'this test was intentionally skipped'
-         ierr = -1
-         
-      end subroutine extras_controls
+module run_star_extras
 
-      end module run_star_extras
-      
+  ! Uses
+
+  use star_lib
+  use star_def
+  use const_def
+  use math_lib
+
+  ! No implicit typing
+
+  implicit none
+  include "test_suite_extras_def.inc"
+
+  ! Procedures
+
+contains
+
+  include "test_suite_extras.inc"
+
+  subroutine extras_controls(id, ierr)
+
+    integer, intent(in) :: id
+    integer, intent(out) :: ierr
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'GYRE is not installed: this test will run without '
+    write(*,*) 'calling GYRE and pretend to pass'
+
+    ! Set up hooks
+
+    s% extras_startup => extras_startup
+    s% extras_finish_step => extras_finish_step
+    s% extras_after_evolve => extras_after_evolve
+
+    s% job% warn_run_star_extras =.false.
+
+  end subroutine extras_controls
+
+  !****
+
+  subroutine extras_startup(id, restart, ierr)
+
+    integer, intent(in)  :: id
+    logical, intent(in)  :: restart
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+    call test_suite_startup(s, restart, ierr)
+
+  end subroutine extras_startup
+
+  !****
+
+  integer function extras_finish_step(id)
+    integer, intent(in) :: id
+    integer :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    extras_finish_step = keep_going
+
+  end function extras_finish_step
+
+  !****
+
+  subroutine extras_after_evolve(id, ierr)
+
+    integer, intent(in)  :: id
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'matched target'
+
+    call test_suite_after_evolve(s, ierr)
+
+  end subroutine extras_after_evolve
+
+end module run_star_extras

--- a/star/test_suite/gyre_in_mesa_spb/src/run_star_extras_stub.f90
+++ b/star/test_suite/gyre_in_mesa_spb/src/run_star_extras_stub.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2010-2019  Bill Paxton & The MESA Team
+!   Copyright (C) 2018-2019  Rich Townsend, Bill Paxton & The MESA Team
 !
 !   this file is part of mesa.
 !
@@ -19,32 +19,100 @@
 !   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
 !
 ! ***********************************************************************
- 
-      module run_star_extras
 
-      use star_lib
-      use star_def
-      use const_def
-      
-      implicit none
-      
-      ! these routines are called by the standard run_star check_model
-      contains
-      
-      subroutine extras_controls(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-            
-         write(*,*) 'matched target'
-         write(*,*) 'GYRE not installed, pretending to pass'
-         write(*,*) 'this test was intentionally skipped'
-         ierr = -1
-         
-      end subroutine extras_controls
+module run_star_extras
 
-      end module run_star_extras
-      
+  ! Uses
+
+  use star_lib
+  use star_def
+  use const_def
+  use math_lib
+
+  ! No implicit typing
+
+  implicit none
+  include "test_suite_extras_def.inc"
+
+  ! Procedures
+
+contains
+
+  include "test_suite_extras.inc"
+
+  subroutine extras_controls(id, ierr)
+
+    integer, intent(in) :: id
+    integer, intent(out) :: ierr
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'GYRE is not installed: this test will run without '
+    write(*,*) 'calling GYRE and pretend to pass'
+
+    ! Set up hooks
+
+    s% extras_startup => extras_startup
+    s% extras_finish_step => extras_finish_step
+    s% extras_after_evolve => extras_after_evolve
+
+    s% job% warn_run_star_extras =.false.
+
+  end subroutine extras_controls
+
+  !****
+
+  subroutine extras_startup(id, restart, ierr)
+
+    integer, intent(in)  :: id
+    logical, intent(in)  :: restart
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+    call test_suite_startup(s, restart, ierr)
+
+  end subroutine extras_startup
+
+  !****
+
+  integer function extras_finish_step(id)
+    integer, intent(in) :: id
+    integer :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    extras_finish_step = keep_going
+
+  end function extras_finish_step
+
+  !****
+
+  subroutine extras_after_evolve(id, ierr)
+
+    integer, intent(in)  :: id
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'matched target'
+
+    call test_suite_after_evolve(s, ierr)
+
+  end subroutine extras_after_evolve
+
+end module run_star_extras

--- a/star/test_suite/gyre_in_mesa_wd/src/run_star_extras_stub.f90
+++ b/star/test_suite/gyre_in_mesa_wd/src/run_star_extras_stub.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2010-2019  Bill Paxton & The MESA Team
+!   Copyright (C) 2018-2019  Rich Townsend, Bill Paxton & The MESA Team
 !
 !   this file is part of mesa.
 !
@@ -19,32 +19,100 @@
 !   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
 !
 ! ***********************************************************************
- 
-      module run_star_extras
 
-      use star_lib
-      use star_def
-      use const_def
-      
-      implicit none
-      
-      ! these routines are called by the standard run_star check_model
-      contains
-      
-      subroutine extras_controls(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-            
-         write(*,*) 'matched target'
-         write(*,*) 'GYRE not installed, pretending to pass'
-         write(*,*) 'this test was intentionally skipped'
-         ierr = -1
-         
-      end subroutine extras_controls
+module run_star_extras
 
-      end module run_star_extras
-      
+  ! Uses
+
+  use star_lib
+  use star_def
+  use const_def
+  use math_lib
+
+  ! No implicit typing
+
+  implicit none
+  include "test_suite_extras_def.inc"
+
+  ! Procedures
+
+contains
+
+  include "test_suite_extras.inc"
+
+  subroutine extras_controls(id, ierr)
+
+    integer, intent(in) :: id
+    integer, intent(out) :: ierr
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'GYRE is not installed: this test will run without '
+    write(*,*) 'calling GYRE and pretend to pass'
+
+    ! Set up hooks
+
+    s% extras_startup => extras_startup
+    s% extras_finish_step => extras_finish_step
+    s% extras_after_evolve => extras_after_evolve
+
+    s% job% warn_run_star_extras =.false.
+
+  end subroutine extras_controls
+
+  !****
+
+  subroutine extras_startup(id, restart, ierr)
+
+    integer, intent(in)  :: id
+    logical, intent(in)  :: restart
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+    call test_suite_startup(s, restart, ierr)
+
+  end subroutine extras_startup
+
+  !****
+
+  integer function extras_finish_step(id)
+    integer, intent(in) :: id
+    integer :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    extras_finish_step = keep_going
+
+  end function extras_finish_step
+
+  !****
+
+  subroutine extras_after_evolve(id, ierr)
+
+    integer, intent(in)  :: id
+    integer, intent(out) :: ierr
+
+    type (star_info), pointer :: s
+
+    ierr = 0
+    call star_ptr(id, s, ierr)
+    if (ierr /= 0) return
+
+    write(*,*) 'matched target'
+
+    call test_suite_after_evolve(s, ierr)
+
+  end subroutine extras_after_evolve
+
+end module run_star_extras


### PR DESCRIPTION
If MESA is built without GYRE, it doesn't make sense to try to test the GYRE interfaces, so the `gyre_in_mesa_*` tests immediately (in `extras_controls`) print a string that satisfies the test requirement and raise `ierr = -1` so that MESA exits. This has the undesirable consequence that MESA exits with a non-zero status, which doesn't make sense given that it hasn't really failed.

This PR modifies the non-GYRE `gyre_in_mesa_*` tests to run the evolution without the calls to GYRE, before feigning success with a suitable message at the end. First, this gives a clean exist (i.e. status zero). Second, it means that even without GYRE, we still get some information about whether the test is working. If the tests break because of MESA's evolution failing, even non-SDK builds will detect it.

I implemented this by copying `run_star_extras.f90` to `run_star_extras_stub.f90` and stripping out all the GYRE infrastructure. An alternative is to let it make calls to the stub library if we want to test it. i.e. we could possibly remove `run_star_extras_stub.f90` completely if we have a neat way of printing `'matched target'` depending on whether GYRE is available or not. That approach might require additions to the GYRE stub library (see `gyre/public/gyre_lib_stub.f`).

Rather than run the full test suite, I've re-run only the `gyre_in_mesa_*` tests on my non-SDK system. The tests are [passing](https://testhub.mesastar.org/whb%2Fevolve-stubbed-gyre-in-mesa/commits/b3d2c90).