### PR TITLE
Sync up history columns

### DIFF
--- a/linters/check_columns.py
+++ b/linters/check_columns.py
@@ -2,10 +2,12 @@
 
 import os
 import re
+import glob
 from collections.abc import MutableSet
 
 MESA_DIR = '../'
-
+ENABLE_TEST_SUITE_HIST_CHECKS=True
+ENABLE_TEST_SUITE_PROF_CHECKS=True
 
 # inspiration from https://stackoverflow.com/a/27531275
 class CaseInsensitiveSet(MutableSet):
@@ -68,6 +70,14 @@ def print_options(options):
     for o in sorted(options):
         print(f"   {o}")
 
+def delete_command(options, filename):
+    print('for i in',' '.join(options),end=';')
+    print('do ', end='')
+    print('sed -i "/^\s*\!$i/d" */'+filename,end=';')
+    print('sed -i "/^\s*\!\s*$i/d" */'+filename,end=';')
+    print('sed -i "/^\s*$i/d" */'+filename,end=';')
+    print('done')
+
 
 def check_history():
     """Run checks on history columns"""
@@ -116,7 +126,7 @@ def check_history():
 
 
     # Values that are in star_history_def.f90 but not in history.f90
-    print_section("Values that are in star_history_def.f90 but not in history.f90n")
+    print_section("Values that are in star_history_def.f90 but not in history.f90")
 
     # define false positives
     known_false_positives = {'burn_relr_regions', 'burning_regions',
@@ -167,9 +177,27 @@ def check_history():
         'photo',
         'pnhe4',
         'pp',
-        'tri_alfa'}
+        'tri_alfa'
+    }
 
     print_options(vals_history_list - vals_history - known_false_positives)
+
+
+    if ENABLE_TEST_SUITE_HIST_CHECKS:
+        known_false_positives = {
+            'misc',
+            'timescales'
+        }
+        # Value in each test case's history_columns.list but not in star/default/history_columns.list
+        for i in glob.glob(os.path.join(MESA_DIR,'star','test_suite','*','history_columns.list')):
+            test_case = get_columns(i.removeprefix(MESA_DIR), regexp)
+            result = test_case - vals_history_list - known_false_positives
+            if len(result):
+                print_section("Values that are in are in " + i + " but not in history_columns.list")
+                print_options(result)
+                delete_command(result,'history_columns.list')
+
+
 
 
 def check_profile():
@@ -306,6 +334,19 @@ def check_profile():
     # Values that are in are in profile_getval.f90 but not in profile_columns.list
     print_section("Values that are in are in profile_getval.f90 but not in profile_columns.list")
     print_options(vals_profile - vals_profile_list)
+
+
+    if ENABLE_TEST_SUITE_PROF_CHECKS:
+        known_false_positives = {
+        }
+        # Value in each test case's profile_columns.list but not in star/default/profile_columns.list
+        for i in glob.glob(os.path.join(MESA_DIR,'star','test_suite','*','profile_columns.list')):
+            test_case = get_columns(i.removeprefix(MESA_DIR), regexp)
+            result = test_case - vals_profile_list - known_false_positives - general_info
+            if len(result):
+                print_section("Values that are in are in " + i + " but not in profile_columns.list")
+                print_options(result)
+                delete_command(result,'profile_columns.list')
 
 
 if __name__ == "__main__":

--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -48,6 +48,7 @@
       !star_age_min ! elapsed simulated time in minutes since the start of the run
       !star_age_hr ! elapsed simulated time in hours since the start of the run
       !star_age_day ! elapsed simulated time in days since the start of the run
+      !day ! elapsed simulated time in days since the start of the run
 
       !log_star_age
       !log_star_age_sec
@@ -56,8 +57,10 @@
 
       !time_step ! timestep in years since previous model
       !time_step_sec ! timestep in seconds since previous model
+      !time_step_days
       log_dt ! log10 time_step in years
       !log_dt_sec ! log10 time_step in seconds
+      !log_dt_days ! log10 time_step in days
 
    !## mass
 
@@ -79,17 +82,20 @@
       !Tsurf_factor
       !tau_factor
       !tau_surface
-      !surface_extra_Pgas
 
    !## imposed center conditions
       !m_center
       !m_center_gm
       !r_center
       !r_center_cm
+      !r_center_km
       !L_center
       !log_L_center
       !log_L_center_ergs_s
       !v_center
+      !v_center_kms
+
+      !logt_max
 
 !----------------------------------------------------------------------------------------------
 
@@ -99,7 +105,6 @@
       !max_gradT_div_grada
       !max_gradT_sub_grada
       !min_log_mlt_Gamma
-      !max_conv_dP_term
 
 
    !## mixing regions
@@ -229,15 +234,16 @@
 
       !power_h_burn ! total thermal power from PP and CNO, excluding neutrinos (in Lsun units)
       !power_he_burn ! total thermal power from triple-alpha, excluding neutrinos (in Lsun units)
-      !power_c_burn ! total thermal power from carbon burning, excluding neutrinos (in Lsun units)
+      !power_photo
+      !power_z_burn
       !log_power_nuc_burn ! total thermal power from all burning, excluding photodisintegrations
       log_LH ! log10 power_h_burn
       log_LHe ! log10 power_he_burn
-      !log_LC ! log10 power_c_burn
       log_LZ ! log10 total burning power including LC, but excluding LH and LHe and photodisintegrations
       log_Lnuc ! log(LH + LHe + LZ)
       !log_Lnuc_ergs_s
       !log_Lnuc_sub_log_L
+      !lnuc_photo
 
       !extra_L ! integral of extra_heat in Lsun units
       !log_extra_L ! log10 extra_L
@@ -338,6 +344,7 @@
 
    !## CO core
       co_core_mass
+      !co_core
       !co_core_radius
       !co_core_lgT
       !co_core_lgRho
@@ -387,10 +394,7 @@
 
       !h_rich_layer_mass ! = star_mass - he_core_mass
       !he_rich_layer_mass ! = he_core_mass - c_core_mass
-      !c_rich_layer_mass ! = c_core_mass - o_core_mass
-      !o_rich_layer_mass ! = o_core_mass - si_core_mass
-      !si_rich_layer_mass ! = si_core_mass - fe_core_mass
-
+      !co_rich_layer_mass
 
 !----------------------------------------------------------------------------------------------
 
@@ -401,13 +405,12 @@
       !mdot_timescale ! star_mass/abs(star_mdot) (years)
       !kh_div_mdot_timescales ! kh_timescale/mdot_timescale
       !nuc_timescale ! nuclear timescale (years) -- proportional to mass divided by luminosity
-      !log_chem_timescale ! burn+mix timescale (years)
-         ! approximately min over all cells k and species i of x(i,k)/abs(dxdt_mix + dxdt_burn)
-      !log_chem_timescale_div_time_step
-      !log_cell_collapse_timescale
 
       !dt_cell_collapse ! min time for any cell to collapse at current velocities
       !dt_div_dt_cell_collapse
+
+      !dt_div_max_tau_conv ! dt/ maximum conv timescale
+      !dt_div_min_tau_conv ! dt/ minimum conv timescale
 
 
       !min_dr_div_cs ! min over all cells of dr/csound (seconds)
@@ -426,6 +429,7 @@
 
    !## conditions at the photosphere
       !effective_T
+      !teff
       log_Teff ! log10 effective temperature
          ! Teff is calculated using Stefan-Boltzmann relation L = 4 pi R^2 sigma Teff^4,
          ! where L and R are evaluated at the photosphere (tau_factor < 1)
@@ -451,6 +455,10 @@
       !photosphere_opacity
       !photosphere_v_div_cs
       !photosphere_xm
+      !photosphere_cell_free_e
+      !photosphere_cell_log_free_e
+      !photosphere_logg
+      !photosphere_t
 
    !## conditions at or near the surface of the model (outer edge of outer cell)
 
@@ -485,9 +493,11 @@
       !v_surf_km_s ! (km/s)
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_div_csound_max ! max value of velocity divided by sound speed at face
+      !v_div_vesc
+      !v_phot_km_s
+      !v_surf_div_escape_v
 
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
 
       !surf_avg_j_rot
       !surf_avg_omega
@@ -501,10 +511,10 @@
       !surf_avg_logRho
       !surf_avg_opacity
 
-      !Gravity Darkening, reports the surface averaged L/Lsun and Teff (K) caused by
-      !gravity darkening in rotating stars. Based on the model of Espinosa Lara & Rieutord (2011)
-      !'polar' refers to the line of sight being directed along the rotation axis of the star
-      !'equatorial' refers to the line of sight coincident with the stellar equator
+      ! Gravity Darkening, reports the surface averaged L/Lsun and Teff (K) caused by
+      ! gravity darkening in rotating stars. Based on the model of Espinosa Lara & Rieutord (2011)
+      ! 'polar' refers to the line of sight being directed along the rotation axis of the star
+      ! 'equatorial' refers to the line of sight coincident with the stellar equator
       !grav_dark_L_polar !Lsun 
       !grav_dark_Teff_polar !K
       !grav_dark_L_equatorial !Lsun 
@@ -526,26 +536,6 @@
       !surf_r_equatorial_div_r_polar
       !surf_r_equatorial_div_r
       !surf_r_polar_div_r
-
-   !## info about location where optical depth is 10
-
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
-
-   !## info about location where optical depth is 100
-
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
 !----------------------------------------------------------------------------------------------
 
@@ -572,11 +562,6 @@
       !center_zbar
 
       !center_eps_grav
-      !center_dL_dm
-      !center_dlnT_dt
-      !center_dlnd_dt
-      !center_dlogRho
-      !center_dlogT
 
       !center_non_nuc_neu
       !center_eps_nuc
@@ -588,9 +573,11 @@
       !max_entropy ! in units of kerg per baryon
       !fe_core_infall
       !non_fe_core_infall
-      !max_infall_speed_mass
+      !non_fe_core_rebound
+      !max_infall_speed
 
       !compactness_parameter ! (m/Msun)/(R(m)/1000km) for m = 2.5 Msun
+      !compactness
 
       !center_omega
       !center_omega_div_omega_crit
@@ -666,7 +653,7 @@
       total_mass he4
       ! etc.
 
-      !individial log10  mass totals for entire star (in Msun units)
+      ! individial log10  mass totals for entire star (in Msun units)
       !log_total_mass h1
       !log_total_mass he4
       ! etc.
@@ -674,66 +661,11 @@
 !----------------------------------------------------------------------------------------------
 
 !# info at specific locations
-
-   !## info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
-
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
-
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
-
-
+      
    !## info at location of max temperature
-      !max_T
-      !log_max_T
-      !max_T_lgT ! equivalent to above
-      !max_T_mass ! (Msun)
-      !max_T_radius ! (Rsun)
-      !max_T_lgRho
-      !max_T_lgP
-      !max_T_entropy
-      !max_T_L ! (Lsun)
-      !max_T_eps_nuc ! (erg/g/s)
-      !max_T_lgP_thin_shell ! log10(G*Mcore*Menv/(4*pi*Rcore^4))
-         ! Mcore = Msun*max_T_mass,
-         ! Menv = Msun*(star_mass - max_T_mass),
-         ! Rcore = Rsun*max_T_radius
-      !max_T_shell_binding_energy ! integral from max_T out
-      
-      
-   !## info at location of max abs velocity
-      ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_gamma1
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_radius_cm
-      !max_abs_v_lgR ! Rsun
-      !max_abs_v_lgR_cm
-      !max_abs_v_L ! Lsun
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
-      !max_abs_v_E0 ! 4/3 pi R^3 crad T^4 at max_abs_v_location
+   !max_T
+   !log_max_T
+
 
 !----------------------------------------------------------------------------------------------
 
@@ -756,40 +688,8 @@
       !shock_gamma1
       !shock_entropy
       !shock_tau
-      !shock_E0 ! 4/3 pi R^3 crad T^4 at shock location
       !shock_k
-
-   !## info at innermost mach 1 location
-      ! excluding locations with q < min_q_for_inner_mach1_location
-      !inner_mach1_mass ! baryonic (Msun)
-      !inner_mach1_q
-      !inner_mach1_radius ! (Rsun)
-      !inner_mach1_velocity
-      !inner_mach1_csound
-      !inner_mach1_v_div_cs
-      !inner_mach1_lgT
-      !inner_mach1_lgRho
-      !inner_mach1_lgP
-      !inner_mach1_gamma1
-      !inner_mach1_entropy
-      !inner_mach1_tau
-      !inner_mach1_k
-
-   !## info at outermost mach 1 location
-      ! excluding locations with q > max_q_for_outer_mach1_location
-      !outer_mach1_mass ! baryonic (Msun)
-      !outer_mach1_q
-      !outer_mach1_radius ! (Rsun)
-      !outer_mach1_velocity
-      !outer_mach1_csound
-      !outer_mach1_v_div_cs
-      !outer_mach1_lgT
-      !outer_mach1_lgRho
-      !outer_mach1_lgP
-      !outer_mach1_gamma1
-      !outer_mach1_entropy
-      !outer_mach1_tau
-      !outer_mach1_k
+      !shock_pre_lgrho
 
 !----------------------------------------------------------------------------------------------
 
@@ -827,74 +727,48 @@
 
       !total_energy ! at end of step
       !log_total_energy ! log(abs(total_energy))
-      !total_energy_start ! at start of step
       !total_energy_after_adjust_mass ! after mass adjustments
-      !total_energy_change ! end - start
 
       ! shorter versions of above
       !tot_E
       !log_tot_E
-      !tot_E_change
-      !tot_E_start
 
 
       !total_gravitational_energy
       !log_total_gravitational_energy ! log(abs(total_gravitational_energy))
-      !total_gravitational_energy_start
       !total_gravitational_energy_after_adjust_mass
-      !total_gravitational_energy_change
 
       ! shorter versions of above
       !tot_PE
       !log_tot_PE
-      !tot_PE_start
-      !tot_PE_change
-
 
       !total_internal_energy
       !log_total_internal_energy
-      !total_internal_energy_start
       !total_internal_energy_after_adjust_mass
-      !total_internal_energy_change
 
       ! shorter versions of above
       !tot_IE
       !log_tot_IE
-      !tot_IE_start
-      !tot_IE_change
-
 
       !total_radial_kinetic_energy
       !log_total_radial_kinetic_energy
-      !total_radial_kinetic_energy_start
       !total_radial_kinetic_energy_after_adjust_mass
-      !total_radial_kinetic_energy_change
 
       ! shorter versions of above (does not include rot KE)
       !tot_KE
       !log_tot_KE
-      !tot_KE_start
-      !tot_KE_change
-
 
       !total_turbulent_energy
       !log_total_turbulent_energy
-      !total_turbulent_energy_start
       !total_turbulent_energy_after_adjust_mass
-      !total_turbulent_energy_change
+      !tot_et
+      !log_tot_et
 
+      !total_energy_foe
 
       !tot_IE_div_IE_plus_KE
       !total_IE_div_IE_plus_KE
 
-      !total_IE_plus_KE
-      !log_total_IE_plus_KE
-      !total_IE_plus_KE_change
-      !total_IE_plus_KE_start
-
-
-      !total_energy_minus_sources_and_sinks
-      !total_energy_plus_L_surf
       !total_entropy
       !total_eps_grav
 
@@ -905,15 +779,14 @@
       !total_extra_heating ! extra heat integrated over the model times dt (erg)
       !total_WD_sedimentation_heating
 
-      !run_deltaE
       !rel_run_E_err
-
-      !rel_run_deltaE
-      !log_rel_run_deltaE
 
       !rel_E_err
       !abs_rel_E_err
       !log_rel_E_err
+
+      !tot_e_equ_err
+      !tot_e_err
 
 
       !error_in_energy_conservation ! for this step
@@ -926,10 +799,10 @@
       !rel_error_in_energy_conservation ! = error_in_energy_conservation/total_energy
       !log_rel_error_in_energy_conservation
 
-      !total_energy_and_integrated_fluxes ! = total_energy + cumulative_sources_and_sinks
-
-      !total_radiation
-      !total_energy_plus_total_radiation
+      !virial_thm_p_avg
+      !virial_thm_rel_err
+      !work_inward_at_center
+      !work_outward_at_surface
 
 
 !----------------------------------------------------------------------------------------------
@@ -942,9 +815,7 @@
 
       !total_rotational_kinetic_energy
       !log_total_rotational_kinetic_energy
-      !total_rotational_kinetic_energy_start
       !total_rotational_kinetic_energy_after_adjust_mass
-      !total_rotational_kinetic_energy_change
 
 !----------------------------------------------------------------------------------------------
 
@@ -965,6 +836,8 @@
       !u_div_csound_surf
       !u_div_csound_max
 
+      !infall_div_cs
+
 !----------------------------------------------------------------------------------------------
 
 !# misc
@@ -974,6 +847,7 @@
    !## eos
       !logQ_max ! logQ = logRho - 2*logT + 12
       !logQ_min
+      !gamma1_min
 
    !## core mixing
       !mass_semiconv_core
@@ -989,14 +863,17 @@
       !one_div_yphot
       !log_one_div_yphot
 
-      !min_kap_floor
-      !log_min_kap_floor
-
       !log_min_opacity
       !min_opacity
 
       !log_tau_center
 
+      !log_max_tau_conv
+      !max_tau_conv
+      !log_min_tau_conv
+      !min_tau_conv
+
+      !tau_qhse_yrs
 
    !## other
 
@@ -1005,12 +882,7 @@
       !h1_czb_mass ! location (in Msun units) of base of 1st convection zone above he core
       !kh_mdot_limit
       !log_cntr_dr_cm
-      !min_L
       !min_Pgas_div_P
-      !min_dL_dm
-      !min_dL_dm_m
-      !rms_dvdt_div_v
-      !split_mixing_choice
       !surf_c12_minus_o16 ! this is useful for seeing effects of dredge up on AGB
       !surf_num_c12_div_num_o16
 
@@ -1027,12 +899,9 @@
 
    !## RTI
       !rti_regions <num>
-      !alpha_RTI_avg_by_mass
 
    !## Ni & Co
       !total_ni_co_56
-      !nico_escape_ergs_s
-      !log_nico_escape_ergs_s
 
 
    !## internal structure constants
@@ -1060,11 +929,6 @@
       !k_for_test_CpT_absMdot_div_L
       !q_for_test_CpT_absMdot_div_L
       !logxq_for_test_CpT_absMdot_div_L
-
-      !k_CpTMdot_lt_L
-      !q_CpTMdot_lt_L
-      !logxq_CpTMdot_lt_L
-
 
 !----------------------------------------------------------------------------------------------
 
@@ -1096,6 +960,24 @@
 
 !----------------------------------------------------------------------------------------------
 
+!# RSP
+
+   !rsp_deltamag
+   !rsp_deltar
+   !rsp_grekm
+   !rsp_grekm_avg_abs
+   !rsp_grpdv
+   !rsp_lina_growth_rate_f
+   !rsp_lina_growth_rate_o1
+   !rsp_lina_growth_rate_o2
+   !rsp_lina_period_f_days
+   !rsp_lina_period_o1_days
+   !rsp_lina_period_o2_days
+   !rsp_num_periods
+   !rsp_period_in_days
+   !rsp_phase
+
+!----------------------------------------------------------------------------------------------
 !# debugging
 
    !## retries
@@ -1106,29 +988,39 @@
       num_iters ! same as num_solver_iterations
       !num_solver_iterations ! iterations at this step
       !total_num_solver_iterations ! total iterations during the run
+      !avg_num_solver_iters
 
       !rotation_solver_steps
 
       !diffusion_solver_steps
       !diffusion_solver_iters
 
+      !avg_setvars_per_step
+      !avg_skipped_setvars_per_step
+      !avg_solver_setvars_per_step
 
-   !## maximum solver residuals
-      !log_max_abs_lgE_residual
-      !log_max_abs_v_residual
-      !log_max_dlnEdt_residual
-      !log_max_drdt_residual
-      !log_max_dvdt_residual
-      !log_max_lnd_residual
+      !burn_solver_maxsteps
 
-      !avg_lgE_residual
-      !avg_v_residual
+      !total_num_solver_calls_converged
+      !total_num_solver_calls_failed
+      !total_num_solver_calls_made
+      !total_num_solver_relax_calls_converged
+      !total_num_solver_relax_calls_failed
+      !total_num_solver_relax_calls_made
+      !total_num_solver_relax_iterations
 
-      !log_avg_lgE_residual
-      !log_avg_v_residual
+      !total_step_attempts
+      !total_step_redos
+      !total_step_retries
+      !total_steps_finished
+      !total_steps_taken
 
-      !max_abs_lgE_residual
-      !max_abs_v_residual
+   !## Relaxation steps
+      !total_relax_step_attempts
+      !total_relax_step_redos
+      !total_relax_step_retries
+      !total_relax_steps_finished
+      !total_relax_steps_taken
 
    !## conservation during mesh adjust
       !log_mesh_adjust_IE_conservation

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -44,12 +44,15 @@
 
 !# Structure
    !logM ! log10(m/Msun)
+   !log_mass
    !dm ! cell mass (grams)
    !dm_bar ! boundary mass (grams) average of adjacent dm's
    !logdq ! log10(dq)
+   !log_dq
    !dq_ratio ! dq(k-1)/dq(k)
    !q ! fraction of star mass interior to outer boundary of this zone
    !log_q ! log10(q)
+   !xq
 
    !grav ! gravitational acceleration (cm sec^2)
    !log_g ! log10 gravitational acceleration (cm sec^2)
@@ -60,6 +63,7 @@
 
    !radius ! radius at outer boundary of zone (in Rsun units)
    !radius_cm ! radius at outer boundary of zone (in centimeters)
+   !radius_km ! radius at outer boundary of zone (in kilometers)
    !logR_cm ! log10 radius at outer boundary of zone (in centimeters)
    !rmid ! radius at center by mass of zone (in Rsun units)
    !r_div_R ! fraction of total radius
@@ -72,7 +76,6 @@
    !scale_height ! in Rsun units
    !pressure_scale_height ! in Rsun units
 
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    !m_div_r ! gm/cm
    !dmbar_m_div_r
    !log_dmbar_m_div_r
@@ -121,6 +124,7 @@
       ! 0 if distance between inner and outer is increasing
    !log_cell_collapse_time ! log of cell_collapse_time
    
+   !compression_gradient
 
 
 
@@ -138,7 +142,6 @@
    !entropy ! specific entropy divided by (avo*kerg)
    !logS ! log10(specific entropy)
    !logS_per_baryon ! log10(specific entropy per baryon / kerg)
-   !del_entropy ! entropy - entropy_start (includes change in entropy due to diffusion at beginning of step)
 
    !pressure ! total pressure at center of zone (pgas + prad)
    !prad ! radiation pressure at center of zone
@@ -164,14 +167,21 @@
    !chiT ! dlnP_dlnT at constant Rho
 
    !csound ! sound speed
+   !log_csound
    !csound_face ! sound speed (was previously called csound_at_face)
    !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
    !v_div_cs ! velocity divided by sound speed
    !v_div_csound ! velocity divided by sound speed
+   !div_v
 
    !thermal_time_to_surface ! in seconds
    !log_thermal_time_to_surface
+   !t_rad
+   !log_t_rad
+   !log_t_sound
+   !log_t_thermal
 
+   !eos_phase
    !eos_frac_OPAL_SCVH
    !eos_frac_HELM
    !eos_frac_Skye
@@ -179,37 +189,44 @@
    !eos_frac_FreeEOS
    !eos_frac_CMS
 
+   !pgas_div_p
+   !prad_div_pgas
+   !prad_div_pgas_div_L_div_Ledd
+   !pressure_scale_height_cm
+
+   !eps_grav_composition_term
+   !eps_grav_plus_eps_mdot
+
+   !chiRho_for_partials
+   !chiT_for_partials
+   !rel_diff_chiRho_for_partials
+   !rel_diff_chiT_for_partials
+
+   !latent_ddlnRho
+   !latent_ddlnT
+
+   !log_P_face
+   !log_Ptrb
+   !log_cp_T_div_t_sound
+
+   !QQ
+
 
 !# Mass accretion
    !eps_grav ! -T*ds/dt (negative for expansion)
    !log_abs_eps_grav_dm_div_L
    !log_abs_v ! log10(abs(velocity)) (cm/s)
