### PR TITLE
Revert "Enable solver controls that avoid negative surface luminosities; use them in pre-MS models"

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -8654,10 +8654,10 @@
       ! max_frac_for_negative_surf_lum
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! If ``.true.``, scales the correction factor in a Newton iteration to prevent the
-      ! surface luminosity from becoming negative. If an iteration would require ``s% L(1)``
+      ! If true, then scales the correction factor in a Newton iteration to prevent the
+      ! surface from reaching a negative luminosity. If an iteration would require s% L(1)
       ! to become negative, then the correction is scaled such that the change in surface
-      ! luminosity is ``-max_frac_for_negative_surf_lum*s% L(1)``.
+      ! luminosity is -max_frac_for_negative_surf_lum*s% L(1)
 
       ! ::
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -382,7 +382,6 @@
     iter_for_resid_tol2, iter_for_resid_tol3, &
     solver_itermin, solver_itermin_until_reduce_min_corr_coeff, &
     solver_reduced_min_corr_coeff, do_solver_damping_for_neg_xa, &
-    scale_max_correction_for_negative_surf_lum, max_frac_for_negative_surf_lum, &
     hydro_mtx_max_allowed_abs_dlogT, hydro_mtx_max_allowed_abs_dlogRho, &
     min_logT_for_hydro_mtx_max_allowed, hydro_mtx_max_allowed_logT, &
     hydro_mtx_max_allowed_logRho, report_min_rcond_from_DGESXV, &
@@ -1971,8 +1970,6 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% solver_itermin_until_reduce_min_corr_coeff = solver_itermin_until_reduce_min_corr_coeff
  s% solver_reduced_min_corr_coeff = solver_reduced_min_corr_coeff
  s% do_solver_damping_for_neg_xa = do_solver_damping_for_neg_xa
- s% scale_max_correction_for_negative_surf_lum = scale_max_correction_for_negative_surf_lum
- s% max_frac_for_negative_surf_lum = max_frac_for_negative_surf_lum
  s% hydro_mtx_max_allowed_abs_dlogT = hydro_mtx_max_allowed_abs_dlogT
  s% hydro_mtx_max_allowed_abs_dlogRho = hydro_mtx_max_allowed_abs_dlogRho
  s% min_logT_for_hydro_mtx_max_allowed = min_logT_for_hydro_mtx_max_allowed
@@ -3644,8 +3641,6 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  solver_itermin_until_reduce_min_corr_coeff = s% solver_itermin_until_reduce_min_corr_coeff
  solver_reduced_min_corr_coeff = s% solver_reduced_min_corr_coeff
  do_solver_damping_for_neg_xa = s% do_solver_damping_for_neg_xa
- scale_max_correction_for_negative_surf_lum = s% scale_max_correction_for_negative_surf_lum
- max_frac_for_negative_surf_lum = s% max_frac_for_negative_surf_lum
  hydro_mtx_max_allowed_abs_dlogT = s% hydro_mtx_max_allowed_abs_dlogT
  hydro_mtx_max_allowed_abs_dlogRho = s% hydro_mtx_max_allowed_abs_dlogRho
  min_logT_for_hydro_mtx_max_allowed = s% min_logT_for_hydro_mtx_max_allowed

--- a/star/private/init.f90
+++ b/star/private/init.f90
@@ -893,8 +893,7 @@
          logical :: restore_at_end
          real(dp) :: xm, total_radiation, warning_limit_for_max_residual
          integer :: k, num_trace_history_values
-         real(dp) :: save_Pextra_factor, save_max_frac_for_negative_surf_lum
-         logical :: save_scale_max_correction_for_negative_surf_lum
+         real(dp) :: save_Pextra_factor
          character (len=256):: save_atm_option, &
             save_atm_T_tau_relation, save_atm_T_tau_opacity
          real(dp), allocatable, dimension(:) :: total_energy_profile
@@ -1154,14 +1153,10 @@
             save_atm_T_tau_relation = s% atm_T_tau_relation
             save_atm_T_tau_opacity = s% atm_T_tau_opacity
             save_Pextra_factor = s% Pextra_factor
-            save_scale_max_correction_for_negative_surf_lum = s% scale_max_correction_for_negative_surf_lum
-            save_max_frac_for_negative_surf_lum = s% max_frac_for_negative_surf_lum
             s% atm_option = 'T_tau'
             s% atm_T_tau_relation = 'Eddington'
             s% atm_T_tau_opacity = 'fixed'
             s% Pextra_factor = 2
-            s% scale_max_correction_for_negative_surf_lum = .true.
-            s% max_frac_for_negative_surf_lum = 0.8
          end subroutine setup_for_relax_after_create_pre_ms_model
 
          subroutine done_relax_after_create_pre_ms_model
@@ -1169,8 +1164,6 @@
             s% atm_T_tau_relation = save_atm_T_tau_relation
             s% atm_T_tau_opacity = save_atm_T_tau_opacity
             s% Pextra_factor = save_Pextra_factor
-            s% scale_max_correction_for_negative_surf_lum = save_scale_max_correction_for_negative_surf_lum
-            s% max_frac_for_negative_surf_lum = save_max_frac_for_negative_surf_lum
          end subroutine done_relax_after_create_pre_ms_model
 
          subroutine check_initials


### PR DESCRIPTION
Reverts MESAHub/mesa#245