### PR TITLE
Removes old prescription for calculating moment of inertia (equivalent to setting `fitted_fp_ft_i_rot = .true.`).

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -3911,12 +3911,10 @@
       ! If false, use slightly more complex expression
       ! that takes into account finite shell thickness.
       ! In practice, there doesn't seem to be a significant difference.
-      ! This is ignored if fitted_fp_ft_i_rot is equal to true, in which
-      ! case rotation dependent moments of inertia are computed.
 
       ! ::
 
-    simple_i_rot_flag = .true.
+    simple_i_rot_flag = .false.
 
 
       ! do_adjust_J_lost

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4003,19 +4003,6 @@
 
     recalc_mixing_info_each_substep = .false.
 
-
-      ! fitted_fp_ft_i_rot
-      ! ~~~~~~~~~~~~~~~~~~
-
-      ! Use analytical fits to the rotational corrections fp and ft, as well as the moments of inertia,
-      ! computed using the Roche potential for a point mass.
-      ! see Paxton et al. (2019), ApJs, 243, 10 for details
-
-      ! ::
-
-    fitted_fp_ft_i_rot = .true.
-
-
       ! w_div_wcrit_max
       ! ~~~~~~~~~~~~~~~
 

--- a/star/private/adjust_mass.f90
+++ b/star/private/adjust_mass.f90
@@ -1253,40 +1253,20 @@
          real(dp) :: w_div_wcrit_roche
 
          r00 = get_r_from_xh(s,k)
-         ! when using the fitted i_rot, the moment of inertia depends
+         ! The moment of inertia depends
          ! on the ratio of rotational frequency to its critical value.
          ! This ratio is computed in two different ways depending on whether
          ! omega or j_rot is known.