-   !log_abs_dvdt_div_v
-
-   !dlnd ! change of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnT ! change of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR ! change of log(radius) at fixed mass coordinate (Lagrangian)
-   
-   !dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR_dt ! time derivative of log(radius) at fixed mass coordinate (Lagrangian)
-   !dr_dt ! time derivative of radius at fixed mass coordinate (Lagrangian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-
-   !ds_from_eps_grav ! -eps_grav/T/(avo*kerg)
-   
-   !dlnd_dt_const_q ! time derivative of log(density) at fixed q (for Eulerian eps_grav)
-   !dlnT_dt_const_q ! time derivative of log(temperature) at fixed q (for Eulerian eps_grav)
-   
-   !signed_dlnd ! sign(dlnd)*log10(max(1,abs(1d6*dlnd)))
-   !signed_dlnT ! sign(dlnT)*log10(max(1,abs(1d6*dlnT)))
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-
-
+   !log_mdot_cs
+   !log_mdot_v
+   !eps_mdot
+   !env_eps_grav
+   !xm_div_delta_m
+   !log_xm_div_delta_m
 
 
 !# Nuclear energy generation
    !signed_log_eps_grav ! sign(eps_grav)*log10(max(1,abs(eps_grav)))
+   !signed_log_eps_nuc
    !net_nuclear_energy ! erg/gm/s from nuclear reactions minus all neutrino losses
       ! The value plotted is net_nuclear_energy = sign(val)*log10(max(1,abs(val)))
       ! where val = net nuclear energy minus all neutrino losses.
@@ -217,6 +234,8 @@
       ! The value plotted is net_energy = sign(val)*log10(max(1,abs(val)))
       ! where val = net nuclear energy plus eps_grav minus all neutrino losses.
    !eps_nuc_plus_nuc_neu
+   !eps_nuc_minus_non_nuc_neu
+   !eps_nuc_start
 
    !eps_nuc ! ergs/g/sec from nuclear reactions (reaction neutrinos subtracted)
    !log_abs_eps_nuc
@@ -247,8 +266,10 @@
    !tri_alfa
 
 
-   ! burn_num_iters ! Number of split_burn iterations taken
-  
+   !burn_num_iters ! Number of split_burn iterations taken
+   !burn_avg_epsnuc
+   !log_burn_avg_epsnuc
+
 !# Composition
    !x_mass_fraction_H
    !y_mass_fraction_He
@@ -320,6 +341,14 @@
    !kap_frac_Compton ! fraction of opacity from Compton_Opacity
    !kap_frac_op_mono ! fraction of opacity from OP mono
 
+   !log_kap
+   !log_kap_times_factor
+
+   !log_c_div_tau
+   !xtau
+   !xlogtau
+   !logtau_sub_xlogtau
+
 !# Luminosity 
    !luminosity ! luminosity at outer boundary of zone (in Lsun units)
    !logL ! log10(max(1d-2,L/Lsun))
@@ -330,28 +359,64 @@
    !log_Lrad_div_L
    !signed_log_power ! sign(L)*log10(max(1,abs(L))) 
 
+   !lum_adv
+   !lum_conv
+   !lum_conv_MLT
+   !lum_div_Ledd
+   !lum_erg_s
+   !lum_plus_lum_adv
+   !lum_rad
 
+   !log_L_div_CpTMdot
+   !log_abs_lum_erg_s
+
+   !L
+   !Lc
+   !Lc_div_L
+   !Lr
+   !Lr_div_L
+   !Lt
+   !Lt_div_L
 
 !# Energetics
    !total_energy ! specific total energy of cell (ergs/g). internal+potential+kinetic+rotation.
-   !total_energy_integral ! sum from surface inwards of cell dm * cell total_energy (ergs)
    !cell_specific_IE
    !cell_specific_KE
    !cell_IE_div_IE_plus_KE
    !cell_KE_div_IE_plus_KE
 
+   !cell_ie_div_star_ie
+   !cell_internal_energy_fraction
+   !cell_internal_energy_fraction_start
+   !cell_specific_PE
 
+   !log_cell_ie_div_star_ie
+   !log_cell_specific_IE
 
+   !ergs_eps_grav_plus_eps_mdot
+   !ergs_error
+   !ergs_error_integral
+   !ergs_mdot
+   !ergs_rel_error_integral
+   !dm_eps_grav
+
+   !dE
+
+   !etrb
+   !log_etrb
+   !extra_grav
+   !log_rel_E_err
+
+   !total_energy_sign
 
 !# Convection
    !mlt_mixing_length ! mixing length for mlt (cm)
    !mlt_mixing_type ! value returned by mlt
    !mlt_Pturb
-   !conv_dP_term ! replaced by mlt_Pturb
+   !alpha_mlt
 
    !conv_vel ! convection velocity (cm/sec)
    !log_conv_vel ! log10 convection velocity (cm/sec)
-   !log_tau_conv_yrs ! timescale for change of conv velocity
 
    !conv_L_div_L
    !log_conv_L_div_L
@@ -363,21 +428,8 @@
    !lum_rad_div_L_Edd_sub_fourPrad_div_PchiT ! density increases outward if this is > 0
       ! see Joss, Salpeter, and Ostriker, "Critical Luminosity", ApJ 181:429-438, 1973. 
 
-   !fourPrad_div_PchiT ! = phi, where 1/phi = 1 + (dPgas/dPrad)|rho 
-      ! if phi < Lrad/Ledd, then will get density inversion
-      ! see Joss, Salpeter, Ostriker, "Critical Luminosity", ApJ 181: 429-438, 1973.
-
    !gradT ! mlt value for required temperature gradient dlnT/dlnP
-   !d_gradT_dlnd00
-   !d_gradT_dlnT00
-   !d_gradT_dlndm1
-   !d_gradT_dlnTm1
-   !d_gradT_dlnR
-   !d_gradT_dL
    
-   !actual_gradT ! actual temperature gradient dlnT/dlnP in model
-   !gradT_sub_actual_gradT
-
    !gradr ! dlnT/dlnP required for purely radiative transport
    !grad_temperature ! smoothed dlnT/dlnP at cell boundary
    !grad_density ! smoothed dlnRho/dlnP at cell boundary
@@ -396,8 +448,6 @@
 
    !log_gradT_div_gradr ! log10 gradT/gradr at cell boundary 
    !log_mlt_Gamma ! convective efficiency
-   !super_ad ! max(0,gradT-grada) at cell boundary 
-   !newly_nonconvective
    !conv_vel_div_csound ! convection velocity divided by sound speed
    !conv_vel_div_L_vel ! L_vel is velocity needed to carry L by convection; L = 4*pi*r^2*rho*vel**3
    !log_mlt_D_mix ! log10 diffusion coefficient for mixing from mlt (cm^2/sec)
@@ -405,14 +455,37 @@
    !gradr_div_grada ! gradr/grada_face; > 1 => Schwarzschild unstable for convection
    !gradr_sub_grada ! gradr - grada_face; > 0 => Schwarzschild unstable for convection
 
+   !gradL_sub_gradr
+   !gradP_div_rho
+   !gradT_excess_effect
+   !gradT_rel_err
+   !gradT_sub_a
+   !grada_face
+   !grada_sub_gradr
+   !diff_grads
+   !log_diff_grads
 
+   !mlt_D
+   !mlt_Gamma
+   !mlt_Y_face
+   !mlt_Zeta
+   !mlt_gradT
+   !mlt_log_abs_Y
+   !mlt_vc
+   !log_mlt_vc
 
+   !superad_reduction_factor
+   !conv_vel_div_mlt_vc
+   !dconv_vel_dt
 
+   !log_Lconv
+   !log_Lconv_div_L
 
 !# Mixing
    !mixing_type ! mixing types are defined in mesa/const/public/const_def   
    !log_D_mix ! log10 diffusion coefficient for mixing in units of cm^2/second (Eulerian)
    !log_D_mix_non_rotation
+   !log_D_mix_rotation
 
    !log_D_conv ! D_mix for regions where mix_type = convective_mixing
    !log_D_leftover ! D_mix for regions where mix_type = leftover_convective_mixing
@@ -422,6 +495,7 @@
    !log_D_minimum ! D_mix for regions where mix_type = minimum_mixing
    !log_D_rayleigh_taylor ! D_mix for regions where mix_type = rayleigh_taylor_mixing
    !log_D_anon ! D_mix for regions where mix_type = anonymous_mixing
+   !log_D_omega
 
    !log_sig_mix ! sig(k) is mixing flow across face k in (gm sec^1)
          ! sig(k) = D_mix*(4*pi*r(k)**2*rho_face)**2/dmavg
@@ -430,6 +504,8 @@
    !dominant_isoZ_for_thermohaline
    !gradL_composition_term
    
+   !mix_type
+
 
 
 !# Optical Depth
@@ -495,6 +571,10 @@
    !dynamo_log_B_r ! (Gauss)
    !dynamo_log_B_phi ! (Gauss)
 
+   !am_domega_dlnR
+   !log_abs_dlnR_domega
+
+   !w_div_w_crit_roche2
 
 
 !# Diffusion
@@ -580,10 +660,94 @@
    !sl2_sub_omega2
 
 
+!# RSP
+
+   !rsp_Chi
+   !rsp_Eq
+   !rsp_Et
+   !rsp_Hp_face
+   !rsp_Lc
+   !rsp_Lc_div_L
+   !rsp_Lr
+   !rsp_Lr_div_L
+   !rsp_Lt
+   !rsp_Lt_div_L
+   !rsp_PII_face
+   !rsp_Pt
+   !rsp_Pvsc
+   !rsp_Uq
+   !rsp_WORK
+   !rsp_WORKC
+   !rsp_WORKQ
+   !rsp_WORKT
+   !rsp_Y_face
+   !rsp_damp
+   !rsp_dampR
+   !rsp_erad
+   !rsp_gradT
+   !rsp_heat_exchange_timescale
+   !rsp_logEt
+   !rsp_log_dt_div_heat_exchange_timescale
+   !rsp_log_erad
+   !rsp_log_heat_exchange_timescale
+   !rsp_sink
+   !rsp_src
+   !rsp_src_snk
+   !w
+   !log_w
+
+   !COUPL
+   !DAMP
+   !DAMPR
+   !SOURCE
+   !Chi
+   !Eq
+   !Hp_face
+   !PII_face
+   !Ptrb
+   !Pvsc
+   !Uq
+   !Y_face
+
+!# RTI
+
+   !RTI_du_diffusion_kick
+   !alpha_RTI
+   !boost_for_eta_RTI
+   !dedt_RTI
+   !dudt_RTI
+   !eta_RTI
+   !log_alpha_RTI
+   !log_boost_for_eta_RTI
+   !log_eta_RTI
+   !log_etamid_RTI
+   !log_lambda_RTI_div_Hrho
+   !log_sig_RTI
+   !log_sigmid_RTI
+   !log_source_RTI
+   !log_source_minus_alpha_RTI
+   !log_source_plus_alpha_RTI
+   !source_minus_alpha_RTI
+   !source_plus_alpha_RTI
+   !lambda_RTI
+
+!# Hydrodynamics
+
+
+   !v
+   !v_div_v_escape
+   !v_div_vesc
+   !v_kms
+   !log_v_escape
+
+   !u
+   !u_face
+
+   !P_face
+
 
 !# Extras
    !extra_heat
-   !extra_dPdm
    !extra_L ! extra_heat integrated from center (Lsun)
    !log_extra_L ! log10 integrated from center (Lsun)
    !log_irradiation_heat
@@ -601,12 +765,6 @@
 
 
 !# Miscellaneous
-   !v_residual
-   !lnd_residual
-   !lnR_residual
-   !log_v_residual
-   !log_lnd_residual
-   !log_lnR_residual
 
    !dlog_h1_dlogP ! (log(h1(k)) - log(h1(k-1)))/(log(P(k)) - log(P(k-1)))
    !dlog_he3_dlogP
@@ -665,15 +823,48 @@
    
    !zFe ! mass fraction of "Fe" = Fe+Co+Ni
    !log_zFe
-   !u_residual
-   !log_u_residual
-   !u
-   !u_face
    !dPdr_dRhodr_info
-   !flux_limit_lambda
-   !flux_limit_R
-   !signed_log_ergs_err
-      
+   !log_sig_raw_mix
+
+   !d_u_div_rmid
+   !d_u_div_rmid_start
+   !d_v_div_r_dm
+   !d_v_div_r_dr
+
+   !dlnP_dlnR
+   !dlnRho_dlnR
+   !dlnRho_dr
+   !dlnX_dr
+   !dlnY_dr
+   !dlogR
+   !dPdr_div_grav
+   !dPdr_info
+   !dRhodr_info
+   !dRstar_div_dr
+   !dr_ratio
+   !dm_eps_grav
+   !dr_ratio
+   !dt_cs_div_dr
+   !dt_div_tau_conv
+   !dt_times_conv_vel_div_mixing_length
+   !log_dt_cs_div_dr
+   !log_dt_div_tau_conv
+   !log_dt_times_conv_vel_div_mixing_length
+   !log_du_kick_div_du
+   !du
+   !dvdt_dPdm
+   !dvdt_grav
+
+   !tau_conv
+   !tau_cool
+   !tau_epsnuc
+   !tau_qhse
+
+   !max_abs_xa_corr
+
+   !tdc_num_iters
+
+   !k
 
 
 ! the first few lines of the profile contain general info about the model.

--- a/star/private/star_history_def.f90
+++ b/star/private/star_history_def.f90
@@ -194,14 +194,8 @@
       integer, parameter :: h_log_avg_abs_v = h_avg_abs_v + 1
       integer, parameter :: h_max_abs_v = h_log_avg_abs_v + 1
       integer, parameter :: h_log_max_abs_v = h_max_abs_v + 1
-
-      integer, parameter :: h_total_IE_plus_KE_start = h_log_max_abs_v + 1
-      integer, parameter :: h_log_total_IE_plus_KE = h_total_IE_plus_KE_start + 1
-      integer, parameter :: h_total_IE_plus_KE = h_log_total_IE_plus_KE + 1
-
-      integer, parameter :: h_total_energy_plus_L_surf = h_total_IE_plus_KE + 1
-
-      integer, parameter :: h_total_internal_energy_after_adjust_mass = h_total_energy_plus_L_surf + 1
+      
+      integer, parameter :: h_total_internal_energy_after_adjust_mass = h_log_max_abs_v + 1
       integer, parameter :: h_total_gravitational_energy_after_adjust_mass = &
          h_total_internal_energy_after_adjust_mass + 1
       integer, parameter :: h_total_turbulent_energy_after_adjust_mass = &
@@ -318,9 +312,7 @@
       integer, parameter :: h_avg_setvars_per_step = h_avg_skipped_setvars_per_step + 1
       integer, parameter :: h_avg_solver_setvars_per_step = h_avg_setvars_per_step + 1
       
-      integer, parameter :: h_num_steps_skipped_1st_setvars = h_avg_solver_setvars_per_step + 1
-      integer, parameter :: h_fraction_of_steps_skipped_1st_setvars = h_num_steps_skipped_1st_setvars + 1
-      integer, parameter :: h_num_retries = h_fraction_of_steps_skipped_1st_setvars + 1
+      integer, parameter :: h_num_retries = h_avg_solver_setvars_per_step + 1
       integer, parameter :: h_h1_czb_mass = h_num_retries + 1
       integer, parameter :: h_surf_c12_minus_o16 = h_h1_czb_mass + 1
       integer, parameter :: h_surf_num_c12_div_num_o16 = h_surf_c12_minus_o16 + 1
@@ -340,21 +332,7 @@
       integer, parameter :: h_envelope_mass = h_center_gamma + 1
       integer, parameter :: h_envelope_fraction_left = h_envelope_mass + 1
 
-      integer, parameter :: h_tau10_mass = h_envelope_fraction_left + 1
-      integer, parameter :: h_tau10_radius = h_tau10_mass + 1
-      integer, parameter :: h_tau10_lgP = h_tau10_radius + 1
-      integer, parameter :: h_tau10_T = h_tau10_lgP + 1
-      integer, parameter :: h_tau10_lgT = h_tau10_T + 1
-      integer, parameter :: h_tau10_lgRho = h_tau10_lgT + 1
-      integer, parameter :: h_tau10_L = h_tau10_lgRho + 1
-      integer, parameter :: h_tau100_mass = h_tau10_L + 1
-      integer, parameter :: h_tau100_radius = h_tau100_mass + 1
-      integer, parameter :: h_tau100_lgP = h_tau100_radius + 1
-      integer, parameter :: h_tau100_T = h_tau100_lgP + 1
-      integer, parameter :: h_tau100_lgT = h_tau100_T + 1
-      integer, parameter :: h_tau100_lgRho = h_tau100_lgT + 1
-      integer, parameter :: h_tau100_L = h_tau100_lgRho + 1
-      integer, parameter :: h_dynamic_timescale = h_tau100_L + 1
+      integer, parameter :: h_dynamic_timescale = h_envelope_fraction_left + 1
       integer, parameter :: h_kh_timescale = h_dynamic_timescale + 1
       integer, parameter :: h_nuc_timescale = h_kh_timescale + 1
       integer, parameter :: h_tau_QHSE_yrs = h_nuc_timescale + 1
@@ -377,54 +355,9 @@
       integer, parameter :: h_diffusion_time_H_He_bdy = h_mass_loc_of_max_eps_nuc + 1
       integer, parameter :: h_temperature_H_He_bdy = h_diffusion_time_H_He_bdy + 1
 
-      integer, parameter :: h_max_abs_v_velocity = h_temperature_H_He_bdy + 1
-      integer, parameter :: h_max_abs_v_csound = h_max_abs_v_velocity + 1
-      integer, parameter :: h_max_abs_v_v_div_cs = h_max_abs_v_csound + 1
-      integer, parameter :: h_max_abs_v_lgT = h_max_abs_v_v_div_cs + 1
-      integer, parameter :: h_max_abs_v_lgRho = h_max_abs_v_lgT + 1
-      integer, parameter :: h_max_abs_v_lgP = h_max_abs_v_lgRho + 1
-      integer, parameter :: h_max_abs_v_mass = h_max_abs_v_lgP + 1
-      integer, parameter :: h_max_abs_v_radius = h_max_abs_v_mass + 1
-      integer, parameter :: h_max_abs_v_radius_cm = h_max_abs_v_radius + 1
-      integer, parameter :: h_max_abs_v_lgR = h_max_abs_v_radius_cm + 1
-      integer, parameter :: h_max_abs_v_lgR_cm = h_max_abs_v_lgR + 1
-      integer, parameter :: h_max_abs_v_L = h_max_abs_v_lgR_cm + 1
-      integer, parameter :: h_max_abs_v_gamma1 = h_max_abs_v_L + 1
-      integer, parameter :: h_max_abs_v_entropy = h_max_abs_v_gamma1 + 1
-      integer, parameter :: h_max_abs_v_E0 = h_max_abs_v_entropy + 1
-      integer, parameter :: h_max_abs_v_eps_nuc = h_max_abs_v_E0 + 1
+      integer, parameter :: h_total_ni_co_56 = h_temperature_H_He_bdy + 1
 
-      integer, parameter :: h_total_ni_co_56 = h_max_abs_v_eps_nuc + 1
-      
-      integer, parameter :: h_inner_mach1_velocity = h_total_ni_co_56 + 1
-      integer, parameter :: h_inner_mach1_csound = h_inner_mach1_velocity + 1
-      integer, parameter :: h_inner_mach1_v_div_cs = h_inner_mach1_csound + 1
-      integer, parameter :: h_inner_mach1_lgT = h_inner_mach1_v_div_cs + 1
-      integer, parameter :: h_inner_mach1_lgRho = h_inner_mach1_lgT + 1
-      integer, parameter :: h_inner_mach1_lgP = h_inner_mach1_lgRho + 1
-      integer, parameter :: h_inner_mach1_q = h_inner_mach1_lgP + 1
-      integer, parameter :: h_inner_mach1_tau = h_inner_mach1_q + 1
-      integer, parameter :: h_inner_mach1_mass = h_inner_mach1_tau + 1
-      integer, parameter :: h_inner_mach1_radius = h_inner_mach1_mass + 1
-      integer, parameter :: h_inner_mach1_gamma1 = h_inner_mach1_radius + 1
-      integer, parameter :: h_inner_mach1_entropy = h_inner_mach1_gamma1 + 1
-      integer, parameter :: h_inner_mach1_k = h_inner_mach1_entropy + 1
-
-      integer, parameter :: h_outer_mach1_velocity = h_inner_mach1_k + 1
-      integer, parameter :: h_outer_mach1_csound = h_outer_mach1_velocity + 1
-      integer, parameter :: h_outer_mach1_v_div_cs = h_outer_mach1_csound + 1
-      integer, parameter :: h_outer_mach1_lgT = h_outer_mach1_v_div_cs + 1
-      integer, parameter :: h_outer_mach1_lgRho = h_outer_mach1_lgT + 1
-      integer, parameter :: h_outer_mach1_lgP = h_outer_mach1_lgRho + 1
-      integer, parameter :: h_outer_mach1_q = h_outer_mach1_lgP + 1
-      integer, parameter :: h_outer_mach1_tau = h_outer_mach1_q + 1
-      integer, parameter :: h_outer_mach1_mass = h_outer_mach1_tau + 1
-      integer, parameter :: h_outer_mach1_radius = h_outer_mach1_mass + 1
-      integer, parameter :: h_outer_mach1_gamma1 = h_outer_mach1_radius + 1
-      integer, parameter :: h_outer_mach1_entropy = h_outer_mach1_gamma1 + 1
-      integer, parameter :: h_outer_mach1_k = h_outer_mach1_entropy + 1
-
-      integer, parameter :: h_shock_velocity = h_outer_mach1_k + 1
+      integer, parameter :: h_shock_velocity = h_total_ni_co_56 + 1
       integer, parameter :: h_shock_csound = h_shock_velocity + 1
       integer, parameter :: h_shock_v_div_cs = h_shock_csound + 1
       integer, parameter :: h_shock_lgT = h_shock_v_div_cs + 1
@@ -441,25 +374,7 @@
       integer, parameter :: h_shock_pre_lgRho = h_shock_entropy + 1
       integer, parameter :: h_shock_k = h_shock_pre_lgRho + 1
 
-      integer, parameter :: h_trace_mass_location = h_shock_k + 1
-      integer, parameter :: h_trace_mass_radius = h_trace_mass_location + 1
-      integer, parameter :: h_trace_mass_lgT = h_trace_mass_radius + 1
-      integer, parameter :: h_trace_mass_lgRho = h_trace_mass_lgT + 1
-      integer, parameter :: h_trace_mass_L = h_trace_mass_lgRho + 1
-      integer, parameter :: h_trace_mass_v = h_trace_mass_L + 1
-
-      integer, parameter :: h_max_T_shell_binding_energy = h_trace_mass_v + 1
-      integer, parameter :: h_max_T_lgP_thin_shell = h_max_T_shell_binding_energy + 1
-      integer, parameter :: h_max_T_lgP = h_max_T_lgP_thin_shell + 1
-      integer, parameter :: h_max_T_entropy = h_max_T_lgP + 1
-      integer, parameter :: h_max_T_mass = h_max_T_entropy + 1
-      integer, parameter :: h_max_T_radius = h_max_T_mass + 1
-      integer, parameter :: h_max_T_lgT = h_max_T_radius + 1
-      integer, parameter :: h_max_T_lgRho = h_max_T_lgT + 1
-      integer, parameter :: h_max_T_L = h_max_T_lgRho + 1
-      integer, parameter :: h_max_T_eps_nuc = h_max_T_L + 1
-
-      integer, parameter :: h_max_conv_vel_div_csound = h_max_T_eps_nuc + 1
+      integer, parameter :: h_max_conv_vel_div_csound = h_shock_k + 1
       integer, parameter :: h_max_gradT_div_grada = h_max_conv_vel_div_csound + 1
       integer, parameter :: h_max_gradT_sub_grada = h_max_gradT_div_grada + 1
       integer, parameter :: h_min_log_mlt_Gamma = h_max_gradT_sub_grada + 1
@@ -548,16 +463,11 @@
       integer, parameter :: h_cz_top_omega = h_cz_top_zone + 1
       integer, parameter :: h_cz_top_omega_div_omega_crit = h_cz_top_omega + 1
 
-      integer, parameter :: h_trace_mass_omega = h_cz_top_omega_div_omega_crit + 1
-      integer, parameter :: h_trace_mass_omega_div_omega_crit = h_trace_mass_omega + 1
-
-      integer, parameter :: h_kh_mdot_limit = h_trace_mass_omega_div_omega_crit + 1
+      integer, parameter :: h_kh_mdot_limit = h_cz_top_omega_div_omega_crit + 1
       integer, parameter :: h_rotational_mdot_boost = h_kh_mdot_limit + 1
       integer, parameter :: h_log_rotational_mdot_boost = h_rotational_mdot_boost + 1
 
-      integer, parameter :: h_logL_for_BB_outer_BC = h_log_rotational_mdot_boost + 1
-      integer, parameter :: h_luminosity_for_BB_outer_BC = h_logL_for_BB_outer_BC + 1
-      integer, parameter :: h_i_rot_total = h_luminosity_for_BB_outer_BC + 1
+      integer, parameter :: h_i_rot_total = h_log_rotational_mdot_boost + 1
       integer, parameter :: h_surf_avg_j_rot = h_i_rot_total + 1
       integer, parameter :: h_surf_avg_omega = h_surf_avg_j_rot + 1
       integer, parameter :: h_surf_avg_omega_crit = h_surf_avg_omega + 1
@@ -695,16 +605,7 @@
       integer, parameter :: h_mass_semiconv_core = h_cz_top_zone_logdq + 1
       integer, parameter :: h_mass_conv_core = h_mass_semiconv_core + 1
 
-      integer, parameter :: h_trace_mass_lgP = h_mass_conv_core + 1
-      integer, parameter :: h_trace_mass_g = h_trace_mass_lgP + 1
-      integer, parameter :: h_trace_mass_X = h_trace_mass_g + 1
-      integer, parameter :: h_trace_mass_Y = h_trace_mass_X + 1
-      integer, parameter :: h_trace_mass_scale_height = h_trace_mass_Y + 1
-      integer, parameter :: h_trace_mass_dlnX_dr = h_trace_mass_scale_height + 1
-      integer, parameter :: h_trace_mass_dlnY_dr = h_trace_mass_dlnX_dr + 1
-      integer, parameter :: h_trace_mass_dlnRho_dr = h_trace_mass_dlnY_dr + 1
-
-      integer, parameter :: h_k_below_const_q = h_trace_mass_dlnRho_dr + 1
+      integer, parameter :: h_k_below_const_q = h_mass_conv_core + 1
       integer, parameter :: h_q_below_const_q = h_k_below_const_q + 1
       integer, parameter :: h_logxq_below_const_q = h_q_below_const_q + 1
 
@@ -927,10 +828,6 @@
          history_column_name(h_log_mesh_adjust_PE_conservation) = 'log_mesh_adjust_PE_conservation'
          history_column_name(h_log_mesh_adjust_KE_conservation) = 'log_mesh_adjust_KE_conservation'
 
-         history_column_name(h_total_IE_plus_KE_start) = 'total_IE_plus_KE_start'
-         history_column_name(h_log_total_IE_plus_KE) = 'log_total_IE_plus_KE'
-         history_column_name(h_total_IE_plus_KE) = 'total_IE_plus_KE'
-
          history_column_name(h_avg_abs_v_div_cs) = 'avg_abs_v_div_cs'
          history_column_name(h_log_avg_abs_v_div_cs) = 'log_avg_abs_v_div_cs'
          history_column_name(h_max_abs_v_div_cs) = 'max_abs_v_div_cs'
@@ -940,8 +837,6 @@
          history_column_name(h_log_avg_abs_v) = 'log_avg_abs_v'
          history_column_name(h_max_abs_v) = 'max_abs_v'
          history_column_name(h_log_max_abs_v) = 'log_max_abs_v'
-
-         history_column_name(h_total_energy_plus_L_surf) = 'total_energy_plus_L_surf'
 
          history_column_name(h_total_internal_energy_after_adjust_mass) = 'total_internal_energy_after_adjust_mass'
          history_column_name(h_total_gravitational_energy_after_adjust_mass) = &
@@ -1084,8 +979,6 @@
          history_column_name(h_avg_setvars_per_step) = 'avg_setvars_per_step'
          history_column_name(h_avg_solver_setvars_per_step) = 'avg_solver_setvars_per_step'
          
-         history_column_name(h_num_steps_skipped_1st_setvars) = 'num_steps_skipped_1st_setvars'
-         history_column_name(h_fraction_of_steps_skipped_1st_setvars) = 'fraction_of_steps_skipped_1st_setvars'
          history_column_name(h_num_retries) = 'num_retries'
 
          history_column_name(h_total_num_solver_iterations) = 'total_num_solver_iterations'
@@ -1163,24 +1056,6 @@
          history_column_name(h_envelope_mass) = 'envelope_mass'
          history_column_name(h_envelope_fraction_left) = 'envelope_fraction_left'
 
-         history_column_name(h_tau10_mass) = &
-            'tau10_mass' ! mass in solar units where optical depth = 10
-         history_column_name(h_tau10_radius) = &
-            'tau10_radius' ! radius in solar units where optical depth = 10
-         history_column_name(h_tau10_lgP) = 'tau10_lgP' ! estimate for log10(P) at tau = 10
-         history_column_name(h_tau10_T) = 'tau10_T' ! estimate for T at tau = 10
-         history_column_name(h_tau10_lgT) = 'tau10_lgT' ! estimate for log10(T) at tau = 10
-         history_column_name(h_tau10_lgRho) = 'tau10_lgRho' ! estimate for log10(density) at tau = 10
-         history_column_name(h_tau10_L) = 'tau10_L' ! estimate for L/Lsun at tau = 10
-         history_column_name(h_tau100_mass) = &
-            'tau100_mass' ! location in solar units where optical depth = 100
-         history_column_name(h_tau100_radius) = &
-            'tau100_radius' ! location in solar units where optical depth = 100
-         history_column_name(h_tau100_lgP) = 'tau100_lgP' ! estimates for values at tau = 100
-         history_column_name(h_tau100_T) = 'tau100_T'
-         history_column_name(h_tau100_lgT) = 'tau100_lgT'
-         history_column_name(h_tau100_lgRho) = 'tau100_lgRho'
-         history_column_name(h_tau100_L) = 'tau100_L'
          history_column_name(h_dynamic_timescale) = 'dynamic_timescale'
          history_column_name(h_dlnR_dlnM) = 'dlnR_dlnM'
          history_column_name(h_kh_timescale) = 'kh_timescale'
@@ -1206,53 +1081,7 @@
          history_column_name(h_diffusion_time_H_He_bdy) = 'diffusion_time_H_He_bdy'
          history_column_name(h_temperature_H_He_bdy) = 'temperature_H_He_bdy'
 
-         history_column_name(h_max_abs_v_velocity) = 'max_abs_v_velocity'
-         history_column_name(h_max_abs_v_csound)  = 'max_abs_v_csound'
-         history_column_name(h_max_abs_v_v_div_cs)  = 'max_abs_v_v_div_cs'
-         history_column_name(h_max_abs_v_lgT)  = 'max_abs_v_lgT'
-         history_column_name(h_max_abs_v_lgRho)  = 'max_abs_v_lgRho'
-         history_column_name(h_max_abs_v_lgP)  = 'max_abs_v_lgP'
-         history_column_name(h_max_abs_v_mass)  = 'max_abs_v_mass'
-         history_column_name(h_max_abs_v_L)  = 'max_abs_v_L'
-         history_column_name(h_max_abs_v_gamma1)  = 'max_abs_v_gamma1'
-         history_column_name(h_max_abs_v_entropy)  = 'max_abs_v_entropy'
-         history_column_name(h_max_abs_v_eps_nuc)  = 'max_abs_v_eps_nuc'
-         history_column_name(h_max_abs_v_E0)  = 'max_abs_v_E0'
-
          history_column_name(h_total_ni_co_56)  = 'total_ni_co_56'
-
-         history_column_name(h_max_abs_v_radius)  = 'max_abs_v_radius'
-         history_column_name(h_max_abs_v_radius_cm)  = 'max_abs_v_radius_cm'
-         history_column_name(h_max_abs_v_lgR)  = 'max_abs_v_lgR'
-         history_column_name(h_max_abs_v_lgR_cm)  = 'max_abs_v_lgR_cm'
-
-         history_column_name(h_inner_mach1_velocity) = 'inner_mach1_velocity'
-         history_column_name(h_inner_mach1_csound)  = 'inner_mach1_csound'
-         history_column_name(h_inner_mach1_v_div_cs)  = 'inner_mach1_v_div_cs'
-         history_column_name(h_inner_mach1_lgT)  = 'inner_mach1_lgT'
-         history_column_name(h_inner_mach1_lgRho)  = 'inner_mach1_lgRho'
-         history_column_name(h_inner_mach1_lgP)  = 'inner_mach1_lgP'
-         history_column_name(h_inner_mach1_q)  = 'inner_mach1_q'
-         history_column_name(h_inner_mach1_tau)  = 'inner_mach1_tau'
-         history_column_name(h_inner_mach1_mass)  = 'inner_mach1_mass'
-         history_column_name(h_inner_mach1_radius)  = 'inner_mach1_radius'
-         history_column_name(h_inner_mach1_gamma1)  = 'inner_mach1_gamma1'
-         history_column_name(h_inner_mach1_entropy)  = 'inner_mach1_entropy'
-         history_column_name(h_inner_mach1_k)  = 'inner_mach1_k'
-
-         history_column_name(h_outer_mach1_velocity) = 'outer_mach1_velocity'
-         history_column_name(h_outer_mach1_csound)  = 'outer_mach1_csound'
-         history_column_name(h_outer_mach1_v_div_cs)  = 'outer_mach1_v_div_cs'
-         history_column_name(h_outer_mach1_lgT)  = 'outer_mach1_lgT'
-         history_column_name(h_outer_mach1_lgRho)  = 'outer_mach1_lgRho'
-         history_column_name(h_outer_mach1_lgP)  = 'outer_mach1_lgP'
-         history_column_name(h_outer_mach1_mass)  = 'outer_mach1_mass'
-         history_column_name(h_outer_mach1_q)  = 'outer_mach1_q'
-         history_column_name(h_outer_mach1_tau)  = 'outer_mach1_tau'
-         history_column_name(h_outer_mach1_radius)  = 'outer_mach1_radius'
-         history_column_name(h_outer_mach1_gamma1)  = 'outer_mach1_gamma1'
-         history_column_name(h_outer_mach1_entropy)  = 'outer_mach1_entropy'
-         history_column_name(h_outer_mach1_k)  = 'outer_mach1_k'
 
          history_column_name(h_shock_velocity) = 'shock_velocity'
          history_column_name(h_shock_csound)  = 'shock_csound'
@@ -1270,32 +1099,6 @@
          history_column_name(h_shock_entropy)  = 'shock_entropy'
          history_column_name(h_shock_pre_lgRho)  = 'shock_pre_lgRho'
          history_column_name(h_shock_k)  = 'shock_k'
-
-         history_column_name(h_trace_mass_location) = 'trace_mass_location'
-         history_column_name(h_trace_mass_radius) = 'trace_mass_radius'
-         history_column_name(h_trace_mass_lgT) = 'trace_mass_lgT'
-         history_column_name(h_trace_mass_lgRho) = 'trace_mass_lgRho'
-         history_column_name(h_trace_mass_L) = 'trace_mass_L'
-         history_column_name(h_trace_mass_v) = 'trace_mass_v'
-         history_column_name(h_trace_mass_lgP) = 'trace_mass_lgP'
-         history_column_name(h_trace_mass_g) = 'trace_mass_g'
-         history_column_name(h_trace_mass_X) = 'trace_mass_X'
-         history_column_name(h_trace_mass_Y) = 'trace_mass_Y'
-         history_column_name(h_trace_mass_scale_height) = 'trace_mass_scale_height'
-         history_column_name(h_trace_mass_dlnX_dr) = 'trace_mass_dlnX_dr'
-         history_column_name(h_trace_mass_dlnY_dr) = 'trace_mass_dlnY_dr'
-         history_column_name(h_trace_mass_dlnRho_dr) = 'trace_mass_dlnRho_dr'
-
-         history_column_name(h_max_T_shell_binding_energy) = 'max_T_shell_binding_energy'
-         history_column_name(h_max_T_lgP_thin_shell) = 'max_T_lgP_thin_shell'
-         history_column_name(h_max_T_lgT) = 'max_T_lgT'
-         history_column_name(h_max_T_lgP) = 'max_T_lgP'
-         history_column_name(h_max_T_entropy) = 'max_T_entropy'
-         history_column_name(h_max_T_mass) = 'max_T_mass'
-         history_column_name(h_max_T_radius) = 'max_T_radius'
-         history_column_name(h_max_T_lgRho) = 'max_T_lgRho'
-         history_column_name(h_max_T_L) = 'max_T_L'
-         history_column_name(h_max_T_eps_nuc) = 'max_T_eps_nuc'
 
          history_column_name(h_log_surf_optical_depth) = 'log_surf_optical_depth'
          history_column_name(h_surface_optical_depth) = 'surface_optical_depth'
@@ -1374,14 +1177,9 @@
          history_column_name(h_cz_top_omega) = 'cz_top_omega'
          history_column_name(h_cz_top_omega_div_omega_crit) = 'cz_top_omega_div_omega_crit'
 
-         history_column_name(h_trace_mass_omega) = 'trace_mass_omega'
-         history_column_name(h_trace_mass_omega_div_omega_crit) = 'trace_mass_omega_div_omega_crit'
          history_column_name(h_kh_mdot_limit) = 'kh_mdot_limit'
          history_column_name(h_rotational_mdot_boost) = 'rotational_mdot_boost'
          history_column_name(h_log_rotational_mdot_boost) = 'log_rotational_mdot_boost'
-
-         history_column_name(h_logL_for_BB_outer_BC) = 'logL_for_BB_outer_BC'
-         history_column_name(h_luminosity_for_BB_outer_BC) = 'luminosity_for_BB_outer_BC'
 
          history_column_name(h_i_rot_total) = 'i_rot_total'
          history_column_name(h_surf_avg_j_rot) = 'surf_avg_j_rot'

--- a/star/private/star_profile_def.f90
+++ b/star/private/star_profile_def.f90
@@ -233,13 +233,11 @@
       integer, parameter :: p_log_rho_times_r3 = p_eos_frac_CMS + 1
       integer, parameter :: p_rho_times_r3 = p_log_rho_times_r3 + 1
       integer, parameter :: p_v_times_t_div_r = p_rho_times_r3 + 1
-      integer, parameter :: p_d_v_div_r = p_v_times_t_div_r + 1
-      integer, parameter :: p_v_div_r = p_d_v_div_r + 1
+      integer, parameter :: p_v_div_r = p_v_times_t_div_r + 1
 
       integer, parameter :: p_log_c_div_tau = p_v_div_r + 1
       integer, parameter :: p_log_v_escape = p_log_c_div_tau + 1
-      integer, parameter :: p_v_escape = p_log_v_escape + 1
-      integer, parameter :: p_v_div_vesc = p_v_escape + 1
+      integer, parameter :: p_v_div_vesc = p_log_v_escape + 1
       integer, parameter :: p_v_div_v_escape = p_v_div_vesc + 1
       integer, parameter :: p_v_div_cs = p_v_div_v_escape + 1
       integer, parameter :: p_v_div_csound = p_v_div_cs + 1
@@ -361,10 +359,7 @@
       integer, parameter :: p_log_abs_eps_nuc = p_signed_log_eps_nuc + 1
       integer, parameter :: p_eps_nuc = p_log_abs_eps_nuc + 1
 
-      integer, parameter :: p_burn_sum_xa_err_before_fix = p_eps_nuc + 1
-      integer, parameter :: p_burn_log_abs_sum_xa_err_before_fix = p_burn_sum_xa_err_before_fix + 1
-
-      integer, parameter :: p_eps_nuc_neu_total = p_burn_log_abs_sum_xa_err_before_fix + 1
+      integer, parameter :: p_eps_nuc_neu_total = p_eps_nuc + 1
       integer, parameter :: p_non_nuc_neu = p_eps_nuc_neu_total + 1
 
       integer, parameter :: p_nonnucneu_plas = p_non_nuc_neu + 1
@@ -392,10 +387,7 @@
 
       integer, parameter :: p_log_P_face = p_P_face + 1
 
-      integer, parameter :: p_dvdt_RTI_diffusion = p_log_P_face + 1
-      integer, parameter :: p_dlnddt_RTI_diffusion = p_dvdt_RTI_diffusion + 1
-
-      integer, parameter :: p_dlnP_dlnR = p_dlnddt_RTI_diffusion + 1
+      integer, parameter :: p_dlnP_dlnR = p_log_P_face + 1
       integer, parameter :: p_dlnRho_dlnR = p_dlnP_dlnR + 1
 
       integer, parameter :: p_gradP_div_rho = p_dlnRho_dlnR + 1
@@ -455,8 +447,7 @@
       integer, parameter :: p_delta_mu = p_delta_eps_nuc + 1
       integer, parameter :: p_log_D_conv = p_delta_mu + 1
 
-      integer, parameter :: p_log_D_smooth = p_log_D_conv + 1
-      integer, parameter :: p_log_D_leftover = p_log_D_smooth + 1
+      integer, parameter :: p_log_D_leftover = p_log_D_conv  + 1
       integer, parameter :: p_log_D_semi = p_log_D_leftover + 1
       integer, parameter :: p_log_D_anon = p_log_D_semi + 1
       integer, parameter :: p_log_D_ovr = p_log_D_anon + 1
@@ -607,9 +598,7 @@
       integer, parameter :: p_Lt = p_Lc_div_L + 1
       integer, parameter :: p_Lt_div_L = p_Lt + 1
 
-      integer, parameter :: p_rsp_vt_div_cs = p_Lt_div_L + 1
-      integer, parameter :: p_rsp_vt = p_rsp_vt_div_cs + 1
-      integer, parameter :: p_rsp_log_erad = p_rsp_vt + 1
+      integer, parameter :: p_rsp_log_erad = p_Lt_div_L + 1
       integer, parameter :: p_rsp_erad = p_rsp_log_erad + 1
       integer, parameter :: p_rsp_logEt = p_rsp_erad + 1
       integer, parameter :: p_rsp_Et = p_rsp_logEt + 1
@@ -707,11 +696,7 @@
       integer, parameter :: p_sl2_sub_omega2 = p_brunt_N2_sub_omega2 + 1
       integer, parameter :: p_k_r_integral = p_sl2_sub_omega2 + 1
 
-      integer, parameter :: p_num_steps = p_k_r_integral + 1
-      integer, parameter :: p_mtx_solve = p_num_steps + 1
-      integer, parameter :: p_mtx_factor = p_mtx_solve + 1
-
-      integer, parameter :: p_log_dt_div_tau_conv = p_mtx_factor + 1
+      integer, parameter :: p_log_dt_div_tau_conv = p_k_r_integral + 1
       integer, parameter :: p_dt_div_tau_conv = p_log_dt_div_tau_conv + 1
       integer, parameter :: p_tau_conv = p_dt_div_tau_conv + 1
       integer, parameter :: p_tau_qhse = p_tau_conv + 1
@@ -760,7 +745,7 @@
          profile_column_name(p_lum_conv) = 'lum_conv'
          profile_column_name(p_lum_conv_MLT) = 'lum_conv_MLT'
 
-         profile_column_name(p_lum_conv_div_lum_Edd) = 'p_lum_conv_MLT'
+         profile_column_name(p_lum_conv_div_lum_Edd) = 'lum_conv_div_lum_Edd'
          profile_column_name(p_lum_rad_div_L_Edd) = 'lum_rad_div_L_Edd'
          profile_column_name(p_lum_rad_div_L) = 'lum_rad_div_L'
          profile_column_name(p_lum_conv_div_L) = 'lum_conv_div_L'
@@ -788,7 +773,7 @@
          profile_column_name(p_log_diff_grads) = 'log_diff_grads'
          profile_column_name(p_diff_grads) = 'diff_grads'
          profile_column_name(p_gradT_excess_effect) = 'gradT_excess_effect'
-         profile_column_name(p_superad_reduction_factor) = 'superad_red'
+         profile_column_name(p_superad_reduction_factor) = 'superad_reduction_factor'
 
          profile_column_name(p_v) = 'v'
          profile_column_name(p_velocity) = 'velocity'
@@ -946,11 +931,9 @@
          profile_column_name(p_rho_times_r3) = 'rho_times_r3'
          profile_column_name(p_v_times_t_div_r) = 'v_times_t_div_r'
          profile_column_name(p_v_div_r) = 'v_div_r'
-         profile_column_name(p_d_v_div_r) = 'd_v_div_r'
          
          profile_column_name(p_log_c_div_tau) = 'log_c_div_tau'
          profile_column_name(p_log_v_escape) = 'log_v_escape'
-         profile_column_name(p_v_escape) = 'v_escape'
          profile_column_name(p_v_div_v_escape) = 'v_div_v_escape'
          profile_column_name(p_v_div_vesc) = 'v_div_vesc'
          profile_column_name(p_v_div_cs) = 'v_div_cs'
@@ -1060,8 +1043,6 @@
          profile_column_name(p_eps_nuc) = 'eps_nuc'
          profile_column_name(p_signed_log_eps_nuc) = 'signed_log_eps_nuc'
          profile_column_name(p_log_abs_eps_nuc) = 'log_abs_eps_nuc'
-         profile_column_name(p_burn_sum_xa_err_before_fix) = 'burn_sum_xa_err_before_fix'
-         profile_column_name(p_burn_log_abs_sum_xa_err_before_fix) = 'burn_log_abs_sum_xa_err_before_fix'
 
          profile_column_name(p_d_epsnuc_dlnd) = 'd_epsnuc_dlnd'
          profile_column_name(p_d_epsnuc_dlnT) = 'd_epsnuc_dlnT'
@@ -1102,8 +1083,6 @@
          profile_column_name(p_gradP_div_rho) = 'gradP_div_rho'
          profile_column_name(p_dPdr_div_grav) = 'dPdr_div_grav'
 
-         profile_column_name(p_dvdt_RTI_diffusion) = 'dvdt_RTI_diffusion'
-         profile_column_name(p_dlnddt_RTI_diffusion) = 'dlnddt_RTI_diffusion'
          profile_column_name(p_log_abs_eps_grav_dm_div_L) = 'log_abs_eps_grav_dm_div_L'
          profile_column_name(p_eps_grav_composition_term) = 'eps_grav_composition_term'
          profile_column_name(p_dm_eps_grav) = 'dm_eps_grav'
@@ -1157,7 +1136,6 @@
          profile_column_name(p_delta_eps_nuc) = 'delta_eps_nuc'
          profile_column_name(p_delta_mu) = 'delta_mu'
          profile_column_name(p_log_D_conv) = 'log_D_conv'
-         profile_column_name(p_log_D_smooth) = 'log_D_smooth'
          profile_column_name(p_log_D_leftover) = 'log_D_leftover'
          profile_column_name(p_log_D_semi) = 'log_D_semi'
          profile_column_name(p_log_D_ovr) = 'log_D_ovr'
@@ -1299,8 +1277,6 @@
          profile_column_name(p_rsp_logEt) = 'rsp_logEt'
          profile_column_name(p_rsp_erad) = 'rsp_erad'
          profile_column_name(p_rsp_log_erad) = 'rsp_log_erad'
-         profile_column_name(p_rsp_vt_div_cs) = 'rsp_vt_div_cs'
-         profile_column_name(p_rsp_vt) = 'rsp_vt'
          profile_column_name(p_rsp_Pt) = 'rsp_Pt'
          profile_column_name(p_rsp_Lr) = 'rsp_Lr'
          profile_column_name(p_rsp_Lc) = 'rsp_Lc'
@@ -1394,10 +1370,6 @@
          profile_column_name(p_brunt_N2_sub_omega2) = 'brunt_N2_sub_omega2'
          profile_column_name(p_sl2_sub_omega2) = 'sl2_sub_omega2'
          profile_column_name(p_k_r_integral) = 'k_r_integral'
-
-         profile_column_name(p_num_steps) = 'num_steps'
-         profile_column_name(p_mtx_solve) = 'mtx_solve'
-         profile_column_name(p_mtx_factor) = 'mtx_factor'
 
          profile_column_name(p_log_brunt_nu) = 'log_brunt_nu'
          profile_column_name(p_log_lamb_Sl1) = 'log_lamb_Sl1'

--- a/star/test_suite/1.5M_with_diffusion/history_columns.list
+++ b/star/test_suite/1.5M_with_diffusion/history_columns.list
@@ -183,44 +183,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -248,7 +223,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/1.5M_with_diffusion/profile_columns.list
+++ b/star/test_suite/1.5M_with_diffusion/profile_columns.list
@@ -91,12 +91,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -112,7 +109,6 @@
    log_D_anon
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -216,20 +212,13 @@
       !cno
       !tri_alfa
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -267,7 +256,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -298,8 +286,6 @@
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
 
 ! the first few lines of the profile contain general info about the model.
@@ -345,9 +331,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/15M_dynamo/history_columns.list
+++ b/star/test_suite/15M_dynamo/history_columns.list
@@ -97,19 +97,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -194,44 +182,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -259,7 +222,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/15M_dynamo/profile_columns.list
+++ b/star/test_suite/15M_dynamo/profile_columns.list
@@ -96,7 +96,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
@@ -107,8 +106,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
       
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -144,23 +141,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -198,17 +188,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -246,7 +230,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -257,17 +240,12 @@
       grad_temperature ! dlnT/dlnP (smoothed)
       
       brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       !logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -314,9 +292,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/16M_conv_premix/history_columns.list
+++ b/star/test_suite/16M_conv_premix/history_columns.list
@@ -97,19 +97,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -194,44 +182,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -259,7 +222,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
       num_solver_iterations ! iterations at this step

--- a/star/test_suite/16M_conv_premix/profile_columns.list
+++ b/star/test_suite/16M_conv_premix/profile_columns.list
@@ -96,7 +96,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
@@ -107,8 +106,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
       
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -144,23 +141,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -198,17 +188,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -246,7 +230,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -257,17 +240,12 @@
       grad_temperature ! dlnT/dlnP (smoothed)
       
       brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       !logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -314,9 +292,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/16M_predictive_mix/history_columns.list
+++ b/star/test_suite/16M_predictive_mix/history_columns.list
@@ -97,19 +97,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -194,44 +182,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -259,7 +222,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
       num_solver_iterations ! iterations at this step

--- a/star/test_suite/16M_predictive_mix/profile_columns.list
+++ b/star/test_suite/16M_predictive_mix/profile_columns.list
@@ -96,7 +96,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
@@ -107,8 +106,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
       
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -144,23 +141,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -198,17 +188,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -246,7 +230,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -257,17 +240,12 @@
       grad_temperature ! dlnT/dlnP (smoothed)
       
       brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       !logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -314,9 +292,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/1M_pre_ms_to_wd/history_columns.list
+++ b/star/test_suite/1M_pre_ms_to_wd/history_columns.list
@@ -107,19 +107,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -204,44 +192,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -269,7 +232,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
 

--- a/star/test_suite/1M_pre_ms_to_wd/profile_columns.list
+++ b/star/test_suite/1M_pre_ms_to_wd/profile_columns.list
@@ -91,12 +91,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -113,7 +110,6 @@
    log_D_anon
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -217,26 +213,16 @@
       !cno
       !tri_alfa
    
-   !cell_energy
-   !cell_energy_fraction
-   !log_cell_energy_fraction
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -274,7 +260,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -305,8 +290,6 @@
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
 
 ! the first few lines of the profile contain general info about the model.
@@ -352,9 +335,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/1M_thermohaline/history_columns.list
+++ b/star/test_suite/1M_thermohaline/history_columns.list
@@ -101,19 +101,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -198,44 +186,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -263,7 +226,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/1M_thermohaline/profile_columns.list
+++ b/star/test_suite/1M_thermohaline/profile_columns.list
@@ -93,14 +93,9 @@
 !   log_conv_vel ! log10 convection velocity (cm/sec)
 !   conv_vel_div_csound ! convection velocity divided by sound speed
 !   log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
 !   gradT ! mlt value for required temperature gradient dlnT/dlnP
 !   gradr ! dlnT/dlnP required for purely radiative transport
-!   dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Lagrangian)
-!   dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -142,20 +137,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
 !      gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -193,7 +181,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -203,17 +190,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -260,9 +242,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/20M_z2m2_high_rotation/history_columns.list
