### PR TITLE
Add support for setting namelists as strings.

### DIFF
--- a/binary/private/binary_job_ctrls_io.f90
+++ b/binary/private/binary_job_ctrls_io.f90
@@ -306,5 +306,72 @@
       end subroutine do_write_binary_job
 
 
+      subroutine get_binary_job(b, name, val, ierr)
+         use utils_lib, only: StrUpCase
+         type (binary_info), pointer :: b
+         character(len=*),intent(in) :: name
+         character(len=*), intent(out) :: val
+         integer, intent(out) :: ierr
+   
+         character(len(name)) :: upper_name
+         character(len=512) :: str
+         integer :: iounit,iostat,ind,i
+   
+   
+         ! First save current controls
+         call set_binary_job_controls_for_writing(b, ierr)
+         if(ierr/=0) return
+   
+         ! Write namelist to temporay file
+         open(newunit=iounit,status='scratch')
+         write(iounit,nml=binary_job)
+         rewind(iounit)
+   
+         ! Namelists get written in captials
+         upper_name = StrUpCase(name)
+         val = ''
+         ! Search for name inside namelist
+         do 
+            read(iounit,'(A)',iostat=iostat) str
+            ind = index(str,trim(upper_name))
+            if( ind /= 0 ) then
+               val = str(ind+len_trim(upper_name)+1:len_trim(str)-1) ! Remove final comma and starting =
+               do i=1,len(val)
+                  if(val(i:i)=='"') val(i:i) = ' '
+               end do
+               exit
+            end if
+            if(is_iostat_end(iostat)) exit
+         end do   
+   
+         if(len_trim(val) == 0 .and. ind==0 ) ierr = -1
+   
+         close(iounit)
+   
+      end subroutine get_binary_job
+   
+      subroutine set_binary_job(b, name, val, ierr)
+         type (binary_info), pointer :: b
+         character(len=*), intent(in) :: name, val
+         character(len=len(name)+len(val)+14) :: tmp
+         integer, intent(out) :: ierr
+   
+         ! First save current controls
+         call set_binary_job_controls_for_writing(b, ierr)
+         if(ierr/=0) return
+   
+         tmp=''
+         tmp = '&binary_job '//trim(name)//'='//trim(val)//' /'
+   
+         ! Load into namelist
+         read(tmp, nml=binary_job)
+   
+         ! Add to star
+         call store_binary_job_controls(b, ierr)
+         if(ierr/=0) return
+   
+      end subroutine set_binary_job
+
+
       end module binary_job_ctrls_io
 

--- a/binary/public/binary_lib.f90
+++ b/binary/public/binary_lib.f90
@@ -163,5 +163,71 @@
          call eval_wind_xfer_fractions(binary_id, ierr)
       end subroutine binary_eval_wind_xfer_fractions
 
+
+      subroutine binary_get_control_namelist(binary_id, name, val, ierr)
+         use binary_ctrls_io, only: get_binary_control
+         use binary_def, only: binary_info, binary_ptr
+         integer, intent(in) :: binary_id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(out) :: val
+         integer, intent(out) :: ierr
+         type (binary_info), pointer :: b
+
+         ierr = 0
+         call binary_ptr(binary_id, b, ierr)
+         if(ierr/=0) return
+         call get_binary_control(b, name, val, ierr)
+
+      end subroutine binary_get_control_namelist
+
+      subroutine binary_set_control_namelist(binary_id, name, val, ierr)
+         use binary_ctrls_io, only: set_binary_control
+         use binary_def, only: binary_info, binary_ptr
+         integer, intent(in) :: binary_id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(in) :: val
+         integer, intent(out) :: ierr
+         type (binary_info), pointer :: b
+
+         ierr = 0
+         call binary_ptr(binary_id, b, ierr)
+         if(ierr/=0) return
+         call set_binary_control(b, name, val, ierr)
+
+      end subroutine binary_set_control_namelist
+
+
+      subroutine binary_get_star_job_namelist(binary_id, name, val, ierr)
+         use binary_job_ctrls_io, only: get_binary_job
+         use binary_def, only: binary_info, binary_ptr
+         integer, intent(in) :: binary_id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(out) :: val
+         integer, intent(out) :: ierr
+         type (binary_info), pointer :: b
+
+         ierr = 0
+         call binary_ptr(binary_id, b, ierr)
+         if(ierr/=0) return
+         call get_binary_job(b, name, val, ierr)
+
+      end subroutine binary_get_star_job_namelist
+
+      subroutine binary_set_star_job_namelist(binary_id, name, val, ierr)
+         use binary_job_ctrls_io, only: set_binary_job
+         use binary_def, only: binary_info, binary_ptr
+         integer, intent(in) :: binary_id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(in) :: val
+         integer, intent(out) :: ierr
+         type (binary_info), pointer :: b
+
+         ierr = 0
+         call binary_ptr(binary_id, b, ierr)
+         if(ierr/=0) return
+         call set_binary_job(b, name, val, ierr)
+
+      end subroutine binary_set_star_job_namelist
+
       end module binary_lib
 

