### PR TITLE
Rework approach to distinguish baryonic and gravitational mass

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -7566,21 +7566,6 @@
     use_gravity_rotation_correction = .true.
 
 
-      ! use_mass_corrections
-      ! ~~~~~~~~~~~~~~~~~~~~
-
-      !   UNTESTED.   EXPERIMENTAL FEATURE.   NOT FOR GENERAL USE.
-
-      ! Gravitational vs baryonic mass corrections.
-      ! If false, then no distinction between gravitational and baryonic mass.
-      ! If true, then gravitational mass is calculated using mass corrections.
-      ! Note: may need to wait for pre-ms model to converged before turning this on.
-
-      ! ::
-
-    use_mass_corrections = .false.
-
-
       ! use_dedt_form_of_energy_eqn
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ! always_use_dedt_form_of_energy_eqn

--- a/star/defaults/controls_dev.defaults
+++ b/star/defaults/controls_dev.defaults
@@ -237,3 +237,44 @@
 
     conv_vel_use_mlt_vc_start = .true.
 
+
+! mass corrections
+! ================
+
+
+      ! use_mass_corrections
+      ! ~~~~~~~~~~~~~~~~~~~~
+
+      ! Gravitational vs baryonic mass corrections.
+
+      ! The Lagrangian coordinate (:math:`m`) in MESA is the baryonic
+      ! mass and the density (:math:`\rho`) is the baryonic mass
+      ! density.
+
+      ! If false, then no distinction between gravitational and baryonic mass.
+      ! If true, then the gravitational mass is calculated using mass corrections
+      ! and the momentum equation, total energy equation, and Brunt are modified.
+
+      ! The variable ``mass_correction`` is the quantity you multiply
+      ! the baryonic mass density by to get the gravitational mass
+      ! density:
+
+      !     (mass density) = (baryon density) * amu * mass_correction
+
+      ! Given the mass fractions in a cell, the value of
+      ! mass_correction is provided by the ``chem`` module.
+
+      ! MESA holds m_grav fixed during the newton iterations.  This results
+      ! in an energy conservation error, because the specific potential energy
+      ! changes when m_grav is updated afterwards.  A message showing
+      ! the relative energy error incurred due to this assumption
+      ! will be printed to the terminal.
+
+      ! Not compatible with RSP.
+
+      ! ::
+
+    use_mass_corrections = .false.
+
+
+

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -668,8 +668,12 @@
 
             call do1(s% mass_correction, c% mass_correction)
             if (failed('mass_correction')) exit
+            call do1(s% mass_correction_start, c% mass_correction_start)
+            if (failed('mass_correction_start')) exit
             call do1(s% m_grav, c% m_grav)
             if (failed('m_grav')) exit
+            call do1(s% m_grav_start, c% m_grav_start)
+            if (failed('m_grav_start')) exit
 
             call do1(s% Peos, c% Peos)
             if (failed('Peos')) exit

--- a/star/private/hydro_momentum.f90
+++ b/star/private/hydro_momentum.f90
@@ -185,10 +185,22 @@
             i_lum = s% i_lum
             i_v = s% i_v
             nz = s% nz
-            if (k > 1) then
-               dm_face = (s% dm(k) + s% dm(k-1))/2d0
-            else ! k == 1
-               dm_face = s% dm(k)/2d0
+            ! in the momentum equation, e.g., dP/dr = -g * rho (for HSE),
+            ! rho represents the inertial (gravitational) mass density.
+            ! since dm is baryonic mass, correct dm_face when using mass corrections
+            ! this will be used in the calculation of dm_div_A
+            if (s% use_mass_corrections) then
+               if (k > 1) then
+                  dm_face = (s% dm(k)*s% mass_correction(k) + s% dm(k-1)*s% mass_correction(k-1))/2d0
+               else ! k == 1
+                  dm_face = s% dm(k)*s% mass_correction(k)/2d0
+               end if
+            else
+               if (k > 1) then
+                  dm_face = (s% dm(k) + s% dm(k-1))/2d0
+               else ! k == 1
+                  dm_face = s% dm(k)/2d0
+               end if
             end if
             d_dm1 = 0d0; d_d00 = 0d0; d_dp1 = 0d0
          end subroutine init

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -326,6 +326,7 @@
             s% latent_ddlnRho_start(k) = s% latent_ddlnRho(k)
             s% eps_nuc_start(k) = s% eps_nuc(k)
             s% opacity_start(k) = s% opacity(k)
+            s% m_grav_start(k) = s% m_grav(k)
          end do
          
          if (s% RSP2_flag) then

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -61,9 +61,9 @@
          ! ye is mean number free electrons per nucleon, assuming complete ionization
          
       ! gravitational vs baryonic mass
-      real(dp), pointer :: mass_correction(:) ! = dm_gravitational/dm_baryonic
+      real(dp), pointer :: mass_correction(:), mass_correction_start(:) ! = dm_gravitational/dm_baryonic
          ! calculated by chem module
-      real(dp), pointer :: m_grav(:) 
+      real(dp), pointer :: m_grav(:), m_grav_start(:)
          ! enclosed gravitational mass at cell outer edge
          ! the variable called "m" is the enclosed baryonic mass
             ! = number of enclosed baryons * atomic mass unit


### PR DESCRIPTION
The MESA option use_mass_corrections allows the user to enable a set
of corrections that distinguish between baryonic and gravitational
mass.  The mass (m) and density (rho) in MESA are baryonic.  The
corrections are due to the composition-dependent mass excess, which is
provided for each cell by chem_lib as mass_correction.  The
gravitational (or inertial) mass of a cell is then given by
dm(k)*mass_correction(k) and the gravitational mass (m_grav) is
obtained by cumulatively summing the per-cell values from the center
to the surface.

The key corrections are as follows:

The momentum equation concerns the inertial mass, so mass corrections
should modify the dm present in this equation.  As was already being
done, the gravitational acceleration should use m_grav.

The Brunt-Vaisala frequency should be consistent with the momentum
equation.  Mass corrections enter through an overall multiplicative
term and through the definition of the gravitational acceleration.
Additionally, in the Brunt B expression, there is a new term that
reflects the difference between the gradient of the inertial mass
density and the baryonic mass density.

The total energy equation should have mass corrections present in the
KE and PE terms.  These terms come from v dot the momentum equation
and so require the same corrections.

The specific PE term contains m_grav.  Since the PE is evaluated at
the start, this requires storing m_grav_start.  Some changes in
remeshing routines were required to ensure that the values necessary
to calculate the PE were present and up to date.

MESA does not change m_grav during solver iterations.  (Doing so
consistently would require adding a new equation in the solver.)  When
m_grav is updated afterwards, this results in an energy conservation
error, because the specific potential energy changes without an
offsetting term in the total energy equation.  Because this reflects a
real inconsistency, the numerical energy conservation will worsen.
This change adds an info print out showing what rel_E_err is due to
this effect when use_mass_correction = .true. .

This also currently ignores changes in the mass_correction over a
timestep so that we don't need to add in its partials.

These corrections have not yet been thoroughly tested and
independently checked.  As such, the use_mass_corrections control is
relocated to controls_dev.