+++ b/star/test_suite/20M_z2m2_high_rotation/history_columns.list
@@ -97,19 +97,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -222,44 +210,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -296,7 +259,6 @@
       
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
        

--- a/star/test_suite/20M_z2m2_high_rotation/profile_columns.list
+++ b/star/test_suite/20M_z2m2_high_rotation/profile_columns.list
@@ -117,7 +117,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
 
    gradT ! mlt value for requared temperature gradient dlnT/dlnP
@@ -130,8 +129,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -167,23 +164,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -191,7 +181,6 @@
       log_J_inside ! J_inside is j_rot integrated from center
       !shear ! abs(dlnomega/dlnR)
       log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !delta_omega ! omega minus omega_pre_hydro
       v_rot ! rotation velocity at cell boundary (km/sec)
       i_rot ! specific moment of interia at cell boundary
       j_rot ! specific angular momentum at cell boundary
@@ -224,17 +213,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -272,7 +255,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -293,7 +275,6 @@
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
-      !brunt_dlnRho_dlnR ! smoothed numerical difference for use with brunt
       
       brunt_B
 
@@ -340,9 +321,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/5M_cepheid_blue_loop/profile_columns.list
+++ b/star/test_suite/5M_cepheid_blue_loop/profile_columns.list
@@ -89,9 +89,6 @@
    !velocity ! velocity at outer boundary of zone -- 0 if no velocity variable
    vel_km_per_s
    