--- a/eos/private/eos_ctrls_io.f90
+++ b/eos/private/eos_ctrls_io.f90
@@ -31,7 +31,7 @@
 
    implicit none
 
-   public :: read_namelist, write_namelist
+   public :: read_namelist, write_namelist, get_eos_controls, set_eos_controls
    private
 
    ! controls for HELM
@@ -656,6 +656,75 @@
       Z_hi = rq% Z_hi
    end subroutine set_controls_for_writing
    
+
+   subroutine get_eos_controls(rq, name, val, ierr)
+      use utils_lib, only: StrUpCase
+      type (EoS_General_Info), pointer :: rq
+      character(len=*),intent(in) :: name
+      character(len=*), intent(out) :: val
+      integer, intent(out) :: ierr
+
+      character(len(name)) :: upper_name
+      character(len=512) :: str
+      integer :: iounit,iostat,ind,i
+
+      ierr = 0
+
+
+      ! First save current controls
+      call set_controls_for_writing(rq)
+
+      ! Write namelist to temporay file
+      open(newunit=iounit,status='scratch')
+      write(iounit,nml=eos)
+      rewind(iounit)
+
+      ! Namelists get written in captials
+      upper_name = StrUpCase(name)
+      val = ''
+      ! Search for name inside namelist
+      do 
+         read(iounit,'(A)',iostat=iostat) str
+         ind = index(str,trim(upper_name))
+         if( ind /= 0 ) then
+            val = str(ind+len_trim(upper_name)+1:len_trim(str)-1) ! Remove final comma and starting =
+            do i=1,len(val)
+               if(val(i:i)=='"') val(i:i) = ' '
+            end do
+            exit
+         end if
+         if(is_iostat_end(iostat)) exit
+      end do   
+
+      if(len_trim(val) == 0 .and. ind==0 ) ierr = -1
+
+      close(iounit)
+
+   end subroutine get_eos_controls
+
+   subroutine set_eos_controls(rq, name, val, ierr)
+      type (EoS_General_Info), pointer :: rq
+      character(len=*), intent(in) :: name, val
+      character(len=len(name)+len(val)+8) :: tmp
+      integer, intent(out) :: ierr
+
+      ierr = 0
+
+      ! First save current eos_controls
+      call set_controls_for_writing(rq)
+
+      tmp=''
+      tmp = '&eos '//trim(name)//'='//trim(val)//' /'
+
+      ! Load into namelist
+      read(tmp, nml=eos)
+
+      ! Add to eos
+      call store_controls(rq)
+      if(ierr/=0) return
+
+   end subroutine set_eos_controls
+
 
    end module eos_ctrls_io
 

--- a/eos/public/eos_lib.f90
+++ b/eos/public/eos_lib.f90
@@ -892,4 +892,35 @@
       end subroutine num_eos_files_loaded
 
 