-         if (s% fitted_fp_ft_i_rot) then
-            if (jrot_known) then
-               w_div_wcrit_roche = w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &
-                  s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
-            else
-               w_div_wcrit_roche = w_div_w_roche_omega(r00,s% m(k),s% omega(k),s% cgrav(k), &
-                  s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
-            end if
+         if (jrot_known) then
+            w_div_wcrit_roche = w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &
+               s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
+         else
+            w_div_wcrit_roche = w_div_w_roche_omega(r00,s% m(k),s% omega(k),s% cgrav(k), &
+               s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
          end if
 
-         if (s% simple_i_rot_flag .or. s% fitted_fp_ft_i_rot .or. k < k_below_just_added) then
-            call eval_i_rot(s, k, r00, r00, r00, w_div_wcrit_roche,&
-               s% i_rot(k), s% di_rot_dlnr(k), s% di_rot_dw_div_wc(k))
-         else
-            r003 = r00*r00*r00
-            if (k == s% nz) then
-               rp13 = pow3(s% R_center)
-            else
-               rp13 = pow3(get_r_from_xh(s,k+1))
-            end if
-            if (k == 1) then
-               rm13 = r003
-            else
-               rm13 = pow3(get_r_from_xh(s,k-1))
-            end if
-            ri = pow((r003 + rp13)/2,one_third)
-            ro = pow((r003 + rm13)/2,one_third)
-            call eval_i_rot(s, k, ri, r00, ro, 0d0,&
-               s% i_rot(k), s% di_rot_dlnr(k), s% di_rot_dw_div_wc(k))
-         end if
+         call eval_i_rot(s, k, r00, r00, r00, w_div_wcrit_roche,&
+            s% i_rot(k), s% di_rot_dlnr(k), s% di_rot_dw_div_wc(k))
 
       end subroutine set1_irot
 

--- a/star/private/adjust_mesh_split_merge.f90
+++ b/star/private/adjust_mesh_split_merge.f90
@@ -172,11 +172,9 @@
          if (s% rotation_flag) then !update moments of inertia and omega
             do k=1, s% nz
                r00 = get_r_from_xh(s,k)
-               if (s% fitted_fp_ft_i_rot) then
-                  s% w_div_w_crit_roche(k) = &
-                     w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &
-                     s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
-               end if
+               s% w_div_w_crit_roche(k) = &
+                  w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &
+                  s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
                call update1_i_rot_from_xh(s, k)
                s% omega(k) = s% j_rot(k)/s% i_rot(k)
             end do

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -287,7 +287,7 @@
     simple_i_rot_flag, recalc_mixing_info_each_substep, adjust_J_fraction, &
     min_q_for_adjust_J_lost, min_J_div_delta_J, max_mdot_redo_cnt, mdot_revise_factor, &
     implicit_mdot_boost, min_years_dt_for_redo_mdot, surf_omega_div_omega_crit_limit, surf_omega_div_omega_crit_tol, &
-    fitted_fp_ft_i_rot, w_div_wcrit_max, w_div_wcrit_max2, &
+    w_div_wcrit_max, w_div_wcrit_max2, &
     fp_min, ft_min, fp_error_limit, ft_error_limit, &
     D_mix_rotation_max_logT_full_on, D_mix_rotation_min_logT_full_off, &
     set_uniform_am_nu_non_rot, uniform_am_nu_non_rot, &
@@ -1712,7 +1712,6 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% min_years_dt_for_redo_mdot = min_years_dt_for_redo_mdot
  s% surf_omega_div_omega_crit_limit = surf_omega_div_omega_crit_limit
  s% surf_omega_div_omega_crit_tol = surf_omega_div_omega_crit_tol
- s% fitted_fp_ft_i_rot = fitted_fp_ft_i_rot 
  s% w_div_wcrit_max = w_div_wcrit_max
  s% w_div_wcrit_max2 = w_div_wcrit_max2
  s% fp_min = fp_min
@@ -3386,7 +3385,6 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  min_years_dt_for_redo_mdot = s% min_years_dt_for_redo_mdot
  surf_omega_div_omega_crit_limit = s% surf_omega_div_omega_crit_limit
  surf_omega_div_omega_crit_tol = S% surf_omega_div_omega_crit_tol
- fitted_fp_ft_i_rot = s% fitted_fp_ft_i_rot 
  w_div_wcrit_max = s% w_div_wcrit_max
  w_div_wcrit_max2 = s% w_div_wcrit_max2
  fp_min = s% fp_min

--- a/star/private/hydro_rotation.f90
+++ b/star/private/hydro_rotation.f90
@@ -195,6 +195,10 @@
          include 'formats'
          if (s% use_other_eval_i_rot) then
             call s% other_eval_i_rot(s% id,ri,r00,ra,w_div_w_crit_roche, i_rot, di_rot_dlnr, di_rot_dw_div_wc)
+         else if (s% simple_i_rot_flag) then
+            i_rot = (2d0/3d0)*r00*r00
+            di_rot_dlnr = 2*i_rot
+            di_rot_dw_div_wc = 0d0
          else
             ! Compute i_rot following Paxton et al. 2019 (ApJs, 243, 10)
             w = w_div_w_crit_roche

--- a/star/private/hydro_rotation.f90
+++ b/star/private/hydro_rotation.f90
@@ -195,8 +195,8 @@
          include 'formats'
          if (s% use_other_eval_i_rot) then
             call s% other_eval_i_rot(s% id,ri,r00,ra,w_div_w_crit_roche, i_rot, di_rot_dlnr, di_rot_dw_div_wc)
-         else if (s% fitted_fp_ft_i_rot) then
-            !If fitted_fp_ft_i_rot is true, then compute i_rot following Paxton et al. 2019 (ApJs, 243, 10)
+         else
+            ! Compute i_rot following Paxton et al. 2019 (ApJs, 243, 10)
             w = w_div_w_crit_roche
             w2 = pow2(w_div_w_crit_roche)
             w3 = pow3(w_div_w_crit_roche)
@@ -214,19 +214,6 @@
             i_rot =  two_thirds*pow2(re)*B/A
             di_rot_dw_div_wc = i_rot*(2d0*dre_dw_div_wc/re + dB_dw_div_wc/B - dA_dw_div_wc/A)
             di_rot_dlnr = 2*i_rot
-         else if (s% simple_i_rot_flag) then
-            i_rot = (2d0/3d0)*r00*r00
-            di_rot_dlnr = 2*i_rot
-            di_rot_dw_div_wc = 0d0
-         else
-            ! expression for evaluation without subtraction from Langer code
-            rai=ra*ri
-            ra2=ra*ra
-            ri2=ri*ri
-            rm2=ri2+rai+ra2
-            i_rot=0.4D0*(ri2*ri2+rai*rm2+ra2*ra2)/rm2
-            di_rot_dlnr = 0d0 ! not supperted for implicit solver
-            di_rot_dw_div_wc = 0d0 ! not supperted for implicit solver
          end if
 
       end subroutine eval_i_rot
@@ -240,7 +227,7 @@
 
 !$OMP PARALLEL DO PRIVATE(k) SCHEDULE(dynamic,2)
          do k=1,s% nz
-            if (s% fitted_fp_ft_i_rot .and. .not. skip_w_div_w_crit_roche) then
+            if (.not. skip_w_div_w_crit_roche) then
                s% w_div_w_crit_roche(k) = &
                   w_div_w_roche_jrot(s% r(k),s% m(k),s% j_rot(k),s% cgrav(k), &
                      s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
@@ -320,52 +307,22 @@
 
          r00 = get_r_from_xh(s,k)
 
-         if (s% fitted_fp_ft_i_rot .or. s% simple_i_rot_flag) then
-            call eval_i_rot(s, k, r00, r00, r00, s% w_div_w_crit_roche(k), &
-               s% i_rot(k), s% di_rot_dlnr(k), s% di_rot_dw_div_wc(k))
-            return
-         end if
-
-         ! Compute the moment of inertia of a thin shell, ignoring rotational deformation
-         ! need to compute rmid at k+1 and k-1. These are respectively r_in and r_out
-         r00 = get_r_from_xh(s,k)
-         r003 = r00*r00*r00
-
-         if (k == s% nz) then
-            rp1 = s% R_center
-         else
-            rp1 = get_r_from_xh(s,k+1)
-         end if
-         rp13 = rp1*rp1*rp1
-         r_in = pow(0.5*(r003 + rp13),one_third)
-
-         if (k == 1) then
-            r_out = r00
-         else
-            rm1 = get_r_from_xh(s,k-1)
-            rm13 = rm1*rm1*rm1
-            r_out = pow(0.5*(r003 + rm13),one_third)
-         end if
-
-         call eval_i_rot(s,k,r_in,r00,r_out,0d0,&
+         call eval_i_rot(s, k, r00, r00, r00, s% w_div_w_crit_roche(k), &
             s% i_rot(k), s% di_rot_dlnr(k), s% di_rot_dw_div_wc(k))
-
       end subroutine update1_i_rot_from_xh
 
       subroutine use_xh_to_update_i_rot(s)
          type (star_info), pointer :: s
          integer :: k
-         if (s% fitted_fp_ft_i_rot) then
-            do k=1,s% nz
-               if (s% j_rot(k) /= 0d0) then
-                  s% w_div_w_crit_roche(k) = &
-                     w_div_w_roche_jrot(get_r_from_xh(s,k),s% m(k),s% j_rot(k),s% cgrav(k), &
-                        s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
-               else
-                  s% w_div_w_crit_roche(k) = 0d0
-               end if
-            end do
-         end if
+         do k=1,s% nz
+            if (s% j_rot(k) /= 0d0) then
+               s% w_div_w_crit_roche(k) = &
+                  w_div_w_roche_jrot(get_r_from_xh(s,k),s% m(k),s% j_rot(k),s% cgrav(k), &
+                     s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
+            else
+               s% w_div_w_crit_roche(k) = 0d0
+            end if
+         end do
          do k=1,s% nz
             call update1_i_rot_from_xh(s,k)
          end do
@@ -374,13 +331,11 @@
       subroutine use_xh_to_update_i_rot_and_j_rot(s)
          type (star_info), pointer :: s
          integer :: k
-         if (s% fitted_fp_ft_i_rot) then
-            do k=1,s% nz
-               s% w_div_w_crit_roche(k) = &
-                  w_div_w_roche_omega(get_r_from_xh(s,k),s% m(k),s% omega(k),s% cgrav(k), &
-                     s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
-            end do
-         end if
+         do k=1,s% nz
+            s% w_div_w_crit_roche(k) = &
+               w_div_w_roche_omega(get_r_from_xh(s,k),s% m(k),s% omega(k),s% cgrav(k), &
+                  s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
+         end do
          do k=1,s% nz
             call update1_i_rot_from_xh(s,k)
          end do
@@ -647,13 +602,9 @@
          do k = 1, s% nz - 1
 
             kap = s% opacity(k)
-            if (s% fitted_fp_ft_i_rot) then
-               ! TODO: better explain
-               ! Use equatorial radius
-               rmid = 0.5d0*(s% r_equatorial(k) + s% r_equatorial(k+1))
-            else
-              rmid = s% rmid(k)
-            end if
+            ! TODO: better explain
+            ! Use equatorial radius
+            rmid = 0.5d0*(s% r_equatorial(k) + s% r_equatorial(k+1))
             dm = s% dm(k)
             dtau = dm*kap/(pi4*rmid*rmid)
 
@@ -782,7 +733,6 @@
 
          dbg = .false. ! (s% model_number >= 5)
 
-         if (s% fitted_fp_ft_i_rot) then
 !$OMP PARALLEL DO PRIVATE(j, A_omega, fp_numerator, ft_numerator, d_A_omega_dw, d_fp_numerator_dw, d_ft_numerator_dw, w, w2, w3, w4, w5, w6, lg_one_sub_w4) SCHEDULE(dynamic,2)
             do j=1, s% nz
                !Compute fp, ft, re and rp using fits to the Roche geometry of a single star.
@@ -821,279 +771,6 @@
                !end if
             end do
 !$OMP END PARALLEL DO
-            return
-         end if
-
-         s% dfp_rot_dw_div_wc(:s% nz) = 0d0
-         s% dft_rot_dw_div_wc(:s% nz) = 0d0
-
-         veta => veta_ary
-         if (.not. have_initialized) then
-            write(*,*) 'must call init_rotation prior to getting rotation info'
-            ierr = -1; return
-         end if
-
-         kmax = 0
-
-         ft_min=1.0d0
-         fp_min=1.0d0
-         ift_in=0
-         ift_out=0
-         ifp_in=0
-         ifp_out=0
-
-         call cash_karp_work_sizes(1,liwork,lwork)
-         allocate(work(lwork),iwork(liwork))
-
-         ! main loop
-         etanu = -1.00d-20
-         tegra=0.d0
-         rnull_out=0d0
-         rho_out = rho(nz)
-         r_out = 0
-         lnr_out = 1d-10
-
-         rnorm=1.d0
-         do i_in=nz+1,2,-1
-            i_out = i_in-1
-
-            ! for each shell, compute the distortion (in terms of r0) of the shell. The
-            ! inner edge of the shell is at r(i_in), the outer edge at r(i_out). The density is
-            ! defined in the interior of each shell and needs to be interpolated when
-            ! it is needed at the edge.
-
-
-            rho_in = rho_out
-            rho_out = rho(i_out)
-            ! Compute mean density at this point
-            r_in = r_out
-            lnr_in = lnr_out
-            r_out = r(i_out)
-            lnr_out = log(r_out)
-            rom1 = xm(i_out)*0.75d0/(pi*r_out*r_out*r_out)
-            rov = rho_in/rom1
-            veta(1) = etanu
-            kanz = 1
-            dat = 1.d-04
-            dot = (lnr_out-lnr_in)/8.d0
-            dut = (lnr_out-lnr_in)/300.d0
-
-            ! E&S, A6 by integration of A7
-            rtol = 1d-6
-            atol = 1d-6
-            h = lnr_out - lnr_in
-            max_step_size = 0d0
-            rpar(1) = rov
-            call cash_karp( &
-               1, rad_fcn, lnr_in, veta, lnr_out, &
-               h, max_step_size, max_steps, &
-               rtol, atol, itol, &
-               null_solout, out_io, &
-               work, lwork, iwork, liwork, &
-               lrpar, rpar, lipar, ipar, &
-               lout, idid)
-            if (idid < 0) then
-               if (report_ierr .or. dbg) write(*,2) 'eval_fp_ft failed in integration', i_out
-               ierr = -1
-               if (dbg) stop 'eval_fp_ft'
-               exit
-            end if
-
-            eta(i_out)=veta(1)
-            xm_out=xm(i_out)
-            wr=aw(i_out)
-            etanu=veta(1)
-            r1=4.00d0*r_out
-            r2=0.01d0*r_out
-            do j = 1, 400 ! exit when have bracketed root
-               ! needs etanu,wr,r_out,xm_out; sets a
-               rpar(1) = etanu
-               rpar(2) = wr
-               rpar(3) = r_out
-               rpar(4) = xm_out
-               ipar(1) = i_out
-               ipar(2) = 0
-               ierr = 0
-               apot1 = apot_fcn(r1, dfdx, lrpar, rpar, lipar, ipar, ierr)
-               if (ierr /= 0) then
-                  if (report_ierr .or. dbg) write(*,2) 'eval_fp_ft failed in calculation of apot1', i_out
-                  if (dbg) stop 'eval_fp_ft'
-                  exit
-               end if
-               apot2 = apot_fcn(r2, dfdx, lrpar, rpar, lipar, ipar, ierr)
-               if (ierr /= 0) then
-                  if (report_ierr .or. dbg) write(*,2) 'eval_fp_ft failed in calculation of apot2', i_out
-                  if (dbg) stop 'eval_fp_ft'
-                  exit
-               end if
-               if (apot1*apot2 <= 0) exit
-               r1=4.00d0*r1
-               r2=0.01d0*r2
-            end do
-
-            if (apot1*apot2 > 0) then
-               ierr = -1
-               if (report_ierr .or. dbg) &
-                  write(*,2) 'eval_fp_ft failed in calculation of apot1, apot2', i_out, apot1, apot2
-
-
-               !exit
-               write(*,2) 'i_out', i_out
-               write(*,1) 'r_out', r_out
-               write(*,1) 'r1', r1
-               write(*,1) 'r2', r2
-               write(*,1) 'apot1', apot1
-               write(*,1) 'apot2', apot2
-               write(*,1) 'epsx', epsx
-               write(*,1) 'epsy', epsy
-               write(*,2) 'imax', imax
-               stop 'hydro_rotation: eval_fp_ft'
-
-
-               exit
-            end if
-
-            rnuv1 = safe_root_with_initial_guess( &
-               apot_fcn, r_out, r1, r2, apot1, apot2, &
-               imax, epsx, epsy, lrpar, rpar, lipar, ipar, ierr)
-            if (ierr /= 0) then
-               if (report_ierr .or. dbg) write(*,2) 'eval_fp_ft failed in calculation of apot', i_out
-               if (.not. dbg) exit
-               write(*,2) 'i_out', i_out
-               write(*,1) 'r_out', r_out
-               write(*,1) 'r1', r1
-               write(*,1) 'r2', r2
-               write(*,1) 'apot1', apot1
-               write(*,1) 'apot2', apot2
-               write(*,1) 'epsx', epsx
-               write(*,1) 'epsy', epsy
-               write(*,2) 'imax', imax
-               stop 'hydro_rotation: eval_fp_ft'
-            end if
-
-            a = rpar(5)
-            rnuv2=rnuv1
-            rnull(i_out) =  rnuv2
-            rnull_in = rnull_out
-            rnull_out = rnuv2
-
-            ! compute integral for the potential calculation. See Endal&Sofia for details
-
-            tegra = psiint(0.5d0*(rho_out+rho_in),xm_out,wr,etanu,rnull_in,rnull_out) + tegra
-
-            ! calculate g and 1/g on a quarter circle.
-            gur(i_out)=0.0d0
-            do k=1,intmax,1
-               gp(k)=gpsi(cgrav,rnull(i_out), tegra, k, a, wr, xm_out, rae)
-               gmh(k)=1.d0 / gp(k)
-               gur(i_out)=gur(i_out)+gp(k)
-            end do
-            gur(i_out)=gur(i_out)*dtheta/pi*2.d0
-            r_polar(i_out) = max(rae(1),r2)
-            r_equatorial(i_out) = min(rae(intmax),r1)
-
-            ! find spsi*<g> and spsi*<1/g>. spsi is the surface area of the equipotential
-            rrs=rae(1)*rae(1)*sint(1)
-            rrs1=rae(intmax)*rae(intmax)*sint(intmax)
-            spgp(i_out)=(gp(1)*rrs+gp (intmax)*rrs1)*dtheta2
-            spgm(i_out)=(gmh(1)*rrs+gmh(intmax)*rrs1)*dtheta2
-
-            do k=2,intmax-1
-               rrs=rae(k)*rae(k)*sint(k)
-               spgp(i_out)=spgp(i_out)+gp(k)*rrs*dtheta
-               spgm(i_out)=spgm(i_out)+gmh(k)*rrs*dtheta
-            enddo
-            spgp(i_out)=spgp(i_out)*pi4
-            spgm(i_out)=spgm(i_out)*pi4
-
-            !  Find fp and ft
-
-            fp(i_out) =  pi4 * r_out*r_out*r_out*r_out     / (cgrav(i_out)*xm_out*spgm(i_out))
-            ft(i_out) = pow2(pi4 * r_out*r_out) / (spgp(i_out)*spgm(i_out))
-
-            if (ft(i_out) < s% ft_error_limit) then
-               ierr = -1
-               if (report_ierr .or. dbg) then
-                  write(*,2) 'FT too small', i_out, ft(i_out), s% ft_error_limit
-                  stop 'eval_fp_ft'
-               end if
-               exit
-               if (ift_in == 0) ift_in=i_out
-               ift_out=i_out
-               ft_min=min(ft_min,ft(i_out))
-            elseif (ift_in /= 0) then
-               ift_in=0
-               ift_out=0
-               ft_min=1.0d0
-            endif
-
-            if (fp(i_out) < s% fp_error_limit) then
-               ierr = -1
-               if (report_ierr .or. dbg) then
-                  write(*,2) 'FP too small', i_out, fp(i_out), s% fp_error_limit
-                  stop 'eval_fp_ft'
-               end if
-               exit
-               if (ifp_in == 0) ifp_in=i_out
-               ifp_out=i_out
-               fp_min=min(fp_min,fp(i_out))
-            elseif (ifp_in /= 0) then
-               ifp_in=0
-               ifp_out=0
-               fp_min=1.0d0
-            endif
-
-            ft(i_out)=max(s% ft_min, min(ft(i_out),1.d0))
-            fp(i_out)=max(s% fp_min, min(fp(i_out),1.d0))
-
-         end do
-
-         deallocate(work, iwork)
-
-         ft(1)=ft(2)
-         fp(1)=fp(2)
-         ft(nz)=ft(nz-1)
-         fp(nz)=fp(nz-1)
-
-         contains
-
-         real(dp) function apot_fcn(rnu, df, lrpar, rpar, lipar, ipar, ierr) result(f)
-            ! returns with ierr = 0 if was able to evaluate f and df/dx at x
-            ! if df/dx not available, it is okay to set it to 0
-            integer, intent(in) :: lrpar, lipar
-            real(dp), intent(in) :: rnu
-            real(dp), intent(out) :: df
-            integer, intent(inout), pointer :: ipar(:) ! (lipar)
-            real(dp), intent(inout), pointer :: rpar(:) ! (lrpar)
-            integer, intent(out) :: ierr
-            real(dp) :: wrnu2, a2, a3, dadrn, c1, rfk, drfk
-            real(dp) :: etanu,wr,r,xm,a,r_psi
-            real(dp), parameter :: c0=1.0d0/3.0d0
-            real(dp), parameter :: c2=2.0d0/35.0d0
-            real(dp), parameter :: c3=3.0d0*c2
-            include 'formats'
-            ierr = 0
-            c1 = 0.6d0*cgrav(1)
-            etanu = rpar(1)
-            wr = rpar(2)
-            r = rpar(3)
-            xm = rpar(4)
-            wrnu2=wr*wr*rnu*rnu/(c1*xm*(2.d0+etanu)) ! (1/3)*da/dr0
-            a=rnu*wrnu2 ! E&S, A10  NOTE: typo in paper where it gives r0^2 instead of r0^3.
-            a2=a*a
-            a3=a2*a
-            drfk= pow(max(1.0d-20,1.d0+0.6d0*a2-c2*a3),c0) ! dr_psi/dr0|A, E&S A13
-            r_psi=rnu*drfk ! r_psi(r0)
-            rfk=r_psi - r ! r_psi(r0) - true_r_psi
-            dadrn=wrnu2*a ! (1/3)*a*da/dr0
-            drfk=drfk+rnu/(drfk*drfk)*(1.2d0*dadrn-c3*a*dadrn) ! dr_psi/dr0
-            ! divide by r to normalize
-            f = rfk / r
-            df = drfk / r
-            if (rfk > 1.d30) f=1.d30
-            if (df > 1.d30) df=1.d30
-            rpar(5) = a
-         end function apot_fcn
 
       end subroutine eval_fp_ft
 

--- a/star/private/mesh_adjust.f90
+++ b/star/private/mesh_adjust.f90
@@ -2163,11 +2163,9 @@
 
          s% j_rot(k) = j_tot/dq_sum
          r00 = get_r_from_xh(s,k)
-         if (s% fitted_fp_ft_i_rot) then
-            s% w_div_w_crit_roche(k) = &
-               w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &
-               s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
-         end if
+         s% w_div_w_crit_roche(k) = &
+            w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &
+            s% w_div_wcrit_max, s% w_div_wcrit_max2, s% w_div_wc_flag)
          call update1_i_rot_from_xh(s, k)
          s% omega(k) = s% j_rot(k)/s% i_rot(k)
 

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -2607,7 +2607,7 @@
          integer, intent(in) :: k
          real(dp) :: Ledd, gamma_factor, Lrad_div_Ledd, rmid, r003, rp13
          include 'formats'
-         if (s% fitted_fp_ft_i_rot .and. s% rotation_flag) then
+         if (s% rotation_flag) then
             ! Use equatorial radius (at center of cell by volume)
             r003 = s% r_equatorial(k)*s% r_equatorial(k)*s% r_equatorial(k)
             if (k < s% nz) then

--- a/star/test_suite/dev_high_rot_darkening/inlist_high_rot_darkening
+++ b/star/test_suite/dev_high_rot_darkening/inlist_high_rot_darkening
@@ -33,8 +33,6 @@
     ! until central hydrogen abundance is 0.69 (from the starting value of 0.7). This is
     ! to have an unambiguously defined starting point for the definition of the initial
     ! rotation rate
-
-    !warning, turn off pgstar if you also turn off fitted_fp_ft_i_rot
     pgstar_flag = .false.
 
     change_initial_w_div_wc_flag = .true.
@@ -58,7 +56,6 @@
     gold_solver_iters_timestep_limit = 20
     gold2_solver_iters_timestep_limit = 20
 
-    fitted_fp_ft_i_rot = .true.
 
     scale_max_correction = 0.05d0
     ignore_species_in_max_correction = .true.

--- a/star/test_suite/dev_ppisn/src/run_star_extras.f90
+++ b/star/test_suite/dev_ppisn/src/run_star_extras.f90
@@ -366,7 +366,6 @@
          call star_ptr(id, s, ierr)
          if (ierr /= 0) return
 
-         if (s% fitted_fp_ft_i_rot) then
 !$OMP PARALLEL DO PRIVATE(j, A_omega, fp_numerator, ft_numerator, d_A_omega_dw, d_fp_numerator_dw, d_ft_numerator_dw, w, w2, w3, w4, w5, w6, lg_one_sub_w4) SCHEDULE(dynamic,2)
             do j=1, s% nz
                !Compute fp, ft, re and rp using fits to the Roche geometry of a single star.
@@ -400,7 +399,6 @@
                end if
             end do
 !$OMP END PARALLEL DO
-         end if
 
          if (s% u_flag) then
             !make fp and ft 1 in the outer 0.001 mass fraction of the star. softly turn to zero from the outer 0.002

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -1001,7 +1001,6 @@
          real(dp) :: min_years_dt_for_redo_mdot, mdot_crit_boost_factor, &
             mdot_revise_factor, implicit_mdot_boost
          real(dp) :: surf_omega_div_omega_crit_limit, surf_omega_div_omega_crit_tol
-         logical :: fitted_fp_ft_i_rot
          real(dp) :: w_div_wcrit_max, w_div_wcrit_max2
          real(dp) :: fp_min, ft_min, fp_error_limit, ft_error_limit
 


### PR DESCRIPTION
Suggested by @orlox in #331, as we were only keeping the old prescription around in case the new one ran into trouble. Given that it's been two years since the change (MESA 11701) it may be time to remove it.

@orlox Could you take a look and make sure I didn't mess anything up in the process? I'll wait for you to sign off and for testhub to clear before merging.