-   !dr_dt ! time derivative of radius at fixed mass coordinate (Langranian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Langranian)
-   !dlnR_dt ! time derivative of log(radius) at fixed mass coordinate (Langranian)
    !log_sig_RTI
 
    v_div_csound ! velocity divided by sound speed
@@ -117,9 +114,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !dE_dRho ! at constant T
@@ -149,19 +143,14 @@
    !log_conv_vel ! log10 convection velocity (cm/sec)
    !conv_vel_div_csound ! convection velocity divided by sound speed
    !log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    !pressure_scale_height ! in Rsun units
    !gradT ! mlt value for required temperature gradient dlnT/dlnP
    !gradr ! dlnT/dlnP required for purely radiative transport
    
-   !grad_superad
-   !grad_superad_actual
    !gradT_sub_grada ! gradT-grada at cell boundary 
    !gradT_rel_err
    !gradT_sub_gradr
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Langranian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    log_mass
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
@@ -208,7 +197,6 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
    
    pressure

--- a/star/test_suite/7M_prems_to_AGB/history_columns.list
+++ b/star/test_suite/7M_prems_to_AGB/history_columns.list
@@ -142,44 +142,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -205,7 +180,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/7M_prems_to_AGB/profile_columns.list
+++ b/star/test_suite/7M_prems_to_AGB/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -129,20 +126,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -180,7 +170,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -190,17 +179,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -247,9 +231,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/8.8M_urca/history_columns.list
+++ b/star/test_suite/8.8M_urca/history_columns.list
@@ -136,44 +136,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -199,7 +174,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/8.8M_urca/profile_columns.list
+++ b/star/test_suite/8.8M_urca/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -135,20 +132,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -186,7 +176,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -196,17 +185,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -253,9 +237,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/T_tau_gradr/profile_columns.list
+++ b/star/test_suite/T_tau_gradr/profile_columns.list
@@ -72,7 +72,6 @@
    !scale_height ! in Rsun units
    !pressure_scale_height ! in Rsun units
 
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    !m_div_r ! gm/cm
    !dmbar_m_div_r
    !log_dmbar_m_div_r
@@ -121,8 +120,6 @@
       ! 0 if distance between inner and outer is increasing
    !log_cell_collapse_time ! log of cell_collapse_time
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))  -- only important for neutron stars
-   !log_grav_gr_factor ! log10(grav_gr_factor)
 
 
 
@@ -142,7 +139,6 @@
    !entropy ! specific entropy divided by (avo*kerg)
    !logS ! log10(specific entropy)
    !logS_per_baryon ! log10(specific entropy per baryon / kerg)
-   !del_entropy ! entropy - entropy_start (includes change in entropy due to diffusion at beginning of step)
 
    !pressure ! total pressure at center of zone (pgas + prad)
    !prad ! radiation pressure at center of zone
@@ -166,8 +162,6 @@
    !logfree_e ! log10(free_e), free_e is mean number of free electrons per nucleon
    !chiRho ! dlnP_dlnRho at constant T
    !chiT ! dlnP_dlnT at constant Rho
-   !dlnRho_dlnT_const_Pgas
-   !dlnRho_dlnPgas_const_T
 
    !csound ! sound speed
    !csound_face ! sound speed (was previously called csound_at_face)
@@ -188,33 +182,13 @@
 
 !# Mass accretion
    !eps_grav ! -T*ds/dt (negative for expansion)
-   !eps_grav_dm_term_const_q ! advection term, T*(ds/dm)*(dm/dt)_q
-   !eps_grav_dt_term_const_q ! fixed relative mass time derivative term, -T*(ds/dt)_q
    !log_abs_eps_grav_dm_div_L
    !log_abs_v ! log10(abs(velocity)) (cm/s)
-   !log_abs_dvdt_div_v
 
-   !dlnd ! change of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnPgas ! change of log(Pgas) at fixed mass coordinate (Lagrangian)
-   !dlnT ! change of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR ! change of log(radius) at fixed mass coordinate (Lagrangian)
    
-   !dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnPgas_dt ! time derivative of log(Pgas) at fixed mass coordinate (Lagrangian)
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR_dt ! time derivative of log(radius) at fixed mass coordinate (Lagrangian)
-   !dr_dt ! time derivative of radius at fixed mass coordinate (Lagrangian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
 
-   !ds_from_eps_grav ! -eps_grav/T/(avo*kerg)
    
-   !dlnd_dt_const_q ! time derivative of log(density) at fixed q (for Eulerian eps_grav)
-   !dlnPgas_dt_const_q ! time derivative of log(Pgas) at fixed q (for Eulerian eps_grav)
-   !dlnT_dt_const_q ! time derivative of log(temperature) at fixed q (for Eulerian eps_grav)
    
-   !signed_dlnd ! sign(dlnd)*log10(max(1,abs(1d6*dlnd)))
-   !signed_dlnT ! sign(dlnT)*log10(max(1,abs(1d6*dlnT)))
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
 
 
 
@@ -350,7 +324,6 @@
    !mlt_mixing_length ! mixing length for mlt (cm)
    !mlt_mixing_type ! value returned by mlt
    !mlt_Pturb
-   !conv_dP_term ! replaced by mlt_Pturb
 
    !conv_vel ! convection velocity (cm/sec)
    !log_conv_vel ! log10 convection velocity (cm/sec)
@@ -365,17 +338,10 @@
    !lum_rad_div_L_Edd_sub_fourPrad_div_PchiT ! density increases outward if this is > 0
       ! see Joss, Salpeter, and Ostriker, "Critical Luminosity", ApJ 181:429-438, 1973. 
 
-   !fourPrad_div_PchiT ! = phi, where 1/phi = 1 + (dPgas/dPrad)|rho 
       ! if phi < Lrad/Ledd, then will get density inversion
       ! see Joss, Salpeter, Ostriker, "Critical Luminosity", ApJ 181: 429-438, 1973.
 
    !gradT ! mlt value for required temperature gradient dlnT/dlnP
-   !d_gradT_dlnd00
-   !d_gradT_dlnT00
-   !d_gradT_dlndm1
-   !d_gradT_dlnTm1
-   !d_gradT_dlnR
-   !d_gradT_dL
    
    !gradr ! dlnT/dlnP required for purely radiative transport
    !grad_temperature ! smoothed dlnT/dlnP at cell boundary
@@ -395,8 +361,6 @@
 
    !log_gradT_div_gradr ! log10 gradT/gradr at cell boundary 
    !log_mlt_Gamma ! convective efficiency
-   !super_ad ! max(0,gradT-grada) at cell boundary 
-   !newly_nonconvective
    !conv_vel_div_csound ! convection velocity divided by sound speed
    !conv_vel_div_L_vel ! L_vel is velocity needed to carry L by convection; L = 4*pi*r^2*rho*vel**3
    !log_mlt_D_mix ! log10 diffusion coefficient for mixing from mlt (cm^2/sec)
@@ -582,7 +546,6 @@
 
 !# Extras
    !extra_heat
-   !extra_dPdm
    !extra_L ! extra_heat integrated from center (Lsun)
    !log_extra_L ! log10 integrated from center (Lsun)
    !log_irradiation_heat
@@ -600,12 +563,6 @@
 
 
 !# Miscellaneous
-   !v_residual
-   !lnd_residual
-   !lnR_residual
-   !log_v_residual
-   !log_lnd_residual
-   !log_lnR_residual
 
    !dlog_h1_dlogP ! (log(h1(k)) - log(h1(k-1)))/(log(P(k)) - log(P(k-1)))
    !dlog_he3_dlogP
@@ -639,7 +596,6 @@
    !dlog_burn_ar_dlogP
    !dlog_burn_ca_dlogP
    !dlog_burn_ti_dlogP
-   !dlog_burn_cr_dlogP
    !dlog_burn_fe_dlogP
       
    !dlog_pnhe4_dlogP
@@ -664,14 +620,9 @@
    
    !zFe ! mass fraction of "Fe" = Fe+Co+Ni
    !log_zFe
-   !u_residual
-   !log_u_residual
    !u
    !u_face
    !dPdr_dRhodr_info
-   !flux_limit_lambda
-   !flux_limit_R
-   !signed_log_ergs_err
       
 
 

--- a/star/test_suite/accreted_material_j/profile_columns.list
+++ b/star/test_suite/accreted_material_j/profile_columns.list
@@ -109,7 +109,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for requared temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP requared for purely radiative transport
@@ -119,8 +118,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -166,23 +163,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -190,7 +180,6 @@
       log_J_inside ! J_inside is j_rot integrated from center
       !shear ! abs(dlnomega/dlnR)
       log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !delta_omega ! omega minus omega_pre_hydro
       v_rot ! rotation velocity at cell boundary (km/sec)
       i_rot ! specific moment of interia at cell boundary
       j_rot ! specific angular momentum at cell boundary
@@ -222,17 +211,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -270,7 +253,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -291,7 +273,6 @@
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
-      !brunt_dlnRho_dlnR ! smoothed numerical difference for use with brunt
       brunt_B ! smoothed numerical difference
       
 
@@ -338,9 +319,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/adjust_net/history_columns.list
+++ b/star/test_suite/adjust_net/history_columns.list
@@ -98,19 +98,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -219,38 +207,16 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -287,7 +253,6 @@
       
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       num_iters
 

--- a/star/test_suite/adjust_net/profile_columns.list
+++ b/star/test_suite/adjust_net/profile_columns.list
@@ -105,7 +105,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
 
    gradT ! mlt value for requared temperature gradient dlnT/dlnP
@@ -118,8 +117,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -142,23 +139,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -166,7 +156,6 @@
       log_J_inside ! J_inside is j_rot integrated from center
       !shear ! abs(dlnomega/dlnR)
       log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !delta_omega ! omega minus omega_pre_hydro
       v_rot ! rotation velocity at cell boundary (km/sec)
       i_rot ! specific moment of interia at cell boundary
       j_rot ! specific angular momentum at cell boundary
@@ -199,17 +188,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -247,7 +230,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -268,7 +250,6 @@
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
-      !brunt_dlnRho_dlnR ! smoothed numerical difference for use with brunt
       
       brunt_B
       
@@ -316,9 +297,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/c13_pocket/history_columns.list
+++ b/star/test_suite/c13_pocket/history_columns.list
@@ -420,8 +420,6 @@
 
       !log_surf_cell_opacity ! old name was log_surf_opacity
       !log_surf_cell_P ! old name was log_surf_P
-      !log_surf_cell_pressure ! old name was log_surf_pressure
-      !log_surf_cell_density ! old name was log_surf_density
       !log_surf_cell_temperature ! old name was log_surf_temperature
       !surface_cell_temperature ! old name was surface_temperature
       !log_surf_cell_z ! old name was log_surf_z
@@ -434,7 +432,6 @@
       !v_div_csound_max ! max value of velocity divided by sound speed at face
 
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
 
       !surf_avg_j_rot
       !surf_avg_omega
@@ -476,23 +473,9 @@
 
    !## info about location where optical depth is 10
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
 
    !## info about location where optical depth is 100
 
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
 !----------------------------------------------------------------------------------------------
 
@@ -622,27 +605,8 @@
 
 !# info at specific locations
 
-   !## info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
 
    !## info at location of max temperature
@@ -664,72 +628,17 @@
 
 
    !## info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
 
    !## info at location of max abs velocity
       ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_gamma1
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_radius_cm
-      !max_abs_v_lgR ! Rsun
-      !max_abs_v_lgR_cm
-      !max_abs_v_L ! Lsun
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
-      !max_abs_v_E0 ! 4/3 pi R^3 crad T^4 at max_abs_v_location
 
 !----------------------------------------------------------------------------------------------
 
@@ -757,35 +666,9 @@
 
    !## info at innermost mach 1 location
       ! excluding locations with q < min_q_for_inner_mach1_location
-      !inner_mach1_mass ! baryonic (Msun)
-      !inner_mach1_q
-      !inner_mach1_radius ! (Rsun)
-      !inner_mach1_velocity
-      !inner_mach1_csound
-      !inner_mach1_v_div_cs
-      !inner_mach1_lgT
-      !inner_mach1_lgRho
-      !inner_mach1_lgP
-      !inner_mach1_gamma1
-      !inner_mach1_entropy
-      !inner_mach1_tau
-      !inner_mach1_k
 
    !## info at outermost mach 1 location
       ! excluding locations with q > max_q_for_outer_mach1_location
-      !outer_mach1_mass ! baryonic (Msun)
-      !outer_mach1_q
-      !outer_mach1_radius ! (Rsun)
-      !outer_mach1_velocity
-      !outer_mach1_csound
-      !outer_mach1_v_div_cs
-      !outer_mach1_lgT
-      !outer_mach1_lgRho
-      !outer_mach1_lgP
-      !outer_mach1_gamma1
-      !outer_mach1_entropy
-      !outer_mach1_tau
-      !outer_mach1_k
 
 !----------------------------------------------------------------------------------------------
 
@@ -843,12 +726,10 @@
 
       !avg_abs_v_div_cs
       !log_avg_abs_v_div_cs
-      !max_abs_v_div_cs
       !log_max_abs_v_div_cs
 
       !avg_abs_v
       !log_avg_abs_v
-      !max_abs_v
       !log_max_abs_v
 
       !u_surf

--- a/star/test_suite/carbon_acc/history_columns.list
+++ b/star/test_suite/carbon_acc/history_columns.list
@@ -426,8 +426,6 @@
 
       !log_surf_cell_opacity ! old name was log_surf_opacity
       !log_surf_cell_P ! old name was log_surf_P
-      !log_surf_cell_pressure ! old name was log_surf_pressure
-      !log_surf_cell_density ! old name was log_surf_density
       !log_surf_cell_temperature ! old name was log_surf_temperature
       !surface_cell_temperature ! old name was surface_temperature
       !log_surf_cell_z ! old name was log_surf_z
@@ -440,7 +438,6 @@
       !v_div_csound_max ! max value of velocity divided by sound speed at face
 
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
 
       !surf_avg_j_rot
       !surf_avg_omega
@@ -482,23 +479,9 @@
 
    !## info about location where optical depth is 10
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
 
    !## info about location where optical depth is 100
 
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
 !----------------------------------------------------------------------------------------------
 
@@ -628,27 +611,8 @@
 
 !# info at specific locations
 
-   !## info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
 
    !## info at location of max temperature
@@ -670,72 +634,17 @@
 
 
    !## info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
 
    !## info at location of max abs velocity
       ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_gamma1
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_radius_cm
-      !max_abs_v_lgR ! Rsun
-      !max_abs_v_lgR_cm
-      !max_abs_v_L ! Lsun
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
-      !max_abs_v_E0 ! 4/3 pi R^3 crad T^4 at max_abs_v_location
 
 !----------------------------------------------------------------------------------------------
 
@@ -763,35 +672,9 @@
 
    !## info at innermost mach 1 location
       ! excluding locations with q < min_q_for_inner_mach1_location
-      !inner_mach1_mass ! baryonic (Msun)
-      !inner_mach1_q
-      !inner_mach1_radius ! (Rsun)
-      !inner_mach1_velocity
-      !inner_mach1_csound
-      !inner_mach1_v_div_cs
-      !inner_mach1_lgT
-      !inner_mach1_lgRho
-      !inner_mach1_lgP
-      !inner_mach1_gamma1
-      !inner_mach1_entropy
-      !inner_mach1_tau
-      !inner_mach1_k
 
    !## info at outermost mach 1 location
       ! excluding locations with q > max_q_for_outer_mach1_location
-      !outer_mach1_mass ! baryonic (Msun)
-      !outer_mach1_q
-      !outer_mach1_radius ! (Rsun)
-      !outer_mach1_velocity
-      !outer_mach1_csound
-      !outer_mach1_v_div_cs
-      !outer_mach1_lgT
-      !outer_mach1_lgRho
-      !outer_mach1_lgP
-      !outer_mach1_gamma1
-      !outer_mach1_entropy
-      !outer_mach1_tau
-      !outer_mach1_k
 
 !----------------------------------------------------------------------------------------------
 
@@ -941,12 +824,10 @@
 
       !avg_abs_v_div_cs
       !log_avg_abs_v_div_cs
-      !max_abs_v_div_cs
       !log_max_abs_v_div_cs
 
       !avg_abs_v
       !log_avg_abs_v
-      !max_abs_v
       !log_max_abs_v
 
       !u_surf
@@ -1121,7 +1002,6 @@
       !log_avg_v_residual
 
       !max_abs_lgE_residual
-      !max_abs_v_residual
 
    !## conservation during mesh adjust
       !log_mesh_adjust_IE_conservation

--- a/star/test_suite/carbon_acc/profile_columns.list
+++ b/star/test_suite/carbon_acc/profile_columns.list
@@ -72,7 +72,6 @@
    !scale_height ! in Rsun units
    !pressure_scale_height ! in Rsun units
 
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    !m_div_r ! gm/cm
    !dmbar_m_div_r
    !log_dmbar_m_div_r
@@ -121,8 +120,6 @@
       ! 0 if distance between inner and outer is increasing
    !log_cell_collapse_time ! log of cell_collapse_time
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))  -- only important for neutron stars
-   !log_grav_gr_factor ! log10(grav_gr_factor)
 
 
 
@@ -142,14 +139,12 @@
    entropy ! specific entropy divided by (avo*kerg)
    !logS ! log10(specific entropy)
    !logS_per_baryon ! log10(specific entropy per baryon / kerg)
-   !del_entropy ! entropy - entropy_start (includes change in entropy due to diffusion at beginning of step)
 
    !pressure ! total pressure at center of zone (pgas + prad)
    !prad ! radiation pressure at center of zone
    !pgas ! gas pressure at center of zone (electrons and ions)
    !logPgas ! log10(pgas)
    !pgas_div_ptotal ! pgas/pressure
-   !pturb_div_pgas_plus_prad
 
    !eta ! electron degeneracy parameter (eta >> 1 for significant degeneracy)
    !mu ! mean molecular weight per gas particle (ions + free electrons)
@@ -167,8 +162,6 @@
    !logfree_e ! log10(free_e), free_e is mean number of free electrons per nucleon
    !chiRho ! dlnP_dlnRho at constant T
    !chiT ! dlnP_dlnT at constant Rho
-   !dlnRho_dlnT_const_Pgas
-   !dlnRho_dlnPgas_const_T
 
    !csound ! sound speed
    !csound_face ! sound speed (was previously called csound_at_face)
@@ -184,33 +177,13 @@
 
 !# Mass accretion
    !eps_grav ! -T*ds/dt (negative for expansion)
-   !eps_grav_dm_term_const_q ! advection term, T*(ds/dm)*(dm/dt)_q
-   !eps_grav_dt_term_const_q ! fixed relative mass time derivative term, -T*(ds/dt)_q
    !log_abs_eps_grav_dm_div_L
    !log_abs_v ! log10(abs(velocity)) (cm/s)
-   !log_abs_dvdt_div_v
 
-   !dlnd ! change of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnPgas ! change of log(Pgas) at fixed mass coordinate (Lagrangian)
-   !dlnT ! change of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR ! change of log(radius) at fixed mass coordinate (Lagrangian)
    