+      subroutine eos_get_control_namelist(handle, name, val, ierr)
+         use eos_def
+         use eos_ctrls_io, only: get_eos_controls
+         integer, intent(in) :: handle ! eos handle; from star, pass s% eos_handle
+         character(len=*),intent(in) :: name
+         character(len=*),intent(out) :: val
+         integer, intent(out) :: ierr
+         type (EoS_General_Info), pointer :: rq
+         ierr = 0
+         call get_eos_ptr(handle,rq,ierr)
+         if(ierr/=0) return
+         call get_eos_controls(rq, name, val, ierr)
+
+      end subroutine eos_get_control_namelist
+
+      subroutine eos_set_control_namelist(handle, name, val, ierr)
+         use eos_def
+         use eos_ctrls_io, only: set_eos_controls
+         integer, intent(in) :: handle ! eos handle; from star, pass s% eos_handle
+         character(len=*),intent(in) :: name
+         character(len=*),intent(in) :: val
+         integer, intent(out) :: ierr
+         type (EoS_General_Info), pointer :: rq
+         ierr = 0
+         call get_eos_ptr(handle,rq,ierr)
+         if(ierr/=0) return
+         call set_eos_controls(rq, name, val, ierr)
+
+      end subroutine eos_set_control_namelist
+
+
       end module eos_lib

--- a/kap/private/kap_ctrls_io.f90
+++ b/kap/private/kap_ctrls_io.f90
@@ -31,7 +31,7 @@
 
    implicit none
 
-   public :: read_namelist, write_namelist
+   public :: read_namelist, write_namelist, get_kap_controls, set_kap_controls
    private
 
    real(dp) :: Zbase
@@ -463,7 +463,105 @@
 
    subroutine set_controls_for_writing(rq)
       type (Kap_General_Info), pointer :: rq
+
+      Zbase = rq% Zbase
+
+      kap_blend_logT_upper_bdy = rq% kap_blend_logT_upper_bdy
+      kap_blend_logT_lower_bdy = rq% kap_blend_logT_lower_bdy
+
+      cubic_interpolation_in_X = rq% cubic_interpolation_in_X
+      cubic_interpolation_in_Z = rq% cubic_interpolation_in_Z
+
+      include_electron_conduction = rq% include_electron_conduction
+      use_blouin_conductive_opacities = rq% use_blouin_conductive_opacities
+
+      use_Zbase_for_Type1 = rq% use_Zbase_for_Type1
+      use_Type2_opacities = rq% use_Type2_opacities
+
+      kap_Type2_full_off_X = rq% kap_Type2_full_off_X
+      kap_Type2_full_on_X = rq% kap_Type2_full_on_X
+      kap_Type2_full_off_dZ = rq% kap_Type2_full_off_dZ
+      kap_Type2_full_on_dZ = rq% kap_Type2_full_on_dZ
+
+      show_info = rq% show_info
+
+      use_other_elect_cond_opacity = rq% use_other_elect_cond_opacity
+      use_other_compton_opacity = rq% use_other_compton_opacity
+      use_other_radiative_opacity = rq% use_other_radiative_opacity
+
+
    end subroutine set_controls_for_writing
