### PR TITLE
Catch negative luminosity in `star_utils:get_phot_info`

### DIFF
--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -1155,6 +1155,7 @@
                   v = s% v(k) + (s% v(k+1) - s% v(k))*(tau_phot - tau00)/dtau
                end if
                L = s% L(k) + (s% L(k+1) - s% L(k))*(tau_phot - tau00)/dtau
+               L = max(1d0, s% L(1)) ! don't use negative L(1)
                logg = safe_log10(s% cgrav(k_phot)*m/(r*r))
                k_phot = k
                ! don't bother interpolating these.


### PR DESCRIPTION
`get_phot_info` can ultimately return values from either the outermost meshpoint, interpolation inside the model, or the innermost meshpoint. The first and last option include a catch
```f90
      L = max(1d0, s% L(1)) ! don't use negative L(1)
```
but the second option (interpolation) did not, which caused an FPE error in `T_tau_gradr`. This PR fixes that by adding the same catch before returning after interpolation. The FPE situation is [no worse](https://testhub.mesastar.org/whb%2Fnegative-L-FPE/commits/89da512) and a full run of the test suite is [passing](https://testhub.mesastar.org/whb%2Fnegative-L-FPE/commits/e05468d).