-   !dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnPgas_dt ! time derivative of log(Pgas) at fixed mass coordinate (Lagrangian)
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR_dt ! time derivative of log(radius) at fixed mass coordinate (Lagrangian)
-   !dr_dt ! time derivative of radius at fixed mass coordinate (Lagrangian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
 
-   !ds_from_eps_grav ! -eps_grav/T/(avo*kerg)
    
-   !dlnd_dt_const_q ! time derivative of log(density) at fixed q (for Eulerian eps_grav)
-   !dlnPgas_dt_const_q ! time derivative of log(Pgas) at fixed q (for Eulerian eps_grav)
-   !dlnT_dt_const_q ! time derivative of log(temperature) at fixed q (for Eulerian eps_grav)
    
-   !signed_dlnd ! sign(dlnd)*log10(max(1,abs(1d6*dlnd)))
-   !signed_dlnT ! sign(dlnT)*log10(max(1,abs(1d6*dlnT)))
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
 
 
 
@@ -346,7 +319,6 @@
 !# Convection
    !mlt_mixing_length ! mixing length for mlt (cm)
    !mlt_mixing_type ! value returned by mlt
-   !conv_dP_term ! P is increased by factor (1 + conv_dP_term) by inclusion of convective turbulence
 
    !conv_vel ! convection velocity (cm/sec)
    !log_conv_vel ! log10 convection velocity (cm/sec)
@@ -361,17 +333,10 @@
    !lum_rad_div_L_Edd_sub_fourPrad_div_PchiT ! density increases outward if this is > 0
       ! see Joss, Salpeter, and Ostriker, "Critical Luminosity", ApJ 181:429-438, 1973. 
 
-   !fourPrad_div_PchiT ! = phi, where 1/phi = 1 + (dPgas/dPrad)|rho 
       ! if phi < Lrad/Ledd, then will get density inversion
       ! see Joss, Salpeter, Ostriker, "Critical Luminosity", ApJ 181: 429-438, 1973.
 
    !gradT ! mlt value for required temperature gradient dlnT/dlnP
-   !d_gradT_dlnd00
-   !d_gradT_dlnT00
-   !d_gradT_dlndm1
-   !d_gradT_dlnTm1
-   !d_gradT_dlnR
-   !d_gradT_dL
 
    !gradr ! dlnT/dlnP required for purely radiative transport
    !grad_temperature ! smoothed dlnT/dlnP at cell boundary
@@ -391,8 +356,6 @@
 
    !log_gradT_div_gradr ! log10 gradT/gradr at cell boundary 
    !log_mlt_Gamma ! convective efficiency
-   !super_ad ! max(0,gradT-grada) at cell boundary 
-   !newly_nonconvective
    !conv_vel_div_csound ! convection velocity divided by sound speed
    !conv_vel_div_L_vel ! L_vel is velocity needed to carry L by convection; L = 4*pi*r^2*rho*vel**3
    !log_mlt_D_mix ! log10 diffusion coefficient for mixing from mlt (cm^2/sec)
@@ -574,7 +537,6 @@
 
 !# Extras
    !extra_heat
-   !extra_dPdm
    !extra_L ! extra_heat integrated from center (Lsun)
    !log_extra_L ! log10 integrated from center (Lsun)
    !log_irradiation_heat
@@ -592,12 +554,6 @@
 
 
 !# Miscellaneous
-   !v_residual
-   !lnd_residual
-   !lnR_residual
-   !log_v_residual
-   !log_lnd_residual
-   !log_lnR_residual
 
    !dlog_h1_dlogP ! (log(h1(k)) - log(h1(k-1)))/(log(P(k)) - log(P(k-1)))
    !dlog_he3_dlogP
@@ -631,7 +587,6 @@
    !dlog_burn_ar_dlogP
    !dlog_burn_ca_dlogP
    !dlog_burn_ti_dlogP
-   !dlog_burn_cr_dlogP
    !dlog_burn_fe_dlogP
       
    !dlog_pnhe4_dlogP
@@ -654,14 +609,9 @@
    
    !zFe ! mass fraction of "Fe" = Fe+Co+Ni
    !log_zFe
-   !u_residual
-   !log_u_residual
    !u
    !u_face
    !dPdr_dRhodr_info
-   !flux_limit_lambda
-   !flux_limit_R
-   !signed_log_ergs_err
       
 
 

--- a/star/test_suite/carbon_kh/history_columns.list
+++ b/star/test_suite/carbon_kh/history_columns.list
@@ -445,8 +445,6 @@
 
       !log_surf_cell_opacity ! old name was log_surf_opacity
       !log_surf_cell_P ! old name was log_surf_P
-      !log_surf_cell_pressure ! old name was log_surf_pressure
-      !log_surf_cell_density ! old name was log_surf_density
       !log_surf_cell_temperature ! old name was log_surf_temperature
       !surface_cell_temperature ! old name was surface_temperature
       !log_surf_cell_z ! old name was log_surf_z
@@ -459,7 +457,6 @@
       !v_div_csound_max ! max value of velocity divided by sound speed at face
 
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
 
       !surf_avg_j_rot
       !surf_avg_omega
@@ -501,23 +498,9 @@
 
    !## info about location where optical depth is 10
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
 
    !## info about location where optical depth is 100
 
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
 !----------------------------------------------------------------------------------------------
 
@@ -647,27 +630,8 @@
 
 !# info at specific locations
 
-   !## info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
 
    !## info at location of max temperature
@@ -689,72 +653,17 @@
 
 
    !## info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
 
    !## info at location of max abs velocity
       ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_gamma1
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_radius_cm
-      !max_abs_v_lgR ! Rsun
-      !max_abs_v_lgR_cm
-      !max_abs_v_L ! Lsun
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
-      !max_abs_v_E0 ! 4/3 pi R^3 crad T^4 at max_abs_v_location
 
 !----------------------------------------------------------------------------------------------
 
@@ -782,35 +691,9 @@
 
    !## info at innermost mach 1 location
       ! excluding locations with q < min_q_for_inner_mach1_location
-      !inner_mach1_mass ! baryonic (Msun)
-      !inner_mach1_q
-      !inner_mach1_radius ! (Rsun)
-      !inner_mach1_velocity
-      !inner_mach1_csound
-      !inner_mach1_v_div_cs
-      !inner_mach1_lgT
-      !inner_mach1_lgRho
-      !inner_mach1_lgP
-      !inner_mach1_gamma1
-      !inner_mach1_entropy
-      !inner_mach1_tau
-      !inner_mach1_k
 
    !## info at outermost mach 1 location
       ! excluding locations with q > max_q_for_outer_mach1_location
-      !outer_mach1_mass ! baryonic (Msun)
-      !outer_mach1_q
-      !outer_mach1_radius ! (Rsun)
-      !outer_mach1_velocity
-      !outer_mach1_csound
-      !outer_mach1_v_div_cs
-      !outer_mach1_lgT
-      !outer_mach1_lgRho
-      !outer_mach1_lgP
-      !outer_mach1_gamma1
-      !outer_mach1_entropy
-      !outer_mach1_tau
-      !outer_mach1_k
 
 !----------------------------------------------------------------------------------------------
 
@@ -960,12 +843,10 @@
 
       !avg_abs_v_div_cs
       !log_avg_abs_v_div_cs
-      !max_abs_v_div_cs
       !log_max_abs_v_div_cs
 
       !avg_abs_v
       !log_avg_abs_v
-      !max_abs_v
       !log_max_abs_v
 
       !u_surf
@@ -1148,7 +1029,6 @@
       !log_avg_v_residual
 
       !max_abs_lgE_residual
-      !max_abs_v_residual
 
    !## conservation during mesh adjust
       !log_mesh_adjust_IE_conservation

--- a/star/test_suite/carbon_kh/profile_columns.list
+++ b/star/test_suite/carbon_kh/profile_columns.list
@@ -71,7 +71,6 @@
    !scale_height ! in Rsun units
    !pressure_scale_height ! in Rsun units
 
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    !m_div_r ! gm/cm
    !dmbar_m_div_r
    !log_dmbar_m_div_r
@@ -120,8 +119,6 @@
       ! 0 if distance between inner and outer is increasing
    !log_cell_collapse_time ! log of cell_collapse_time
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))  -- only important for neutron stars
-   !log_grav_gr_factor ! log10(grav_gr_factor)
 
 
 
@@ -141,14 +138,12 @@
    entropy ! specific entropy divided by (avo*kerg)
    !logS ! log10(specific entropy)
    !logS_per_baryon ! log10(specific entropy per baryon / kerg)
-   !del_entropy ! entropy - entropy_start (includes change in entropy due to diffusion at beginning of step)
 
    !pressure ! total pressure at center of zone (pgas + prad)
    !prad ! radiation pressure at center of zone
    !pgas ! gas pressure at center of zone (electrons and ions)
    !logPgas ! log10(pgas)
    !pgas_div_ptotal ! pgas/pressure
-   !pturb_div_pgas_plus_prad
 
    !eta ! electron degeneracy parameter (eta >> 1 for significant degeneracy)
    !mu ! mean molecular weight per gas particle (ions + free electrons)
@@ -166,8 +161,6 @@
    !logfree_e ! log10(free_e), free_e is mean number of free electrons per nucleon
    !chiRho ! dlnP_dlnRho at constant T
    !chiT ! dlnP_dlnT at constant Rho
-   !dlnRho_dlnT_const_Pgas
-   !dlnRho_dlnPgas_const_T
 
    !csound ! sound speed
    !csound_face ! sound speed (was previously called csound_at_face)
@@ -183,33 +176,13 @@
 
 !# Mass accretion
    !eps_grav ! -T*ds/dt (negative for expansion)
-   !eps_grav_dm_term_const_q ! advection term, T*(ds/dm)*(dm/dt)_q
-   !eps_grav_dt_term_const_q ! fixed relative mass time derivative term, -T*(ds/dt)_q
    !log_abs_eps_grav_dm_div_L
    !log_abs_v ! log10(abs(velocity)) (cm/s)
-   !log_abs_dvdt_div_v
 
-   !dlnd ! change of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnPgas ! change of log(Pgas) at fixed mass coordinate (Lagrangian)
-   !dlnT ! change of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR ! change of log(radius) at fixed mass coordinate (Lagrangian)
    
-   !dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Lagrangian)
-   !dlnPgas_dt ! time derivative of log(Pgas) at fixed mass coordinate (Lagrangian)
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dlnR_dt ! time derivative of log(radius) at fixed mass coordinate (Lagrangian)
-   !dr_dt ! time derivative of radius at fixed mass coordinate (Lagrangian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
 
-   !ds_from_eps_grav ! -eps_grav/T/(avo*kerg)
    
-   !dlnd_dt_const_q ! time derivative of log(density) at fixed q (for Eulerian eps_grav)
-   !dlnPgas_dt_const_q ! time derivative of log(Pgas) at fixed q (for Eulerian eps_grav)
-   !dlnT_dt_const_q ! time derivative of log(temperature) at fixed q (for Eulerian eps_grav)
    
-   !signed_dlnd ! sign(dlnd)*log10(max(1,abs(1d6*dlnd)))
-   !signed_dlnT ! sign(dlnT)*log10(max(1,abs(1d6*dlnT)))
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
 
 
 
@@ -345,7 +318,6 @@
 !# Convection
    !mlt_mixing_length ! mixing length for mlt (cm)
    !mlt_mixing_type ! value returned by mlt
-   !conv_dP_term ! P is increased by factor (1 + conv_dP_term) by inclusion of convective turbulence
 
    !conv_vel ! convection velocity (cm/sec)
    !log_conv_vel ! log10 convection velocity (cm/sec)
@@ -360,17 +332,10 @@
    !lum_rad_div_L_Edd_sub_fourPrad_div_PchiT ! density increases outward if this is > 0
       ! see Joss, Salpeter, and Ostriker, "Critical Luminosity", ApJ 181:429-438, 1973. 
 
-   !fourPrad_div_PchiT ! = phi, where 1/phi = 1 + (dPgas/dPrad)|rho 
       ! if phi < Lrad/Ledd, then will get density inversion
       ! see Joss, Salpeter, Ostriker, "Critical Luminosity", ApJ 181: 429-438, 1973.
 
    !gradT ! mlt value for required temperature gradient dlnT/dlnP
-   !d_gradT_dlnd00
-   !d_gradT_dlnT00
-   !d_gradT_dlndm1
-   !d_gradT_dlnTm1
-   !d_gradT_dlnR
-   !d_gradT_dL
 
    !gradr ! dlnT/dlnP required for purely radiative transport
    !grad_temperature ! smoothed dlnT/dlnP at cell boundary
@@ -390,8 +355,6 @@
 
    !log_gradT_div_gradr ! log10 gradT/gradr at cell boundary 
    !log_mlt_Gamma ! convective efficiency
-   !super_ad ! max(0,gradT-grada) at cell boundary 
-   !newly_nonconvective
    !conv_vel_div_csound ! convection velocity divided by sound speed
    !conv_vel_div_L_vel ! L_vel is velocity needed to carry L by convection; L = 4*pi*r^2*rho*vel**3
    !log_mlt_D_mix ! log10 diffusion coefficient for mixing from mlt (cm^2/sec)
@@ -573,7 +536,6 @@
 
 !# Extras
    !extra_heat
-   !extra_dPdm
    !extra_L ! extra_heat integrated from center (Lsun)
    !log_extra_L ! log10 integrated from center (Lsun)
    !log_irradiation_heat
@@ -591,12 +553,6 @@
 
 
 !# Miscellaneous
-   !v_residual
-   !lnd_residual
-   !lnR_residual
-   !log_v_residual
-   !log_lnd_residual
-   !log_lnR_residual
 
    !dlog_h1_dlogP ! (log(h1(k)) - log(h1(k-1)))/(log(P(k)) - log(P(k-1)))
    !dlog_he3_dlogP
@@ -630,7 +586,6 @@
    !dlog_burn_ar_dlogP
    !dlog_burn_ca_dlogP
    !dlog_burn_ti_dlogP
-   !dlog_burn_cr_dlogP
    !dlog_burn_fe_dlogP
       
    !dlog_pnhe4_dlogP
@@ -653,14 +608,9 @@
    
    !zFe ! mass fraction of "Fe" = Fe+Co+Ni
    !log_zFe
-   !u_residual
-   !log_u_residual
    !u
    !u_face
    !dPdr_dRhodr_info
-   !flux_limit_lambda
-   !flux_limit_R
-   !signed_log_ergs_err
       
 
 

--- a/star/test_suite/cburn_inward/history_columns.list
+++ b/star/test_suite/cburn_inward/history_columns.list
@@ -97,19 +97,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -204,44 +192,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -274,7 +237,6 @@
       
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/cburn_inward/profile_columns.list
+++ b/star/test_suite/cburn_inward/profile_columns.list
@@ -87,12 +87,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -128,20 +125,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -179,7 +169,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -189,17 +178,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -246,9 +230,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/ccsn_IIp/history_columns.list
+++ b/star/test_suite/ccsn_IIp/history_columns.list
@@ -163,13 +163,9 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
 
       

--- a/star/test_suite/ccsn_IIp/profile_columns.list
+++ b/star/test_suite/ccsn_IIp/profile_columns.list
@@ -160,15 +160,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -201,10 +198,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -216,9 +211,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -235,7 +227,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    gradP_div_rho
    
    RTI_du_diffusion_kick
@@ -298,9 +289,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/conserve_angular_momentum/history_columns.list
+++ b/star/test_suite/conserve_angular_momentum/history_columns.list
@@ -92,19 +92,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -189,44 +177,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -254,7 +217,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/conserve_angular_momentum/profile_columns.list
+++ b/star/test_suite/conserve_angular_momentum/profile_columns.list
@@ -99,7 +99,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
@@ -110,8 +109,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -147,23 +144,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -201,17 +191,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -249,7 +233,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -260,17 +243,12 @@
       grad_temperature ! dlnT/dlnP (smoothed)
       
       brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       !logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -317,9 +295,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/custom_rates/history_columns.list
+++ b/star/test_suite/custom_rates/history_columns.list
@@ -153,19 +153,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -272,54 +260,24 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location
-      !trace_mass_radius
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L
-      !trace_mass_v
 
    
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !max_conv_vel_div_csound

--- a/star/test_suite/custom_rates/profile_columns.list
+++ b/star/test_suite/custom_rates/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -148,20 +145,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -199,7 +189,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -209,17 +198,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -266,9 +250,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_high_rot_darkening/history_columns.list
+++ b/star/test_suite/dev_high_rot_darkening/history_columns.list
@@ -244,21 +244,7 @@
 
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -314,8 +300,6 @@
       !lum_div_Ledd
       !log_surf_opacity
       !log_surf_P
-      !log_surf_pressure
-      !log_surf_density
       !log_surf_temperature
       !surface_temperature
       !log_surf_optical_depth
@@ -460,76 +444,18 @@
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)      
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)      
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
    
    ! info at location of max temperature
@@ -574,7 +500,6 @@
       !v_surf ! (cm/s)
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       
       !e_thermal ! sum over all zones of Cp*T*dm
       

--- a/star/test_suite/dev_high_rot_darkening/profile_columns.list
+++ b/star/test_suite/dev_high_rot_darkening/profile_columns.list
@@ -35,9 +35,7 @@
    !log_column_depth ! log10 column depth, exterior mass / area (g cm^-2)
    !log_radial_depth ! log10 radial distance to surface (cm)
    luminosity ! luminosity at outer boundary of zone (in Lsun units)
-   !luminosity_rad ! radiative luminosity at outer boundary of zone (in Lsun units)
       ! -(4 pi r^2)^2 a c / (3 kap) d(T^4)/dm
-   !luminosity_conv ! luminosity - luminosity_rad (in Lsun units)
    !lum_conv_div_lum_rad
    !lum_rad_div_L_Edd
    !lum_conv_div_lum_Edd
@@ -71,10 +69,7 @@
    entropy ! specific entropy divided by (avo*kerg)
    mixing_type ! mixing types are defined in mesa/mlt/public/mlt_def
    csound ! sound speed
-   !csound_at_face ! sound speed
    v_div_csound ! velocity divided by sound speed
-   !binding_energy ! v^2/2 - G m / r + E + P / rho (ergs/gm).  negative if bound.
-   !binding_energy_integral ! sum from surface inwards of dm*(v^2/2 - G m / r + E + P/rho) (ergs)
    !v_div_r ! velocity divided by radius
    !scale_height ! in Rsun units
    eta ! electron degeneracy parameter (eta >> 1 for significant degeneracy)
@@ -92,8 +87,6 @@
    pressure ! total pressure at center of zone (pgas + prad)
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
-   !conv_dP_term ! value returned by MLT
-   !fourPrad_div_PchiT ! = phi, where 1/phi = 1 + (dPgas/dPrad)|rho 
       ! if phi < Lrad/Ledd, then will get density inversion
       ! see Joss, Salpeter, Ostriker, "Critical Luminosity", ApJ 181: 429-438, 1973.
    logPgas ! log10(pgas)
@@ -105,7 +98,6 @@
    !cv ! specific heat at constant volume
    !cp ! specific heat at constant total pressure
    !log_CpT
-   !log_CpTabsMdot_div_L
    !logS ! log10(specific entropy)
    !logS_per_baryon ! log10(specific entropy per baryon / kerg)
    !gamma1 ! dlnP_dlnRho at constant S
@@ -115,8 +107,6 @@
    !logfree_e ! log10(free_e), free_e is mean number of free electrons per nucleon
    !chiRho ! dlnP_dlnRho at constant T
    !chiT ! dlnP_dlnT at constant Rho
-   !dlnRho_dlnT_const_Pgas
-   !dlnRho_dlnPgas_const_T
    x_mass_fraction_H
    y_mass_fraction_He
    z_mass_fraction_metals
@@ -125,17 +115,13 @@
    !z2bar ! average charge^2
    ye ! average charge per baryon = proton fraction
    !opacity ! opacity measured at center of zone
-   !dkap_dlnrho_at_face ! partial derivative of opacity wrt. ln rho (at T=const) at outer edge of cell
-   !dkap_dlnt_at_face ! partial derivative of opacity wrt. ln T (at rho=const) at outer edge of cell
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (reaction neutrinos subtracted)
    log_abs_eps_nuc
    d_lnepsnuc_dlnd
    !d_epsnuc_dlnd
-   !deps_dlnd_at_face
    d_lnepsnuc_dlnT
    !d_epsnuc_dlnT
-   !deps_dlnT_at_face
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
@@ -150,26 +136,20 @@
    !log_irradiation_heat
    mlt_mixing_length ! mixing length for mlt (cm)
    mlt_mixing_type ! value returned by mlt
-   !conv_dP_term
          ! P is increased by factor (1 + conv_dP_term) by inclusion of convective turbulence
          
    gradT_sub_grada ! gradT-grada at cell boundary 
    gradT_div_grada ! gradT/grada at cell boundary 
    log_mlt_Gamma ! convective efficiency
    
-   !super_ad ! max(0,gradT-grada) at cell boundary 
    log_D_mix ! log10 diffusion coefficient for mixing in units of cm^2/second (Eulerian)
    log_D_mix_non_rotation
    !log_sig_mix ! sig(k) is mixing flow across face k in (gm sec^1)
          ! sig(k) = D_mix*(4*pi*r(k)**2*rho_face)**2/dmavg
-   !log_sig_div_siglim
          ! this is raw_sig(k)/siglimit(k)
          ! where siglimit(k) = sig_term_limit*min(dm(k),dm(k-1))/dt
          ! and raw_sig(k) is sig(k) before it is set to min(siglimit(k),raw_sig(k))
-   !log_am_sig_div_siglim
    log_conv_vel ! log10 convection velocity (cm/sec)
-   !log_conv_vel_old ! log10 previous convection velocity (cm/sec)
-   !newly_nonconvective
    conv_vel_div_csound ! convection velocity divided by sound speed
    !conv_vel_div_L_vel ! L_vel is velocity needed to carry L by convection; L = 4*pi*r^2*rho*vel**3
    log_mlt_D_mix ! log10 diffusion coefficient for mixing from mlt (cm^2/sec)
@@ -191,27 +171,15 @@
    gradL ! gradient for Ledoux criterion for convection
    !sch_stable ! 1 if grada > gradr, 0 otherwise
    !ledoux_stable ! 1 if gradL > gradr, 0 otherwise
-   !stability_type ! values same as defined in mlt_def for mixing types
    
    ! the "for_mixing" values are the ones used to calculate the mixing diffusion coeffs,
    ! i.e., from the start of the step.  
    ! the names without "for_mixing" are the values at the end of the step.
-   !gradr_for_mixing
-   !gradT_for_mixing
-   !grada_for_mixing
-   !gradL_for_mixing
    
    !dominant_isoA_for_thermohaline
    !dominant_isoZ_for_thermohaline
    !gradL_composition_term
    
-   !dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Langranian)
-   !dlnPgas_dt ! time derivative of log(Pgas) at fixed mass coordinate (Langranian)
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Langranian)
-   !signed_dlnd ! sign(dlnd)*log10(max(1,abs(1d6*dlnd)))
-   !signed_dlnT ! sign(dlnT)*log10(max(1,abs(1d6*dlnT)))
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Langranian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    !logM ! log10(m/Msun)
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
@@ -236,8 +204,6 @@
    !log_dr_div_cs_yr ! log10 cell sound crossing time (years)
    
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))  -- only important for neutron stars
-   !log_grav_gr_factor ! log10(grav_gr_factor)
    
    x ! hydrogen mass fraction
    !log_x
@@ -284,7 +250,6 @@
       !cno
       !tri_alfa
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       !log_omega
       log_j_rot
@@ -327,39 +292,20 @@
       !dynamo_log_B_phi ! (Gauss)
 
 
-   ! misc
    
-      !nse_fraction ! 0 -> net; 1 -> nse
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
       
-      !dlnP_dm ! for pressure equation
-      !dlnT_dm ! for temperature equation
-      !dL_dm ! for energy equation
       
-      !equP ! residual for pressure equation
-      !log_equP ! log10(abs(equP))
-      !equT ! residual for temperature equation
-      !log_equT 
-      !equR 
-      !log_equR
-      !equL 
-      !log_equL
-      !equv 
-      !log_equv 
 
-      !dlnP_dlnm
-      !dlnT_dlnm
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
       
       ! electric field from element diffusion calculation
       !e_field
       !log_e_field
       
-      !sum_x_advection
       
       ! element diffusion velocity for species
       !edv h1
@@ -435,7 +381,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -462,7 +407,6 @@
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
 
       !brunt_nu ! brunt_frequency in microHz
-      !dlnX_dr_Rsun_inv
       
       
       !lamb_Sl1 ! for l=1; = sqrt(2)*csound/r   (microHz)
@@ -537,9 +481,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_ppisn/history_columns.list
+++ b/star/test_suite/dev_ppisn/history_columns.list
@@ -247,21 +247,7 @@
 
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -317,8 +303,6 @@
       !lum_div_Ledd
       !log_surf_opacity
       !log_surf_P
-      !log_surf_pressure
-      !log_surf_density
       !log_surf_temperature
       !surface_temperature
       !log_surf_optical_depth
@@ -464,76 +448,18 @@
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)      
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)      
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
    
    ! info at location of max temperature
@@ -578,7 +504,6 @@
       v_surf ! (cm/s)
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       
       !e_thermal ! sum over all zones of Cp*T*dm
       

--- a/star/test_suite/dev_ppisn/profile_columns.list
+++ b/star/test_suite/dev_ppisn/profile_columns.list
@@ -35,9 +35,7 @@
    !log_column_depth ! log10 column depth, exterior mass / area (g cm^-2)
    !log_radial_depth ! log10 radial distance to surface (cm)
    luminosity ! luminosity at outer boundary of zone (in Lsun units)
-   !luminosity_rad ! radiative luminosity at outer boundary of zone (in Lsun units)
       ! -(4 pi r^2)^2 a c / (3 kap) d(T^4)/dm
-   !luminosity_conv ! luminosity - luminosity_rad (in Lsun units)
    !lum_conv_div_lum_rad
    !lum_rad_div_L_Edd
    !lum_conv_div_lum_Edd
@@ -71,7 +69,6 @@
    entropy ! specific entropy divided by (avo*kerg)
    mixing_type ! mixing types are defined in mesa/mlt/public/mlt_def
    csound ! sound speed
-   !csound_at_face ! sound speed
    v_div_csound ! velocity divided by sound speed
    !v_div_r ! velocity divided by radius
    !scale_height ! in Rsun units
@@ -90,7 +87,6 @@
    !pressure ! total pressure at center of zone (pgas + prad)
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
-   !fourPrad_div_PchiT ! = phi, where 1/phi = 1 + (dPgas/dPrad)|rho 
       ! if phi < Lrad/Ledd, then will get density inversion
       ! see Joss, Salpeter, Ostriker, "Critical Luminosity", ApJ 181: 429-438, 1973.
    logPgas ! log10(pgas)
@@ -102,7 +98,6 @@
    !cv ! specific heat at constant volume
    !cp ! specific heat at constant total pressure
    !log_CpT
-   !log_CpTabsMdot_div_L
    !logS ! log10(specific entropy)
    !logS_per_baryon ! log10(specific entropy per baryon / kerg)
    gamma1 ! dlnP_dlnRho at constant S