+
+
+
+   subroutine get_kap_controls(rq, name, val, ierr)
+      use utils_lib, only: StrUpCase
+      type (kap_General_Info), pointer :: rq
+      character(len=*),intent(in) :: name
+      character(len=*), intent(out) :: val
+      integer, intent(out) :: ierr
+
+      character(len(name)) :: upper_name
+      character(len=512) :: str
+      integer :: iounit,iostat,ind,i
+
+      ierr = 0
+
+
+      ! First save current controls
+      call set_controls_for_writing(rq)
+
+      ! Write namelist to temporay file
+      open(newunit=iounit,status='scratch')
+      write(iounit,nml=kap)
+      rewind(iounit)
+
+      ! Namelists get written in captials
+      upper_name = StrUpCase(name)
+      val = ''
+      ! Search for name inside namelist
+      do 
+         read(iounit,'(A)',iostat=iostat) str
+         ind = index(str,trim(upper_name))
+         if( ind /= 0 ) then
+            val = str(ind+len_trim(upper_name)+1:len_trim(str)-1) ! Remove final comma and starting =
+            do i=1,len(val)
+               if(val(i:i)=='"') val(i:i) = ' '
+            end do
+            exit
+         end if
+         if(is_iostat_end(iostat)) exit
+      end do   
+
+      if(len_trim(val) == 0 .and. ind==0 ) ierr = -1
+
+      close(iounit)
+
+   end subroutine get_kap_controls
+
+   subroutine set_kap_controls(rq, name, val, ierr)
+      type (kap_General_Info), pointer :: rq
+      character(len=*), intent(in) :: name, val
+      character(len=len(name)+len(val)+8) :: tmp
+      integer, intent(out) :: ierr
+
+      ierr = 0
+
+      ! First save current kap_controls
+      call set_controls_for_writing(rq)
+
+      tmp=''
+      tmp = '&kap '//trim(name)//'='//trim(val)//' /'
+
+      ! Load into namelist
+      read(tmp, nml=kap)
+
+      ! Add to kap
+      call store_controls(rq,ierr)
+      if(ierr/=0) return
+
+   end subroutine set_kap_controls
+
 
 
    end module kap_ctrls_io

--- a/kap/public/kap_lib.f90
+++ b/kap/public/kap_lib.f90
@@ -664,6 +664,36 @@
       end subroutine get_op_mono_args
 
 
+      subroutine kap_get_control_namelist(handle, name, val, ierr)
+         use kap_def
+         use kap_ctrls_io, only: get_kap_controls
+         integer, intent(in) :: handle ! kap handle; from star, pass s% kap_handle
+         character(len=*),intent(in) :: name
+         character(len=*),intent(out) :: val
+         integer, intent(out) :: ierr
+         type (kap_General_Info), pointer :: rq
+         ierr = 0
+         call kap_ptr(handle,rq,ierr)
+         if(ierr/=0) return
+         call get_kap_controls(rq, name, val, ierr)
+
+      end subroutine kap_get_control_namelist
+
+      subroutine kap_set_control_namelist(handle, name, val, ierr)
+         use kap_def
+         use kap_ctrls_io, only: set_kap_controls
+         integer, intent(in) :: handle ! kap handle; from star, pass s% kap_handle
+         character(len=*),intent(in) :: name
+         character(len=*),intent(in) :: val
+         integer, intent(out) :: ierr
+         type (kap_General_Info), pointer :: rq
+         ierr = 0
+         call kap_ptr(handle,rq,ierr)
+         if(ierr/=0) return
+         call set_kap_controls(rq, name, val, ierr)
+
+      end subroutine kap_set_control_namelist
+
 
       end module kap_lib
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -4135,5 +4135,72 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
 
  end subroutine set_controls_for_writing
 