@@ -112,8 +107,6 @@
    !logfree_e ! log10(free_e), free_e is mean number of free electrons per nucleon
    !chiRho ! dlnP_dlnRho at constant T
    !chiT ! dlnP_dlnT at constant Rho
-   !dlnRho_dlnT_const_Pgas
-   !dlnRho_dlnPgas_const_T
    x_mass_fraction_H
    y_mass_fraction_He
    z_mass_fraction_metals
@@ -122,17 +115,13 @@
    !z2bar ! average charge^2
    ye ! average charge per baryon = proton fraction
    !opacity ! opacity measured at center of zone
-   !dkap_dlnrho_at_face ! partial derivative of opacity wrt. ln rho (at T=const) at outer edge of cell
-   !dkap_dlnt_at_face ! partial derivative of opacity wrt. ln T (at rho=const) at outer edge of cell
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (reaction neutrinos subtracted)
    !log_abs_eps_nuc
    !d_lnepsnuc_dlnd
    !d_epsnuc_dlnd
-   !deps_dlnd_at_face
    !d_lnepsnuc_dlnT
    !d_epsnuc_dlnT
-   !deps_dlnT_at_face
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
@@ -158,18 +147,14 @@
    gradT_div_grada ! gradT/grada at cell boundary 
    log_mlt_Gamma ! convective efficiency
    
-   !super_ad ! max(0,gradT-grada) at cell boundary 
    log_D_mix ! log10 diffusion coefficient for mixing in units of cm^2/second (Eulerian)
    !log_D_mix_non_rotation
    !log_sig_mix ! sig(k) is mixing flow across face k in (gm sec^1)
          ! sig(k) = D_mix*(4*pi*r(k)**2*rho_face)**2/dmavg
-   !log_sig_div_siglim
          ! this is raw_sig(k)/siglimit(k)
          ! where siglimit(k) = sig_term_limit*min(dm(k),dm(k-1))/dt
          ! and raw_sig(k) is sig(k) before it is set to min(siglimit(k),raw_sig(k))
-   !log_am_sig_div_siglim
    log_conv_vel ! log10 convection velocity (cm/sec)
-   !newly_nonconvective
    conv_vel_div_csound ! convection velocity divided by sound speed
    !conv_vel_div_L_vel ! L_vel is velocity needed to carry L by convection; L = 4*pi*r^2*rho*vel**3
    log_mlt_D_mix ! log10 diffusion coefficient for mixing from mlt (cm^2/sec)
@@ -191,27 +176,15 @@
    gradL ! gradient for Ledoux criterion for convection
    !sch_stable ! 1 if grada > gradr, 0 otherwise
    !ledoux_stable ! 1 if gradL > gradr, 0 otherwise
-   !stability_type ! values same as defined in mlt_def for mixing types
    
    ! the "for_mixing" values are the ones used to calculate the mixing diffusion coeffs,
    ! i.e., from the start of the step.  
    ! the names without "for_mixing" are the values at the end of the step.
-   !gradr_for_mixing
-   !gradT_for_mixing
-   !grada_for_mixing
-   !gradL_for_mixing
    
    !dominant_isoA_for_thermohaline
    !dominant_isoZ_for_thermohaline
    !gradL_composition_term
    
-   !dlnd_dt ! time derivative of log(density) at fixed mass coordinate (Langranian)
-   !dlnPgas_dt ! time derivative of log(Pgas) at fixed mass coordinate (Langranian)
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Langranian)
-   !signed_dlnd ! sign(dlnd)*log10(max(1,abs(1d6*dlnd)))
-   !signed_dlnT ! sign(dlnT)*log10(max(1,abs(1d6*dlnT)))
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Langranian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    !logM ! log10(m/Msun)
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
@@ -236,8 +209,6 @@
    !log_dr_div_cs_yr ! log10 cell sound crossing time (years)
    
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))  -- only important for neutron stars
-   !log_grav_gr_factor ! log10(grav_gr_factor)
    
    x ! hydrogen mass fraction
    !log_x
@@ -284,7 +255,6 @@
       !cno
       !tri_alfa
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       !log_omega
       log_j_rot
@@ -325,39 +295,20 @@
       !dynamo_log_B_phi ! (Gauss)
 
 
-   ! misc
    
-      !nse_fraction ! 0 -> net; 1 -> nse
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
       
-      !dlnP_dm ! for pressure equation
-      !dlnT_dm ! for temperature equation
-      !dL_dm ! for energy equation
       
-      !equP ! residual for pressure equation
-      !log_equP ! log10(abs(equP))
-      !equT ! residual for temperature equation
-      !log_equT 
-      !equR 
-      !log_equR
-      !equL 
-      !log_equL
-      !equv 
-      !log_equv 
 
-      !dlnP_dlnm
-      !dlnT_dlnm
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
       
       ! electric field from element diffusion calculation
       !e_field
       !log_e_field
       
-      !sum_x_advection
       
       ! element diffusion velocity for species
       !edv h1
@@ -433,7 +384,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -460,7 +410,6 @@
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
 
       !brunt_nu ! brunt_frequency in microHz
-      !dlnX_dr_Rsun_inv
       
       
       !lamb_Sl1 ! for l=1; = sqrt(2)*csound/r   (microHz)
@@ -535,9 +484,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_split_burn_big_net/history_columns.list
+++ b/star/test_suite/dev_split_burn_big_net/history_columns.list
@@ -126,19 +126,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -176,7 +164,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T
@@ -236,44 +223,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/dev_split_burn_big_net/profile_columns.list
+++ b/star/test_suite/dev_split_burn_big_net/profile_columns.list
@@ -159,15 +159,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -200,10 +197,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -217,9 +212,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -236,7 +228,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -256,7 +247,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -338,9 +328,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_to_cc_12/history_columns.list
+++ b/star/test_suite/dev_to_cc_12/history_columns.list
@@ -141,19 +141,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -191,7 +179,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T
@@ -254,44 +241,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/dev_to_cc_12/profile_columns.list
+++ b/star/test_suite/dev_to_cc_12/profile_columns.list
@@ -159,15 +159,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -200,10 +197,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -217,9 +212,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -236,7 +228,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -256,7 +247,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -338,9 +328,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_to_cc_20/history_columns.list
+++ b/star/test_suite/dev_to_cc_20/history_columns.list
@@ -139,19 +139,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -189,7 +177,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T
@@ -252,44 +239,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/dev_to_cc_20/profile_columns.list
+++ b/star/test_suite/dev_to_cc_20/profile_columns.list
@@ -160,15 +160,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -201,10 +198,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -218,9 +213,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -237,7 +229,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -257,7 +248,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -339,9 +329,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_to_cc_80/history_columns.list
+++ b/star/test_suite/dev_to_cc_80/history_columns.list
@@ -139,19 +139,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -189,7 +177,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T
@@ -252,44 +239,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/dev_to_cc_80/profile_columns.list
+++ b/star/test_suite/dev_to_cc_80/profile_columns.list
@@ -160,15 +160,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -201,10 +198,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -218,9 +213,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -237,7 +229,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -257,7 +248,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -339,9 +329,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_to_pisn_200/history_columns.list
+++ b/star/test_suite/dev_to_pisn_200/history_columns.list
@@ -148,19 +148,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -198,7 +186,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T

--- a/star/test_suite/dev_to_pisn_200/profile_columns.list
+++ b/star/test_suite/dev_to_pisn_200/profile_columns.list
@@ -159,15 +159,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -200,10 +197,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -217,9 +212,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -236,7 +228,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -256,7 +247,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -338,9 +328,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/dev_to_ppisn_100/history_columns.list
+++ b/star/test_suite/dev_to_ppisn_100/history_columns.list
@@ -148,19 +148,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -198,7 +186,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T

--- a/star/test_suite/dev_to_ppisn_100/profile_columns.list
+++ b/star/test_suite/dev_to_ppisn_100/profile_columns.list
@@ -160,15 +160,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -201,10 +198,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -218,9 +213,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -237,7 +229,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -257,7 +248,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -339,9 +329,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/diffusion_smoothness/history_columns.list
+++ b/star/test_suite/diffusion_smoothness/history_columns.list
@@ -137,44 +137,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -200,7 +175,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/diffusion_smoothness/profile_columns.list
+++ b/star/test_suite/diffusion_smoothness/profile_columns.list
@@ -89,12 +89,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -134,7 +131,6 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
       ! electric field from element diffusion calculation
@@ -183,17 +179,11 @@
       typical_charge mg24
 
 
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -231,7 +221,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -264,8 +253,6 @@
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -312,9 +299,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/gyre_in_mesa_rsg/history_columns.list
+++ b/star/test_suite/gyre_in_mesa_rsg/history_columns.list
@@ -1,27 +1,219 @@
+! log_columns.list -- determines the contents of star history logs
+! you can use a non-standard version by setting log_columns_file in your inlist
+
+! units are cgs unless otherwise noted.
+
+! reorder the following names as desired to reorder columns.
+! comment out the name to omit a column (fewer columns => less IO => faster running).
+! remove '!' to restore a column.
+
+! if you have a situation where you want a non-standard set of columns,
+! make a copy of this file, edit as desired, and give the new filename in your inlist
+! as log_columns_file.   if you are just adding columns, you can 'include' this file,
+! and just list the additions in your file.   note: to include the standard default
+! version, use include '' -- the 0 length string means include the default file.
+
+! blank lines and comments can be used freely.
+! if a column name appears more than once in the list, only the first occurrence is used.
+
+! if you need to have something added to the list of options, let me know....
+
+
+! the first few lines of the log file contain parameter values as of the start of the run
+! for completeness, those items are described here:
+   
+   ! initial_mass -- star mass at start of run (Msun units)
+   ! initial_z -- starting metallicity
+   ! h1_boundary_limit -- defines abundance limit for h1_boundary_mass 
+   ! he4_boundary_limit -- defines abundance limit for he4_boundary_mass
+   ! burn_min1 -- 1st limit for reported burning, in erg/g/s
+   ! burn_min2 -- 2nd limit for reported burning, in erg/g/s
+
+
+! note: you can include another list by doing
+!        include 'filename'
+!        include '' means include the default standard list file
+
+
+! the following lines of the log file contain info about 1 model per row
+   
+   ! some general info about the model
    
       model_number ! counting from the start of the run
-      num_retries ! total during the run
-      star_age
-      star_age_sec
-      star_age_min
-      star_age_hr
-      star_age_day
-      star_age_yr
-      log_dt_sec
-      time_step_sec
-      log_rel_run_E_err
-      v_surf_km_s
-      v_div_cs
-      v_div_vesc
+      star_age ! elapsed simulated time in years since the start of the run
+      !star_age_sec ! elapsed simulated time in seconds since the start of the run
+      !star_age_min ! elapsed simulated time in minutes since the start of the run
+      !star_age_hr ! elapsed simulated time in hours since the start of the run
+      star_age_day ! elapsed simulated time in days since the start of the run
+      
+      
+      star_mass ! in Msun units
+      !star_mdot ! d(star_mass)/dt (in msolar per year)
+      !time_step ! timestep in years since previous model
+      !log_dt ! log10 time_step in years
+      log_dt_sec ! log10 time_step in seconds
+      num_zones ! number of zones in the model
+      
+      dt_cell_collapse
+      dt_div_dt_cell_collapse
+
+   ! mixing regions
+   
+      !  mx1 refers to the largest (by mass) convective region.
+      !  mx2 is the 2nd largest.
+
+      !  conv_mx1_top and conv_mx1_bot are the region where mixing_type == convective_mixing.
+      !  mx1_top and mx1_bot are the extent of all kinds of mixing, convective and other.
+
+      !conv_mx1_top
+      !conv_mx1_bot
+      !conv_mx2_top
+      !conv_mx2_bot
+      !mx1_top
+      !mx1_bot
+      !mx2_top
+      !mx2_bot
+      
+       
+      
+   ! regions of strong nuclear burning
+   
+      ! 2 zones where eps_nuc > burn_min1 erg/g/s
+      ! for each zone have 4 numbers: start1, start2, end2, end1
+      ! start1 is mass of inner edge where first goes > burn_min1 (or -20 if none such)
+      ! start2 is mass of inner edge where first zone reaches burn_min2 erg/g/sec (or -20 if none such)
+      ! end2 is mass of outer edge where first zone drops back below burn_min2 erg/g/s
+      ! end1 is mass of outer edge where first zone ends (i.e. eps_nuc < burn_min1)
+      ! similar for the second zone
+   
+      !epsnuc_M_1 ! start1 for 1st zone
+      !epsnuc_M_2 ! start2
+      !epsnuc_M_3 ! end2
+      !epsnuc_M_4 ! end1
+      
+      !epsnuc_M_5 ! start1 for 2nd zone
+      !epsnuc_M_6 ! start2
+      !epsnuc_M_7 ! end2
+      !epsnuc_M_8 ! end1
+   
+   ! information about abundance transitions
+   
+      !he_core_mass
+      !co_core_mass
+      !fe_core_mass
+   
+   
+   ! info at location of max abs velocity
+      ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
+
+   ! timescales
+      
+      !dynamic_timescale ! dynamic timescale (seconds) -- estimated by 2*pi*sqrt(r^3/(G*m))
+      !kh_timescale ! kelvin-helmholtz timescale (years)
+      !nuc_timescale ! nuclear timescale (years) -- proportional to mass divided by luminosity
+
+   ! integrated power from hydrogen and helium burning
+   
+      !power_h_burn ! total thermal power from PP and CNO, excluding neutrinos (in Lsun units)
+      !power_he_burn ! total thermal power from triple-alpha, excluding neutrinos (in Lsun units)
+      log_LH ! log10 power_h_burn
+      !log_LHe ! log10 power_he_burn
+   
+   ! conditions near surface
       radius
       log_R
+      v_surf_km_s ! (km/s)
+      v_surf_div_escape_v
+      v_surf ! (cm/s)
+      v_div_csound_surf ! velocity divided by sound speed at outermost grid point
+      surf_escape_v ! cm/s
+      luminosity ! luminosity in Lsun units
+      !gravity 
+   
+      log_L ! log10 luminosity in Lsun units
       effective_T
-      Teff
-      log_Teff
-      luminosity
-      log_L
-      log_LHe
-      log_LH
+      log_Teff ! log10 effective temperature
+      photosphere_L
+      photosphere_r
+      log_g ! log10 gravity
+      log_L_div_Ledd ! log10(L/Leddington)
+   
+   ! conditions near center
+   
+      log_center_T ! temperature
+      log_center_Rho ! density
+      !log_center_P ! pressure
+      !center_degeneracy ! the electron chemical potential in units of k*T
+      !center_gamma ! plasma interaction parameter at the centermost meshpoint.
       
+      !log_center h1
+      !log_center h2
+      !log_center he3
+      !log_center he4
+      !log_center li7
+      
+
+   ! log10 total ergs/sec for reaction categories (Lsun units)
+      
+      !pp
+      !cno
+      !tri_alfa
+
+   ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
+      
+
+
+      
+      !mixing_regions 40
+      !burning_regions 80
+
+
+
+      ! you might want to get a more complete list of mixing regions by using the following
+      
+      !mixing_regions 40
+      
+      !mixing_regions <integer> ! note: this includes regions where the mixing type is no_mixing.
+         ! the <integer> is the number of regions to report
+         ! there will be 2*<integer> columns for this in the log file, 2 for each region.
+         ! the first column for a region gives the mixing type using the values defined in const_def
+         ! the types are no_mixing, convective_mixing, overshoot_mixing, semiconvective_mixing,
+         ! and salt_finger_mixing, numbered from 0 to 4.
+         ! entries for extra columns after the last region in the star will have an invalid mixing_type value of -1.
+         ! the second column for a region gives the m/mstar location of the top of the region
+         ! mstar is the total mass of the star, so these locations range from 0 to 1
+         ! all regions are include starting from the center, so the bottom of one region
+         ! is the top of the previous one.  since we start at the center, the bottom of the 1st region is 0.
+         
+         ! the columns in the log file will have names like 'mix_type_1' and 'mix_qtop_1'
+
+      ! energy information
+      avg_abs_v_div_cs
+      log_avg_abs_v_div_cs
+      max_abs_v_div_cs
+      log_max_abs_v_div_cs
+      
+      avg_abs_v
+      log_avg_abs_v
+      max_abs_v
+      log_max_abs_v
+
+      v_div_csound_surf ! velocity divided by sound speed at outermost grid point
+      v_surf ! (cm/s)
+      v_surf_km_s ! (km/s)
+
+
+   ! misc
+   
+      log_rel_run_E_err
+      rel_E_err
+
+   ! misc
+      
+      r_center
+      v_center
+
+      num_retries ! total during the run
+      num_iters
 
 

--- a/star/test_suite/gyre_in_mesa_rsg/profile_columns.list
+++ b/star/test_suite/gyre_in_mesa_rsg/profile_columns.list
@@ -91,12 +91,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -113,7 +110,6 @@
    log_D_anon
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -217,26 +213,16 @@
       !cno
       !tri_alfa
    
-   !cell_energy
-   !cell_energy_fraction
-   !log_cell_energy_fraction
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -274,7 +260,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -305,8 +290,6 @@
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
 
 ! the first few lines of the profile contain general info about the model.
@@ -352,9 +335,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/gyre_in_mesa_wd/history_columns.list
+++ b/star/test_suite/gyre_in_mesa_wd/history_columns.list
@@ -102,19 +102,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -209,44 +197,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/gyre_in_mesa_wd/profile_columns.list
+++ b/star/test_suite/gyre_in_mesa_wd/profile_columns.list
@@ -123,7 +123,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for requared temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP requared for purely radiative transport
@@ -133,8 +132,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -170,23 +167,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -194,7 +184,6 @@
       log_J_inside ! J_inside is j_rot integrated from center
       !shear ! abs(dlnomega/dlnR)
       log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !delta_omega ! omega minus omega_pre_hydro
       v_rot ! rotation velocity at cell boundary (km/sec)
       i_rot ! specific moment of interia at cell boundary
       j_rot ! specific angular momentum at cell boundary
@@ -226,17 +215,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -274,7 +257,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -295,7 +277,6 @@
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
-      !brunt_dlnRho_dlnR ! smoothed numerical difference for use with brunt
       brunt_B ! smoothed numerical difference
       
 
@@ -342,9 +323,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/hb_2M/history_columns.list
+++ b/star/test_suite/hb_2M/history_columns.list
@@ -436,8 +436,6 @@
 
       !log_surf_cell_opacity ! old name was log_surf_opacity
       !log_surf_cell_P ! old name was log_surf_P
-      !log_surf_cell_pressure ! old name was log_surf_pressure
-      !log_surf_cell_density ! old name was log_surf_density
       !log_surf_cell_temperature ! old name was log_surf_temperature
       !surface_cell_temperature ! old name was surface_temperature
       !log_surf_cell_z ! old name was log_surf_z
@@ -450,7 +448,6 @@
       !v_div_csound_max ! max value of velocity divided by sound speed at face
 
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
 
       !surf_avg_j_rot
       !surf_avg_omega
@@ -492,23 +489,9 @@
 
    !## info about location where optical depth is 10
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
 
    !## info about location where optical depth is 100
 
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
 !----------------------------------------------------------------------------------------------
 
@@ -638,27 +621,8 @@
 
 !# info at specific locations
 
-   !## info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
 
    !## info at location of max temperature
@@ -680,72 +644,17 @@
 
 
    !## info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
 
    !## info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
 
    !## info at location of max abs velocity
       ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_gamma1
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_radius_cm
-      !max_abs_v_lgR ! Rsun
-      !max_abs_v_lgR_cm
-      !max_abs_v_L ! Lsun
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
-      !max_abs_v_E0 ! 4/3 pi R^3 crad T^4 at max_abs_v_location
 
 !----------------------------------------------------------------------------------------------
 
@@ -773,35 +682,9 @@
 
    !## info at innermost mach 1 location
       ! excluding locations with q < min_q_for_inner_mach1_location
-      !inner_mach1_mass ! baryonic (Msun)
-      !inner_mach1_q
-      !inner_mach1_radius ! (Rsun)
-      !inner_mach1_velocity
-      !inner_mach1_csound
-      !inner_mach1_v_div_cs
-      !inner_mach1_lgT
-      !inner_mach1_lgRho
-      !inner_mach1_lgP
-      !inner_mach1_gamma1
-      !inner_mach1_entropy
-      !inner_mach1_tau
-      !inner_mach1_k
 
    !## info at outermost mach 1 location
       ! excluding locations with q > max_q_for_outer_mach1_location
-      !outer_mach1_mass ! baryonic (Msun)
-      !outer_mach1_q
-      !outer_mach1_radius ! (Rsun)
-      !outer_mach1_velocity
-      !outer_mach1_csound
-      !outer_mach1_v_div_cs
-      !outer_mach1_lgT
-      !outer_mach1_lgRho
-      !outer_mach1_lgP
-      !outer_mach1_gamma1
-      !outer_mach1_entropy
-      !outer_mach1_tau
-      !outer_mach1_k
 
 !----------------------------------------------------------------------------------------------
 
@@ -935,12 +818,10 @@
 
       !avg_abs_v_div_cs
       !log_avg_abs_v_div_cs
-      !max_abs_v_div_cs
       !log_max_abs_v_div_cs
 
       !avg_abs_v
       !log_avg_abs_v
-      !max_abs_v
       !log_max_abs_v
 
       !u_surf
@@ -1119,7 +1000,6 @@
       !log_avg_v_residual
 
       !max_abs_lgE_residual
-      !max_abs_v_residual
 
    !## conservation during mesh adjust
       !log_mesh_adjust_IE_conservation

--- a/star/test_suite/hb_2M/profile_columns.list
+++ b/star/test_suite/hb_2M/profile_columns.list
@@ -158,15 +158,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -199,10 +196,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -214,9 +209,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -233,7 +225,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    gradP_div_rho
    
    RTI_du_diffusion_kick
@@ -297,9 +288,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/high_mass/history_columns.list
+++ b/star/test_suite/high_mass/history_columns.list
@@ -178,44 +178,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -243,7 +218,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/high_mass/profile_columns.list
+++ b/star/test_suite/high_mass/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -129,20 +126,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -180,7 +170,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -190,17 +179,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -247,9 +231,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/high_z/profile_columns.list
+++ b/star/test_suite/high_z/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -133,20 +130,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -184,7 +174,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -194,17 +183,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -251,9 +235,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/hot_cool_wind/profile_columns.list
+++ b/star/test_suite/hot_cool_wind/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -135,20 +132,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -186,7 +176,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -196,17 +185,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -253,9 +237,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/hse_riemann/history_columns.list
+++ b/star/test_suite/hse_riemann/history_columns.list
@@ -94,7 +94,6 @@
 
    ! misc
    
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/hse_riemann/profile_columns.list
+++ b/star/test_suite/hse_riemann/profile_columns.list
@@ -78,13 +78,9 @@
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
    !nonnucneu_phot ! photon neutrinos (for reactions like e- + gamma => e- + nu_e + nubar_e)
    !nonnucneu_pair ! pair production (for reactions like e+ + e- => nu_e + nubar_e)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    !pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dlnT_dt ! time derivative of log(temperature) at fixed mass coordinate (Lagrangian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -103,8 +99,6 @@
    !velocity ! velocity at outer boundary of zone -- 0 if no velocity variable
    !vel_km_per_s ! velocity at outer boundary of zone (km/s) -- 0 if no velocity variable
    !v_div_csound ! velocity divided by sound speed
-   !v_residual
-   !log_v_residual
    
    add_abundances ! this adds all of the isos that are in the current net
    ! NOTE: you can list specific isotopes by giving their names (from chem_def)
@@ -134,10 +128,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
       

--- a/star/test_suite/irradiated_planet/history_columns.list
+++ b/star/test_suite/irradiated_planet/history_columns.list
@@ -131,44 +131,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -194,7 +169,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/irradiated_planet/profile_columns.list
+++ b/star/test_suite/irradiated_planet/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -129,20 +126,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -180,7 +170,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -190,17 +179,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -247,9 +231,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/magnetic_braking/history_columns.list
+++ b/star/test_suite/magnetic_braking/history_columns.list
@@ -98,19 +98,7 @@
 
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
 
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
 
@@ -223,44 +211,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
 
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
 
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
 
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
 
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
 
 
@@ -297,5 +260,4 @@
 
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run

--- a/star/test_suite/magnetic_braking/profile_columns.list
+++ b/star/test_suite/magnetic_braking/profile_columns.list
@@ -106,7 +106,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
 
    gradT ! mlt value for requared temperature gradient dlnT/dlnP
@@ -118,8 +117,6 @@
    gradL ! gradient for Ledoux criterion for convection
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
-      !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -155,23 +152,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -179,7 +169,6 @@
       log_J_inside ! J_inside is j_rot integrated from center
       !shear ! abs(dlnomega/dlnR)
       log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !delta_omega ! omega minus omega_pre_hydro
       v_rot ! rotation velocity at cell boundary (km/sec)
       i_rot ! specific moment of interia at cell boundary
       j_rot ! specific angular momentum at cell boundary
@@ -212,17 +201,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -260,7 +243,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -281,7 +263,6 @@
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
-      !brunt_dlnRho_dlnR ! smoothed numerical difference for use with brunt
       
       brunt_B
 
@@ -328,9 +309,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/make_co_wd/history_columns.list
+++ b/star/test_suite/make_co_wd/history_columns.list
@@ -102,19 +102,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -209,44 +197,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/make_co_wd/profile_columns.list
+++ b/star/test_suite/make_co_wd/profile_columns.list
@@ -116,7 +116,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for requared temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP requared for purely radiative transport
@@ -126,8 +125,6 @@
    sch_stable ! 1 if grada > gradr, 0 otherwise
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -163,23 +160,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -187,7 +177,6 @@
       log_J_inside ! J_inside is j_rot integrated from center
       !shear ! abs(dlnomega/dlnR)
       log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !delta_omega ! omega minus omega_pre_hydro
       v_rot ! rotation velocity at cell boundary (km/sec)
       i_rot ! specific moment of interia at cell boundary
       j_rot ! specific angular momentum at cell boundary
@@ -219,17 +208,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -267,7 +250,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -288,7 +270,6 @@
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
       !lamb_S ! for l=1: S = sqrt(2)*csound/r
-      !brunt_dlnRho_dlnR ! smoothed numerical difference for use with brunt
       brunt_B ! smoothed numerical difference
       
 
@@ -335,9 +316,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/make_env/history_columns.list
+++ b/star/test_suite/make_env/history_columns.list
@@ -147,19 +147,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -246,13 +234,11 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !burn_nfcn_total ! only non-zero for burn_split

--- a/star/test_suite/make_env/profile_columns.list
+++ b/star/test_suite/make_env/profile_columns.list
@@ -88,11 +88,7 @@
    !opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
-   !eps_binding ! ergs/g/sec from change in binding energy
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
-   !eps_nuc_from_bindings ! = eps_binding - eps_nuc_neu_total
-   !eps_nuc_vs_binding ! compare eps_nuc to eps_nuc_from_bindings
-      ! eps_nuc_vs_binding = (eps_nuc - eps_nuc_from_bindings) / max(1,abs(eps_nuc),abs(eps_nuc_from_bindings))
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
@@ -105,12 +101,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -160,23 +153,14 @@
       !cno
       !tri_alfa
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
-      !eps_nuc_avg ! (eps_nuc_start + eps_nuc_end)/2
          ! where eps_nuc_start is eps_nuc at start of step
          ! eps_nuc_end is eps_nuc at end of step
-      !eps_nuc_shift ! eps_nuc - eps_nuc_avg
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -214,7 +198,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -222,12 +205,10 @@
       !dlog_other_dlogP
       
             
-      !gradB ! for Brunt-Vaisala and Ledoux
       !brunt_N2 ! brunt-vaisala frequence squared
       !brunt_N ! sqrt(abs(brunt_N2))
       !log_brunt_N ! log10(brunt_N)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
-      !dlnmu_dr ! for thermohaline mixing
 
       
       !logQ ! logQ = logRho - 2*logT + 12
@@ -279,9 +260,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/make_he_wd/history_columns.list
+++ b/star/test_suite/make_he_wd/history_columns.list
@@ -94,19 +94,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -150,44 +138,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -213,7 +176,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/make_he_wd/profile_columns.list
+++ b/star/test_suite/make_he_wd/profile_columns.list
@@ -89,12 +89,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -135,20 +132,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -186,7 +176,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -196,17 +185,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -253,9 +237,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/make_metals/history_columns.list
+++ b/star/test_suite/make_metals/history_columns.list
@@ -99,19 +99,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -152,38 +140,16 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -209,7 +175,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/make_metals/profile_columns.list
+++ b/star/test_suite/make_metals/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -129,20 +126,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -180,7 +170,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -190,17 +179,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -247,9 +231,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/make_o_ne_wd/history_columns.list
+++ b/star/test_suite/make_o_ne_wd/history_columns.list
@@ -102,19 +102,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -234,44 +222,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/make_planets/history_columns.list
+++ b/star/test_suite/make_planets/history_columns.list
@@ -149,19 +149,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -259,54 +247,24 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location
-      !trace_mass_radius
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L
-      !trace_mass_v
 
    
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !max_conv_vel_div_csound

--- a/star/test_suite/make_planets/profile_columns.list
+++ b/star/test_suite/make_planets/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -130,20 +127,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -181,7 +171,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -191,17 +180,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -248,9 +232,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/make_sdb/history_columns.list
+++ b/star/test_suite/make_sdb/history_columns.list
@@ -143,44 +143,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -206,7 +181,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/make_sdb/profile_columns.list
+++ b/star/test_suite/make_sdb/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -134,20 +131,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -185,7 +175,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -195,17 +184,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -252,9 +236,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/ns_c/history_columns.list
+++ b/star/test_suite/ns_c/history_columns.list
@@ -102,19 +102,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -234,44 +222,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/ns_c/profile_columns.list
+++ b/star/test_suite/ns_c/profile_columns.list
@@ -88,11 +88,7 @@
    !opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
-   !eps_binding ! ergs/g/sec from change in binding energy
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
-   !eps_nuc_from_bindings ! = eps_binding - eps_nuc_neu_total
-   !eps_nuc_vs_binding ! compare eps_nuc to eps_nuc_from_bindings
-      ! eps_nuc_vs_binding = (eps_nuc - eps_nuc_from_bindings) / max(1,abs(eps_nuc),abs(eps_nuc_from_bindings))
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
@@ -105,12 +101,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -160,23 +153,14 @@
       !cno
       !tri_alfa
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
-      !eps_nuc_avg ! (eps_nuc_start + eps_nuc_end)/2
          ! where eps_nuc_start is eps_nuc at start of step
          ! eps_nuc_end is eps_nuc at end of step
-      !eps_nuc_shift ! eps_nuc - eps_nuc_avg
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -214,7 +198,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -222,12 +205,10 @@
       !dlog_other_dlogP
       
             
-      !gradB ! for Brunt-Vaisala and Ledoux
       !brunt_N2 ! brunt-vaisala frequence squared
       !brunt_N ! sqrt(abs(brunt_N2))
       !log_brunt_N ! log10(brunt_N)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
-      !dlnmu_dr ! for thermohaline mixing
 
       
       !logQ ! logQ = logRho - 2*logT + 12
@@ -279,9 +260,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/ns_h/history_columns.list
+++ b/star/test_suite/ns_h/history_columns.list
@@ -147,19 +147,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -246,13 +234,11 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !burn_nfcn_total ! only non-zero for burn_split

--- a/star/test_suite/ns_h/profile_columns.list
+++ b/star/test_suite/ns_h/profile_columns.list
@@ -88,11 +88,7 @@
    !opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
-   !eps_binding ! ergs/g/sec from change in binding energy
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
-   !eps_nuc_from_bindings ! = eps_binding - eps_nuc_neu_total
-   !eps_nuc_vs_binding ! compare eps_nuc to eps_nuc_from_bindings
-      ! eps_nuc_vs_binding = (eps_nuc - eps_nuc_from_bindings) / max(1,abs(eps_nuc),abs(eps_nuc_from_bindings))
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
@@ -105,12 +101,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -160,23 +153,14 @@
       !cno
       !tri_alfa
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
-      !eps_nuc_avg ! (eps_nuc_start + eps_nuc_end)/2
          ! where eps_nuc_start is eps_nuc at start of step
          ! eps_nuc_end is eps_nuc at end of step
-      !eps_nuc_shift ! eps_nuc - eps_nuc_avg
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -214,7 +198,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -222,12 +205,10 @@
       !dlog_other_dlogP
       
             
-      !gradB ! for Brunt-Vaisala and Ledoux
       !brunt_N2 ! brunt-vaisala frequence squared
       !brunt_N ! sqrt(abs(brunt_N2))
       !log_brunt_N ! log10(brunt_N)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
-      !dlnmu_dr ! for thermohaline mixing
 
       
       !logQ ! logQ = logRho - 2*logT + 12
@@ -279,9 +260,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/ns_he/history_columns.list
+++ b/star/test_suite/ns_he/history_columns.list
@@ -147,19 +147,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -246,13 +234,11 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !burn_nfcn_total ! only non-zero for burn_split

--- a/star/test_suite/ns_he/profile_columns.list
+++ b/star/test_suite/ns_he/profile_columns.list
@@ -88,11 +88,7 @@
    !opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
-   !eps_binding ! ergs/g/sec from change in binding energy
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
-   !eps_nuc_from_bindings ! = eps_binding - eps_nuc_neu_total
-   !eps_nuc_vs_binding ! compare eps_nuc to eps_nuc_from_bindings
-      ! eps_nuc_vs_binding = (eps_nuc - eps_nuc_from_bindings) / max(1,abs(eps_nuc),abs(eps_nuc_from_bindings))
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
@@ -105,12 +101,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -160,23 +153,14 @@
       !cno
       !tri_alfa
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
-      !eps_nuc_avg ! (eps_nuc_start + eps_nuc_end)/2
          ! where eps_nuc_start is eps_nuc at start of step
          ! eps_nuc_end is eps_nuc at end of step
-      !eps_nuc_shift ! eps_nuc - eps_nuc_avg
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -214,7 +198,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -222,12 +205,10 @@
       !dlog_other_dlogP
       
             
-      !gradB ! for Brunt-Vaisala and Ledoux
       !brunt_N2 ! brunt-vaisala frequence squared
       !brunt_N ! sqrt(abs(brunt_N2))
       !log_brunt_N ! log10(brunt_N)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
-      !dlnmu_dr ! for thermohaline mixing
 
       
       !logQ ! logQ = logRho - 2*logT + 12
@@ -279,9 +260,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/other_physics_hooks/history_columns.list
+++ b/star/test_suite/other_physics_hooks/history_columns.list
@@ -131,44 +131,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -194,7 +169,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/other_physics_hooks/profile_columns.list
+++ b/star/test_suite/other_physics_hooks/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -129,20 +126,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -180,7 +170,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -190,17 +179,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -247,9 +231,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/radiative_levitation/history_columns.list
+++ b/star/test_suite/radiative_levitation/history_columns.list
@@ -137,44 +137,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -200,7 +175,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
 
       diffusion_solver_steps
       diffusion_solver_iters

--- a/star/test_suite/radiative_levitation/profile_columns.list
+++ b/star/test_suite/radiative_levitation/profile_columns.list
@@ -89,12 +89,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -134,7 +131,6 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
       ! electric field from element diffusion calculation
@@ -183,17 +179,11 @@
       typical_charge mg24
 
 
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -231,7 +221,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -264,8 +253,6 @@
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -312,9 +299,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/rsp_BEP/history_columns.list
+++ b/star/test_suite/rsp_BEP/history_columns.list
@@ -38,8 +38,6 @@
       luminosity ! luminosity in Lsun units
       L_center
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T

--- a/star/test_suite/rsp_BEP/profile_columns.list
+++ b/star/test_suite/rsp_BEP/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_BLAP/history_columns.list
+++ b/star/test_suite/rsp_BLAP/history_columns.list
@@ -38,8 +38,6 @@
       luminosity ! luminosity in Lsun units
       L_center
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T

--- a/star/test_suite/rsp_BLAP/profile_columns.list
+++ b/star/test_suite/rsp_BLAP/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_Cepheid/history_columns.list
+++ b/star/test_suite/rsp_Cepheid/history_columns.list
@@ -38,8 +38,6 @@
       luminosity ! luminosity in Lsun units
       L_center
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T

--- a/star/test_suite/rsp_Cepheid/profile_columns.list
+++ b/star/test_suite/rsp_Cepheid/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_Delta_Scuti/history_columns.list
+++ b/star/test_suite/rsp_Delta_Scuti/history_columns.list
@@ -38,8 +38,6 @@
       luminosity ! luminosity in Lsun units
       L_center
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T

--- a/star/test_suite/rsp_Delta_Scuti/profile_columns.list
+++ b/star/test_suite/rsp_Delta_Scuti/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_RR_Lyrae/history_columns.list
+++ b/star/test_suite/rsp_RR_Lyrae/history_columns.list
@@ -38,8 +38,6 @@
       luminosity ! luminosity in Lsun units
       L_center
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T

--- a/star/test_suite/rsp_RR_Lyrae/profile_columns.list
+++ b/star/test_suite/rsp_RR_Lyrae/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_Type_II_Cepheid/history_columns.list
+++ b/star/test_suite/rsp_Type_II_Cepheid/history_columns.list
@@ -38,8 +38,6 @@
       luminosity ! luminosity in Lsun units
       L_center
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T

--- a/star/test_suite/rsp_Type_II_Cepheid/profile_columns.list
+++ b/star/test_suite/rsp_Type_II_Cepheid/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_gyre/history_columns.list
+++ b/star/test_suite/rsp_gyre/history_columns.list
@@ -120,19 +120,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -217,44 +205,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -282,7 +245,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
 

--- a/star/test_suite/rsp_gyre/profile_columns.list
+++ b/star/test_suite/rsp_gyre/profile_columns.list
@@ -40,9 +40,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    grada ! dlnT_dlnP at constant S
    !cv ! specific heat at constant volume

--- a/star/test_suite/rsp_save_and_load_file/history_columns.list
+++ b/star/test_suite/rsp_save_and_load_file/history_columns.list
@@ -141,17 +141,6 @@
    
    ! info at location of max abs velocity
       ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_L
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
 
    ! timescales
       
@@ -182,8 +171,6 @@
       !surf_escape_v ! cm/s
       luminosity ! luminosity in Lsun units
       !gravity 
-      !log_surf_pressure
-      !log_surf_density
    
       log_L ! log10 luminosity in Lsun units
       effective_T
@@ -227,13 +214,9 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
 
       
@@ -263,12 +246,10 @@
       ! energy information
       !avg_abs_v_div_cs
       !log_avg_abs_v_div_cs
-      !max_abs_v_div_cs
       !log_max_abs_v_div_cs
       
       !avg_abs_v
       !log_avg_abs_v
-      !max_abs_v
       !log_max_abs_v
 
 
@@ -289,7 +270,6 @@
       !num_iters
       
       num_retries ! total during the run
-      !num_backups ! total during the run
       !total_num_newton_solves
       !total_num_newton_iterations
       !avg_num_newton_iters

--- a/star/test_suite/rsp_save_and_load_file/profile_columns.list
+++ b/star/test_suite/rsp_save_and_load_file/profile_columns.list
@@ -90,9 +90,6 @@
    !velocity ! velocity at outer boundary of zone -- 0 if no velocity variable
    vel_km_per_s
    
-   !dr_dt ! time derivative of radius at fixed mass coordinate (Langranian)
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Langranian)
-   !dlnR_dt ! time derivative of log(radius) at fixed mass coordinate (Langranian)
    !log_sig_RTI
 
    v_div_csound ! velocity divided by sound speed
@@ -118,9 +115,6 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    pgas_div_ptotal ! pgas/pressure
    logPgas ! log10(pgas)
-   !logPrad
-   !log_erad
-   !log_egas
    energy ! internal energy (ergs/g)
    !grada ! dlnT_dlnP at constant S
    !dE_dRho ! at constant T
@@ -129,7 +123,6 @@
    !logS ! log10(specific entropy)
    !gamma1 ! dlnP_dlnRho at constant S
    !gamma3 ! gamma3 - 1 = dlnT_dlnRho at constant S
-   !theta_e ! electron degeneracy factor for graboske screening
    !gam ! plasma interaction parameter (> 160 or so means starting crystallization)
    free_e ! free_e is mean number of free electrons per nucleon
    logfree_e ! log10(free_e), free_e is mean number of free electrons per nucleon
@@ -151,21 +144,16 @@
    !log_conv_vel ! log10 convection velocity (cm/sec)
    !conv_vel_div_csound ! convection velocity divided by sound speed
    !log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    !pressure_scale_height ! in Rsun units
    !gradT ! mlt value for required temperature gradient dlnT/dlnP
    !gradr ! dlnT/dlnP required for purely radiative transport
    
-   !grad_superad
-   !grad_superad_actual
    !gradT_sub_grada ! gradT-grada at cell boundary 
    !gradT_rel_err
    !gradT_sub_gradr
    
    !dRstar_div_dr
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Langranian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    log_mass
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
@@ -176,8 +164,6 @@
    dq
    log_dq
    
-      !rsp_vt_div_cs
-      !rsp_vt
       rsp_logEt
       rsp_Et
       rsp_Pt
@@ -195,12 +181,7 @@
       rsp_Hp_face
       rsp_Y_face
       rsp_Pvsc
-      !rsp_gvisc
-      !rsp_gvisc_div_g
       rsp_Chi
-      !Trsp_Trad
-      !Trsp_Trad_div_T
-      !Trsp_Trad_div_T_sub1
       rsp_Lr_div_L
       rsp_Lc_div_L
       rsp_Lt_div_L
@@ -209,8 +190,6 @@
       !rsp_log_dt_div_heat_exchange_timescale
       !rsp_erad
       !rsp_log_erad
-      !rsp_f_Edd
-      !rsp_mesh_function
 
 
       ergs_error
@@ -249,7 +228,6 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
    
    pressure

--- a/star/test_suite/semiconvection/profile_columns.list
+++ b/star/test_suite/semiconvection/profile_columns.list
@@ -96,7 +96,6 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
@@ -108,8 +107,6 @@
    ledoux_stable ! 1 if gradL > gradr, 0 otherwise
    
 
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -145,23 +142,16 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
       
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -199,17 +189,11 @@
       dynamo_log_B_phi ! (Gauss)
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -247,7 +231,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -258,17 +241,12 @@
       grad_temperature ! dlnT/dlnP (smoothed)
       
       brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       !logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -315,9 +293,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/simplex_solar_calibration/history_columns.list
+++ b/star/test_suite/simplex_solar_calibration/history_columns.list
@@ -191,8 +191,6 @@
       !log_Ledd
       !log_L_div_Ledd ! log10(L/Leddington)
       !log_surf_opacity
-      !log_surf_pressure
-      !log_surf_density
       !log_surf_temperature
       !surface_temperature
       !log_surf_optical_depth
@@ -267,15 +265,6 @@
       !log_average he4
       ! etc.
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location (Msun)
-      !trace_mass_radius (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L (Lsun)
-      !trace_mass_v
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
    
    ! info at location of max temperature
@@ -317,7 +306,6 @@
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       
       !e_thermal ! sum over all zones of Cp*T*dm
       

--- a/star/test_suite/simplex_solar_calibration/profile_columns.list
+++ b/star/test_suite/simplex_solar_calibration/profile_columns.list
@@ -37,9 +37,7 @@
    !log_column_depth ! log10 column depth, exterior mass / area (g cm^-2)
    !log_radial_depth ! log10 radial distance to surface (cm)
    luminosity ! luminosity at outer boundary of zone (in Lsun units)
-   !luminosity_rad ! radiative luminosity at outer boundary of zone (in Lsun units)
       ! -(4 pi r^2)^2 a c / (3 kap) d(T^4)/dm
-   !lum_minus_lum_rad ! at outer boundary of zone (in Lsun units)
    !grav ! gravitational acceleration (cm sec^2)
    !g_div_r ! grav/radius (sec^2)
    !r_div_g ! radius/grav (sec^-2)
@@ -104,7 +102,6 @@
    !dkap_dlnt_face ! partial derivative of opacity wrt. ln T (at rho=const) at outer edge of cell
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (reaction neutrinos subtracted)
-   !deps_dlnrho_face ! partial derivative of eps_nuc wrt. ln rho (at T=const) at outer edge of cell
    !deps_dlnt_face ! partial derivative of eps_nuc wrt. ln T (at rho=const) at outer edge of cell
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
    non_nuc_neu ! non-nuclear-reaction neutrino losses
@@ -127,12 +124,10 @@
    mlt_mixing_length ! mixing length for mlt (cm)
    mlt_mixing_type ! value returned by mlt
    gradT_sub_grada ! gradT-grada at cell boundary 
-   !super_ad ! max(0,gradT-grada) at cell boundary 
    log_D_mix ! log10 diffusion coefficient for mixing in units of cm^2/second (Eulerian)
    !log_D_mix_non_rotation
    !log_sig_mix ! sig(k) is mixing flow across face k in (gm sec^1)
          ! sig(k) = D_mix*(4*pi*r(k)**2*rho_face)**2/dmavg
-   !log_sig_div_siglim
          ! this is raw_sig(k)/siglimit(k)
          ! where siglimit(k) = sig_term_limit*min(dm(k),dm(k-1))/dt
          ! and raw_sig(k) is sig(k) before it is set to min(siglimit(k),raw_sig(k))
@@ -158,13 +153,7 @@
    ! the "for_mixing" values are the ones used to calculate the mixing diffusion coeffs,
    ! i.e., from the start of the step.  
    ! the names without "for_mixing" are the values at the end of the step.
-   !gradr_for_mixing
-   !gradT_for_mixing
-   !grada_for_mixing
-   !gradL_for_mixing
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    !mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    
@@ -188,8 +177,6 @@
    !log_dr_div_cs_yr ! log10 cell sound crossing time (years)
    
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))  -- only important for neutron stars
-   !log_grav_gr_factor ! log10(grav_gr_factor)
    
    x ! hydrogen mass fraction
    !log_x
@@ -230,18 +217,11 @@
       
    ! equation residuals
       
-      !equP ! momentum conservation
-      !equT ! energy transport
-      !equR ! mass-volume-density relation
-      !equL ! energy conservation
-      !equv ! velocity definition
-      !equJ ! angular momentum
       !equ_chem h1
       !equ_chem he4
       ! any other isotopes you want
       
       
-   ! rotation
       !omega ! angular velocity = j_rot/i_rot
       !log_omega
       !log_j_rot
@@ -249,8 +229,6 @@
       !log_J_inside ! J_inside is j_rot integrated from center
       !shear ! -dlnomega/dlnR
       !log_abs_shear ! log10(abs(dlnomega/dlnR))
-      !domega_dt ! time derivative of omega at fixed mass coordinate (Lagrangian)
-      !delta_omega ! omega minus omega_pre_hydro
       !i_rot ! specific moment of interia at cell boundary
       !j_rot ! specific angular momentum at cell boundary
       !v_rot ! rotation velocity at cell boundary (km/sec)
@@ -261,8 +239,6 @@
       
       !r_polar ! (Rsun)
       !log_r_polar ! log10 (Rsun)
-      !r_equitorial ! (Rsun)
-      !log_r_equitorial ! log10 (Rsun)
       !r_e_div_r_p ! r_equitorial/r_polar
       !omega_crit ! breakup angular velocity = sqrt(G M / r_equitorial^3)
       !omega_div_omega_crit
@@ -280,21 +256,13 @@
       !dynamo_log_B_r ! (Gauss)
       !dynamo_log_B_phi ! (Gauss)
       
-      !am_coeff_D_SSI ! strength coeff for D_SSI in [0..1]
 
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
       
       ! element diffusion velocity for species
@@ -344,7 +312,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlog
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -416,9 +383,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/timing/history_columns.list
+++ b/star/test_suite/timing/history_columns.list
@@ -137,44 +137,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -200,7 +175,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/timing/profile_columns.list
+++ b/star/test_suite/timing/profile_columns.list
@@ -87,12 +87,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -135,20 +132,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -186,7 +176,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -196,17 +185,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -253,9 +237,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/twin_studies/history_columns.list
+++ b/star/test_suite/twin_studies/history_columns.list
@@ -140,19 +140,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -190,7 +178,6 @@
       v_div_cs
       v_surf_km_s
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
    
    ! conditions near center
       log_center_T
@@ -253,44 +240,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 

--- a/star/test_suite/twin_studies/profile_columns.list
+++ b/star/test_suite/twin_studies/profile_columns.list
@@ -159,15 +159,12 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
    
    gradT_sub_grada ! gradT-grada at cell boundary 
    
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    dm
@@ -200,10 +197,8 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_D_conv ! D_mix for regions where mix_type = convective_mixing
    log_D_semi ! D_mix for regions where mix_type = semiconvective_mixing
@@ -217,9 +212,6 @@
 
       log_sig_mix
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
    
    alpha_RTI
@@ -236,7 +228,6 @@
    log_dr
    dlogR
    
-   dlnRho_dlnR
    
    RTI_du_diffusion_kick
    log_du_kick_div_du
@@ -256,7 +247,6 @@
 
    extra_heat
    
-   ! rotation
       omega ! angular velocity = j_rot/i_rot
       log_omega
       log_j_rot
@@ -338,9 +328,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_acc_small_dm/history_columns.list
+++ b/star/test_suite/wd_acc_small_dm/history_columns.list
@@ -265,21 +265,7 @@
 
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_T ! estimate for T at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_T
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -353,8 +339,6 @@
 
       !log_surf_cell_opacity ! old name was log_surf_opacity
       !log_surf_cell_P ! old name was log_surf_P