+   subroutine get_control(s, name, val, ierr)
+      use utils_lib, only: StrUpCase
+      type (star_info), pointer :: s
+      character(len=*),intent(in) :: name
+      character(len=*), intent(out) :: val
+      integer, intent(out) :: ierr
+
+      character(len(name)) :: upper_name
+      character(len=512) :: str
+      integer :: iounit,iostat,ind,i
+
+
+      ! First save current controls
+      call set_controls_for_writing(s, ierr)
+      if(ierr/=0) return
+
+      ! Write namelist to temporay file
+      open(newunit=iounit,status='scratch')
+      write(iounit,nml=controls)
+      rewind(iounit)
+
+      ! Namelists get written in captials
+      upper_name = StrUpCase(name)
+      val = ''
+      ! Search for name inside namelist
+      do 
+         read(iounit,'(A)',iostat=iostat) str
+         ind = index(str,trim(upper_name))
+         if( ind /= 0 ) then
+            val = str(ind+len_trim(upper_name)+1:len_trim(str)-1) ! Remove final comma and starting =
+            do i=1,len(val)
+               if(val(i:i)=='"') val(i:i) = ' '
+            end do
+            exit
+         end if
+         if(is_iostat_end(iostat)) exit
+      end do   
+
+      if(len_trim(val) == 0 .and. ind==0 ) ierr = -1
+
+      close(iounit)
+
+   end subroutine get_control
+
+   subroutine set_control(s, name, val, ierr)
+      type (star_info), pointer :: s
+      character(len=*), intent(in) :: name, val
+      character(len=len(name)+len(val)+13) :: tmp
+      integer, intent(out) :: ierr
+
+      ! First save current controls
+      call set_controls_for_writing(s, ierr)
+      if(ierr/=0) return
+
+      tmp=''
+      tmp = '&controls '//trim(name)//'='//trim(val)//' /'
+
+      ! Load into namelist
+      read(tmp, nml=controls)
+
+      ! Add to star
+      call store_controls(s, ierr)
+      if(ierr/=0) return
+
+   end subroutine set_control
+
+
  end module ctrls_io
 

--- a/star/private/pgstar_ctrls_io.f90
+++ b/star/private/pgstar_ctrls_io.f90
@@ -6766,6 +6766,5 @@
 
       end subroutine set_default_pgstar_controls
 
-
       end module pgstar_ctrls_io
 

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -3262,4 +3262,66 @@
       end subroutine star_init_star_handles
       
       
+      subroutine star_get_control_namelist(id, name, val, ierr)
+         use ctrls_io, only: get_control
+         integer, intent(in) :: id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(out) :: val
+         integer, intent(out) :: ierr
+         type (star_info), pointer :: s
+
+         ierr = 0
+         call star_ptr(id, s, ierr)
+         if(ierr/=0) return
+         call get_control(s, name, val, ierr)
+
+      end subroutine star_get_control_namelist
+
+      subroutine star_set_control_namelist(id, name, val, ierr)
+         use ctrls_io, only: set_control
+         integer, intent(in) :: id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(in) :: val
+         integer, intent(out) :: ierr
+         type (star_info), pointer :: s
+
+         ierr = 0
+         call star_ptr(id, s, ierr)
+         if(ierr/=0) return
+         call set_control(s, name, val, ierr)
+
+      end subroutine star_set_control_namelist
+
+
+      subroutine star_get_star_job_namelist(id, name, val, ierr)
+         use star_job_ctrls_io, only: get_star_job
+         integer, intent(in) :: id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(out) :: val
+         integer, intent(out) :: ierr
+         type (star_info), pointer :: s
+
+         ierr = 0
+         call star_ptr(id, s, ierr)
+         if(ierr/=0) return
+         call get_star_job(s, name, val, ierr)
+
+      end subroutine star_get_star_job_namelist
+
+      subroutine star_set_star_job_namelist(id, name, val, ierr)
+         use star_job_ctrls_io, only: set_star_job
+         integer, intent(in) :: id
+         character(len=*),intent(in) :: name
+         character(len=*),intent(in) :: val
+         integer, intent(out) :: ierr
+         type (star_info), pointer :: s
+
+         ierr = 0
+         call star_ptr(id, s, ierr)
+         if(ierr/=0) return
+         call set_star_job(s, name, val, ierr)
+
+      end subroutine star_set_star_job_namelist
+
+
       end module star_lib


### PR DESCRIPTION
This adds a get and set subroutine for each namelist
(eos, kap, controls, star_job, binary_controls, and binary_job) though pgstar namelists are not supported,
that allows setting a variable as a string, thus:

call star_get_control_namelist(id,'mesh_delta_coeff',var,ierr)
or
call star_set_control_namelist(id,'mesh_delta_coeff','1.5',ierr)

This means any code that interfaces with mesa and its modules no longer
needs to understand what a namelist is or the how to understand the various
*_info derived types (good luck any one attempting to interface with star_type).