-      !log_surf_cell_pressure ! old name was log_surf_pressure
-      !log_surf_cell_density ! old name was log_surf_density
       !log_surf_cell_temperature ! old name was log_surf_temperature
       !surface_cell_temperature ! old name was surface_temperature
       !log_surf_cell_z ! old name was log_surf_z
@@ -510,76 +494,18 @@
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !max_eps_h ! erg/g/s
-      !max_eps_h_lgT ! log10 temperature at location of max burn
-      !max_eps_h_lgRho ! log10 density at location of max burn
-      !max_eps_h_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_h_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_h_lgP ! log10 pressure at location of max burn
-      !max_eps_h_lgR ! log10 radius at location of max burn
-      !max_eps_h_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !max_eps_he ! erg/g/s
-      !max_eps_he_lgT ! log10 temperature at location of max_eps_he
-      !max_eps_he_lgRho ! log10 density at location of max burn
-      !max_eps_he_m ! mass coordinate at location of max burn (Msun units)
-      !max_eps_he_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_he_lgP ! log10 pressure at location of max burn
-      !max_eps_he_lgR ! log10 radius at location of max burn
-      !max_eps_he_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !max_eps_z ! erg/g/s
-      !max_eps_z_lgT ! log10 temperature at location of max burn
-      !max_eps_z_lgRho ! log10 density at location of max burn
-      !max_eps_z_m ! mass coordinate at location of max burn (Msun units)      
-      !max_eps_z_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_z_lgP ! log10 pressure at location of max burn
-      !max_eps_z_lgR ! log10 radius at location of max burn
-      !max_eps_z_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of all types
-      !max_eps_nuc ! erg/g/s
-      !max_eps_nuc_lgT ! log10 temperature at location of max burn
-      !max_eps_nuc_lgRho ! log10 density at location of max burn
-      !max_eps_nuc_m ! mass coordinate at location of max burn (Msun units)      
-      !max_eps_nuc_xm ! mass exterior to location of max burn (Msun units)
-      !max_eps_nuc_lgP ! log10 pressure at location of max burn
-      !max_eps_nuc_lgR ! log10 radius at location of max burn
-      !max_eps_nuc_opacity ! opacity at location of max burn
-      !max_eps_nuc_cp ! Cp at location of max burn
-      !max_eps_nuc_t_heat ! Cp*T/eps_nuc at location of max burn
-      !max_eps_nuc_csound
-      !max_eps_nuc_pi_r_div_cs
-      !max_eps_nuc_H ! pressure scale height
-      !max_eps_nuc_H_div_cs
-      !max_eps_nuc_log_xa he4 ! any species
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location ! (Msun)
-      !trace_mass_radius ! (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L ! (Lsun)
-      !trace_mass_v
 
-      !trace_mass_lgP
-      !trace_mass_g
-      !trace_mass_X
-      !trace_mass_Y
-      !trace_mass_edv_H
-      !trace_mass_edv_He
-      !trace_mass_scale_height
-      !trace_mass_dlnX_dr
-      !trace_mass_dlnY_dr
-      !trace_mass_dlnRho_dr
 
-      !trace_mass_omega
-      !trace_mass_omega_div_omega_crit
 
    
    ! info at location of max temperature
@@ -600,21 +526,6 @@
    
    ! info at location of max abs velocity
       ! note: can use control "min_tau_for_max_abs_v_location" to exclude surface
-      !max_abs_v_velocity
-      !max_abs_v_csound
-      !max_abs_v_v_div_cs
-      !max_abs_v_lgT
-      !max_abs_v_lgRho
-      !max_abs_v_lgP
-      !max_abs_v_mass
-      !max_abs_v_radius
-      !max_abs_v_radius_cm
-      !max_abs_v_lgR ! Rsun
-      !max_abs_v_lgR_cm
-      !max_abs_v_L ! Lsun
-      !max_abs_v_entropy
-      !max_abs_v_eps_nuc
-      !max_abs_v_E0 ! 4/3 pi R^3 crad T^4 at max_abs_v_location
       
       ! info about outermost outward moving shock
       ! excluding locations with q > max_q_for_outer_mach1_location
@@ -637,70 +548,18 @@
       ! info at innermost mach 1 location
       ! excluding locations with q < min_q_for_inner_mach1_location
       ! dr = r at mach 1 times mach1_plus_dr_factor parameter
-      !inner_mach1_plus_dr_mass ! baryonic (Msun)
-      !inner_mach1_plus_dr_q
-      !inner_mach1_plus_dr_radius ! (Rsun)
-      !inner_mach1_plus_dr_velocity
-      !inner_mach1_plus_dr_csound
-      !inner_mach1_plus_dr_v_div_cs
-      !inner_mach1_plus_dr_lgT
-      !inner_mach1_plus_dr_lgRho
-      !inner_mach1_plus_dr_lgP
-      !inner_mach1_plus_dr_gamma1
-      !inner_mach1_plus_dr_entropy
-      !inner_mach1_plus_dr_tau
-      !inner_mach1_plus_dr_k
       
       ! info at location of max entropy inward from inner mach 1 location
       ! excluding locations with q < min_q_for_inner_mach1_location
       ! dr = r at mach 1 times mach1_minus_dr_factor parameter
-      !inner_mach1_minus_dr_mass ! baryonic (Msun)
-      !inner_mach1_minus_dr_q
-      !inner_mach1_minus_dr_radius ! (Rsun)
-      !inner_mach1_minus_dr_velocity
-      !inner_mach1_minus_dr_csound
-      !inner_mach1_minus_dr_v_div_cs
-      !inner_mach1_minus_dr_lgT
-      !inner_mach1_minus_dr_lgRho
-      !inner_mach1_minus_dr_lgP
-      !inner_mach1_minus_dr_gamma1
-      !inner_mach1_minus_dr_entropy
-      !inner_mach1_minus_dr_tau
-      !inner_mach1_minus_dr_k
       
       ! info at outermost mach 1 location
       ! excluding locations with q > max_q_for_outer_mach1_location
       ! dr = r at mach 1 times mach1_plus_dr_factor parameter
-      !outer_mach1_plus_dr_mass ! baryonic (Msun)
-      !outer_mach1_plus_dr_q
-      !outer_mach1_plus_dr_radius ! (Rsun)
-      !outer_mach1_plus_dr_velocity
-      !outer_mach1_plus_dr_csound
-      !outer_mach1_plus_dr_v_div_cs
-      !outer_mach1_plus_dr_lgT
-      !outer_mach1_plus_dr_lgRho
-      !outer_mach1_plus_dr_lgP
-      !outer_mach1_plus_dr_gamma1
-      !outer_mach1_plus_dr_entropy
-      !outer_mach1_plus_dr_tau
-      !outer_mach1_plus_dr_k
       
       ! info at location of max entropy inward from outer mach 1 location
       ! excluding locations with q > max_q_for_outer_mach1_location
       ! dr = r at mach 1 times mach1_minus_dr_factor parameter
-      !outer_mach1_minus_dr_mass ! baryonic (Msun)
-      !outer_mach1_minus_dr_q
-      !outer_mach1_minus_dr_radius ! (Rsun)
-      !outer_mach1_minus_dr_velocity
-      !outer_mach1_minus_dr_csound
-      !outer_mach1_minus_dr_v_div_cs
-      !outer_mach1_minus_dr_lgT
-      !outer_mach1_minus_dr_lgRho
-      !outer_mach1_minus_dr_lgP
-      !outer_mach1_minus_dr_gamma1
-      !outer_mach1_minus_dr_entropy
-      !outer_mach1_minus_dr_tau
-      !outer_mach1_minus_dr_k
       
    
    ! asteroseismology
@@ -739,7 +598,6 @@
       !v_surf_km_s ! (km/s)
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
       !v_surf_div_v_kh ! v_surf/(photosphere_r/kh_timescale)
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       
       !v_div_csound_max ! max value of velocity divided by sound speed at face
       !e_thermal ! sum over all zones of Cp*T*dm

--- a/star/test_suite/wd_acc_small_dm/profile_columns.list
+++ b/star/test_suite/wd_acc_small_dm/profile_columns.list
@@ -91,12 +91,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -132,20 +129,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -183,7 +173,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -193,17 +182,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -250,9 +234,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_aic/history_columns.list
+++ b/star/test_suite/wd_aic/history_columns.list
@@ -136,44 +136,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -199,7 +174,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/wd_aic/profile_columns.list
+++ b/star/test_suite/wd_aic/profile_columns.list
@@ -89,12 +89,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -136,20 +133,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -187,7 +177,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -197,17 +186,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -254,9 +238,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_c_core_ignition/history_columns.list
+++ b/star/test_suite/wd_c_core_ignition/history_columns.list
@@ -144,44 +144,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -207,7 +182,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/wd_c_core_ignition/profile_columns.list
+++ b/star/test_suite/wd_c_core_ignition/profile_columns.list
@@ -45,7 +45,6 @@
       ! where val = net nuclear energy plus eps_grav minus all neutrino losses.
    !logL ! log10(max(1d-6,L/Lsun))
    signed_log_power ! sign(L)*log10(max(1,abs(L)))
-   !signed_log_energy_balance ! (net_energy + eps_grav - dL/dm)  (ergs/gm/sec)
       ! should = 0 for perfect energy balance
    velocity ! velocity at outer boundary of zone -- 0 if no velocity variable
    entropy ! specific entropy divided by (avo*kerg)
@@ -53,7 +52,6 @@
    csound ! sound speed
    v_div_csound ! velocity divided by sound speed
    !total_energy ! v^2/2 - G m / r + E (ergs/g).  negative if bound
-   !burn_times_ratio ! (scale_height/conv_vel)/(cp*T/eps_nuc) if both conv_vel and eps_nuc > 0
    !v_div_r ! velocity divided by radius
    !scale_height ! pressure scale height; P / (g rho)   (in Rsun units)
    eta ! electron degeneracy parameter (eta >> 1 for significant degeneracy)
@@ -93,11 +91,7 @@
    !opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
-   !eps_binding ! ergs/g/sec from change in binding energy
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
-   !eps_nuc_from_bindings ! = eps_binding - eps_nuc_neu_total
-   !eps_nuc_vs_binding ! compare eps_nuc to eps_nuc_from_bindings
-      ! eps_nuc_vs_binding = (eps_nuc - eps_nuc_from_bindings) / max(1,abs(eps_nuc),abs(eps_nuc_from_bindings))
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
@@ -105,24 +99,16 @@
    !nonnucneu_pair ! pair production (for reactions like e+ + e- => nu_e + nubar_e)
    mlt_mixing_length ! mixing length for mlt (cm)
    mlt_mixing_type ! value returned by mlt
-   !mlt_dlnmu_dr ! smoothed for use by mlt
    gradT_sub_grada ! gradT-grada at cell boundary 
-   !super_ad ! max(0,gradT-grada) at cell boundary 
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
-   !lconv ! convective luminosity (Lsun units)
    !log_Lconv ! log10 convective luminosity (Lsun units)
-   !lrad ! radiative diffusion luminosity (Lsun units)
    !log_Lconv ! log10 radiative diffusion luminosity (Lsun units)
-   !lconv_plus_lrad ! (Lsun units)
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -179,23 +165,14 @@
       !cno
       !tri_alfa
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
-      !eps_nuc_avg ! (eps_nuc_start + eps_nuc_end)/2
          ! where eps_nuc_start is eps_nuc at start of step
          ! eps_nuc_end is eps_nuc at end of step
-      !eps_nuc_shift ! eps_nuc - eps_nuc_avg
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
       
       ! element diffusion velocity for species
@@ -243,7 +220,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -259,8 +235,6 @@
       !log_brunt_N ! log10(brunt_N)
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
-      !dlnmu_dr ! for thermohaline mixing
-      !dlnRho_dlnR ! numerical estimate
 
       
       !logQ ! logQ = logRho - 2*logT + 12
@@ -312,9 +286,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_cool_0.6M/history_columns.list
+++ b/star/test_suite/wd_cool_0.6M/history_columns.list
@@ -149,19 +149,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -186,7 +174,6 @@
       log_L_div_Ledd ! log10(L/Leddington)
       !effective_T
       !log_surf_opacity
-      !log_surf_density
       !log_surf_temperature
       !log_surf_z
       !log_Ledd
@@ -252,48 +239,19 @@
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location (Msun)
-      !trace_mass_radius (Rsun)
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L (Lsun)
-      !trace_mass_v
       
    
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       
       
       num_retries ! total during the run

--- a/star/test_suite/wd_cool_0.6M/profile_columns.list
+++ b/star/test_suite/wd_cool_0.6M/profile_columns.list
@@ -45,7 +45,6 @@
       ! where val = net nuclear energy plus eps_grav minus all neutrino losses.
    !logL ! log10(max(1d-6,L/Lsun))
    signed_log_power ! sign(L)*log10(max(1,abs(L)))
-   !signed_log_energy_balance ! (net_energy + eps_grav - dL/dm)  (ergs/gm/sec)
       ! should = 0 for perfect energy balance
    velocity ! velocity at outer boundary of zone -- 0 if no velocity variable
    entropy ! specific entropy divided by (avo*kerg)
@@ -53,7 +52,6 @@
    csound ! sound speed
    v_div_csound ! velocity divided by sound speed
    !total_energy ! v^2/2 - G m / r + E (ergs/g).  negative if bound
-   !burn_times_ratio ! (scale_height/conv_vel)/(cp*T/eps_nuc) if both conv_vel and eps_nuc > 0
    !v_div_r ! velocity divided by radius
    !scale_height ! pressure scale height; P / (g rho)   (in Rsun units)
    eta ! electron degeneracy parameter (eta >> 1 for significant degeneracy)
@@ -93,11 +91,7 @@
    !opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
    eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
-   !eps_binding ! ergs/g/sec from change in binding energy
    !eps_nuc_neu_total ! erg/gm/sec as neutrinos from nuclear reactions
-   !eps_nuc_from_bindings ! = eps_binding - eps_nuc_neu_total
-   !eps_nuc_vs_binding ! compare eps_nuc to eps_nuc_from_bindings
-      ! eps_nuc_vs_binding = (eps_nuc - eps_nuc_from_bindings) / max(1,abs(eps_nuc),abs(eps_nuc_from_bindings))
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)
@@ -105,24 +99,16 @@
    !nonnucneu_pair ! pair production (for reactions like e+ + e- => nu_e + nubar_e)
    mlt_mixing_length ! mixing length for mlt (cm)
    mlt_mixing_type ! value returned by mlt
-   !mlt_dlnmu_dr ! smoothed for use by mlt
    gradT_sub_grada ! gradT-grada at cell boundary 
-   !super_ad ! max(0,gradT-grada) at cell boundary 
    log_D_mix ! log10 diffusion coefficient in units of cm^2/second (Eulerian)
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
-   !lconv ! convective luminosity (Lsun units)
    !log_Lconv ! log10 convective luminosity (Lsun units)
-   !lrad ! radiative diffusion luminosity (Lsun units)
    !log_Lconv ! log10 radiative diffusion luminosity (Lsun units)
-   !lconv_plus_lrad ! (Lsun units)
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -140,13 +126,7 @@
    !log_dr_div_cs_yr ! log10 cell sound crossing time (years)
    
    
-   !grav_gr_factor ! (1/sqrt(1 - 2Gm/(rc^2))
-   !log_grav_gr_factor ! log10(grav_gr_factor)
    
-   !gr_mass_excess ! gravitational mass excess
-   !gr_time_excess ! time distortion
-   !gr_space_excess ! space distortion
-   !gr_enthalpy_excess ! gr specific enthalpy - 1
    
    !z ! metallicity
    !log_z ! metallicity
@@ -187,23 +167,14 @@
       !cno
       !tri_alfa
 
-   ! misc
 
       !gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
 
-      !dlnP_dlnm ! for structure equation
-      !dlnT_dlnm ! for structure equation
       
-      !eps_nuc_avg ! (eps_nuc_start + eps_nuc_end)/2
          ! where eps_nuc_start is eps_nuc at start of step
          ! eps_nuc_end is eps_nuc at end of step
-      !eps_nuc_shift ! eps_nuc - eps_nuc_avg
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
       
       ! element diffusion velocity for species
@@ -251,7 +222,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -267,8 +237,6 @@
       !log_brunt_N ! log10(brunt_N)
       !log_brunt_N2 ! log10(brunt_N2)
       !sign_brunt_N2 ! sign of brunt_N2 (+1 for Ledoux stable; -1 for Ledoux unstable)
-      !dlnmu_dr ! for thermohaline mixing
-      !dlnRho_dlnR ! numerical estimate
 
       
       !logQ ! logQ = logRho - 2*logT + 12
@@ -320,9 +288,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_diffusion/history_columns.list
+++ b/star/test_suite/wd_diffusion/history_columns.list
@@ -137,44 +137,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -200,7 +175,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/wd_diffusion/profile_columns.list
+++ b/star/test_suite/wd_diffusion/profile_columns.list
@@ -91,12 +91,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -154,20 +151,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -205,7 +195,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -215,17 +204,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -272,9 +256,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_he_shell_ignition/history_columns.list
+++ b/star/test_suite/wd_he_shell_ignition/history_columns.list
@@ -152,19 +152,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -271,54 +259,24 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location
-      !trace_mass_radius
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L
-      !trace_mass_v
 
    
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !max_conv_vel_div_csound

--- a/star/test_suite/wd_he_shell_ignition/profile_columns.list
+++ b/star/test_suite/wd_he_shell_ignition/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -141,20 +138,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -192,7 +182,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -202,17 +191,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -259,9 +243,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_nova_burst/history_columns.list
+++ b/star/test_suite/wd_nova_burst/history_columns.list
@@ -140,44 +140,19 @@
       !pp
       !cno
       !tri_alfa
-      !c12_alfa
-      !n14_alfa
-      !o16_alfa
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
 
@@ -203,7 +178,6 @@
    ! misc
    
       !v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
 
 

--- a/star/test_suite/wd_nova_burst/profile_columns.list
+++ b/star/test_suite/wd_nova_burst/profile_columns.list
@@ -87,12 +87,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -133,20 +130,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -184,7 +174,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -194,17 +183,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -251,9 +235,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius

--- a/star/test_suite/wd_stable_h_burn/history_columns.list
+++ b/star/test_suite/wd_stable_h_burn/history_columns.list
@@ -149,19 +149,7 @@
    
    ! info about locations where optical depth is 10 or 100
 
-      !tau10_mass ! mass in solar units where optical depth = 10
-      !tau10_radius ! radius in solar units where optical depth = 10
-      !tau10_lgP ! estimate for log10(P) at tau = 10
-      !tau10_lgT ! estimate for log10(T) at tau = 10
-      !tau10_lgRho ! estimate for log10(density) at tau = 10
-      !tau10_L ! estimate for L/Lsun at tau = 10
       
-      !tau100_mass ! location in solar units where optical depth = 100
-      !tau100_radius ! location in solar units where optical depth = 100
-      !tau100_lgP ! estimates for values at tau = 100
-      !tau100_lgT
-      !tau100_lgRho
-      !tau100_L
 
    ! timescales
       
@@ -259,54 +247,24 @@
 
    ! log10 total ergs/sec for specific reactions (names from rates_def; Lsun units)
       
-      !rpp
 
    ! info about the max burning locations for hydrogen, helium, and metals
       
       ! info about location where have max rate of hydrogen burning (PP and CNO)
-      !eps_h_max ! erg/g/s
-      !eps_h_max_lgT ! log10 temperature at location of max burn
-      !eps_h_max_lgRho ! log10 density at location of max burn
-      !eps_h_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_h_max_lgP ! log10 pressure at location of max burn
-      !eps_h_max_lgR ! log10 radius at location of max burn
-      !eps_h_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of helium burning
          ! triple-alpha plus alpha capture on C12, N14, O16, and Ne20.
-      !eps_he_max ! erg/g/s
-      !eps_he_max_lgT ! log10 temperature at location of max burn
-      !eps_he_max_lgRho ! log10 density at location of max burn
-      !eps_he_max_m ! mass coordinate at location of max burn (Msun units)
-      !eps_he_max_lgP ! log10 pressure at location of max burn
-      !eps_he_max_lgR ! log10 radius at location of max burn
-      !eps_he_max_opacity ! opacity at location of max burn
       
       ! info about location where have max rate of burning of metals
          ! alpha capture on heavy elements plus C+C, C+O, O+O, etc.
-      !eps_z_max ! erg/g/s
-      !eps_z_max_lgT ! log10 temperature at location of max burn
-      !eps_z_max_lgRho ! log10 density at location of max burn
-      !eps_z_max_m ! mass coordinate at location of max burn (Msun units)      
-      !eps_z_max_lgP ! log10 pressure at location of max burn
-      !eps_z_max_lgR ! log10 radius at location of max burn
-      !eps_z_max_opacity ! opacity at location of max burn
 
    
    
-   ! info at a specified mass coordinate (given by trace_mass_location)
-      !trace_mass_location
-      !trace_mass_radius
-      !trace_mass_lgT
-      !trace_mass_lgRho
-      !trace_mass_L
-      !trace_mass_v
 
    
    ! misc
    
       v_div_csound_surf ! velocity divided by sound speed at outermost grid point
-      !surface_accel_div_grav ! (v - v_old)/dt divided by GM/R^2 at outermost grid point
       num_retries ! total during the run
       
       !max_conv_vel_div_csound

--- a/star/test_suite/wd_stable_h_burn/profile_columns.list
+++ b/star/test_suite/wd_stable_h_burn/profile_columns.list
@@ -88,12 +88,9 @@
    log_conv_vel ! log10 convection velocity (cm/sec)
    conv_vel_div_csound ! convection velocity divided by sound speed
    log_mlt_D_mix ! log10 cdc from mlt (cm^2/sec)
-   !use_gradr_for_gradT ! if = 1, then zone has been forced radiative in spite of mlt results.
    pressure_scale_height ! in Rsun units
    gradT ! mlt value for required temperature gradient dlnT/dlnP
    gradr ! dlnT/dlnP required for purely radiative transport
-   !dv_dt ! time derivative of velocity at fixed mass coordinate (Lagrangian)
-   !accel_div_grav ! dv_dt/grav  --  only if v_flag is true.  0 otherwise.
    mass ! m/Msun. mass coordinate of outer boundary of cell.
    mmid ! mass at midpoint of cell (average of mass coords of the cell boundaries)  Msun units.
    !logM ! log10(m/Msun)
@@ -129,20 +126,13 @@
 
    ! ergs/g/sec for specific reactions (names from rates_def)
       
-      !rpp
 
       
-   ! misc
 
       gradr_sub_grada ! gradr - grada; > 0 => Schwarzschild unstable for convection
-      !dlnR_dm ! for structure equation
-      !dlnP_dm ! for structure equation
-      !dlnT_dm ! for structure equation
-      !dL_dm ! for structure equation
       
       
       !delta_r ! r(outer edge) - r(inner edge); radial extent of cell in cm.
-      !delta_v ! v(inner edge) - v(outer edge); rate at which delta_r is shrinking (cm/sec).
       !dt_dv_div_dr ! dt*delta_v/delta_r; need to have this << 1 for every cell
          
          
@@ -180,7 +170,6 @@
       !dlog_burn_ar_dlogP
       !dlog_burn_ca_dlogP
       !dlog_burn_ti_dlogP
-      !dlog_burn_cr_dlogP
       !dlog_burn_fe_dlogP
       
       !dlog_pnhe4_dlogP
@@ -190,17 +179,12 @@
       
       
       !brunt_N2 ! brunt-vaisala frequence squared.  only positive values shown.
-      !brunt_Astar ! Astar := r N^2 / g.  only positive values shown.
       !brunt_B ! the composition gradient term in the brunt N^2 calculation
-      !chiY ! dlnP/dlnY used in calculate of brunt_B term
-      !dlnY_dlnP ! the actual dlnY/dlnP in the model as used in brunt_B
       
       logQ ! logQ = logRho - 2*logT + 12
       
       !cs_at_cell_bdy ! sound speed at cell boundary (csound is at cell center)
       
-      !dlnmu_dr ! for salt-finger mixing
-      !semiconvection_criterion ! positive means stable
          ! 1/chiRho - dlnT_dlnP*chiT/chiRho - dlnRho_dlnP
       
 
@@ -247,9 +231,6 @@
       ! star_mass_o16
       ! star_mass_ne20
    ! locations of abundance transitions
-      ! h1_boundary_mass
-      ! he4_boundary_mass
-      ! c12_boundary_mass
    ! location of optical depths 10 and 100
       ! tau10_mass
       ! tau10_radius


### PR DESCRIPTION
Re-syncs history columns data and adds a new linter for checking history columns. Of course if I'd spent 5 minutes checking I would have seen Josiah had already added one to do that. The only advantage of mine is does it case insensitive matching.

We should probably merge the linters rather than have separate ones, but i wanted t get the fixes in first so i can get back to what i actually wanted to do before going down the rabbit hole of bad history columns in the test suite. 