### PR TITLE
Avoiding ambiguity in what it means to "subtract" neutrino losses

### DIFF
--- a/net/public/net_lib.f90
+++ b/net/public/net_lib.f90
@@ -636,7 +636,7 @@
          real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
          real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
 
-         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after subtract reaction neutrinos
+         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including reaction neutrinos
          real(dp), intent(out) :: d_eps_nuc_dT
          real(dp), intent(out) :: d_eps_nuc_dRho
          real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos) 
@@ -895,7 +895,7 @@
          real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
          real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
 
-         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after subtract reaction neutrinos
+         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including reaction neutrinos
          real(dp), intent(out) :: d_eps_nuc_dT
          real(dp), intent(out) :: d_eps_nuc_dRho
          real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos) 
@@ -995,7 +995,7 @@
          real(dp), intent(in) :: weak_rate_factor
          real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
          real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
-         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after subtract reaction neutrinos
+         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including reaction neutrinos
          real(dp), intent(out) :: d_eps_nuc_dT
          real(dp), intent(out) :: d_eps_nuc_dRho
          real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos) 

--- a/net/public/net_lib.f90
+++ b/net/public/net_lib.f90
@@ -636,7 +636,7 @@
          real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
          real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
 
-         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including reaction neutrinos
+         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including losses from reaction neutrinos
          real(dp), intent(out) :: d_eps_nuc_dT
          real(dp), intent(out) :: d_eps_nuc_dRho
          real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos) 

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -237,7 +237,7 @@
    !eps_nuc_minus_non_nuc_neu
    !eps_nuc_start
 
-   !eps_nuc ! ergs/g/sec from nuclear reactions (reaction neutrinos subtracted)
+   !eps_nuc ! ergs/g/sec from nuclear reactions (including losses to reaction neutrinos)
    !log_abs_eps_nuc
    !d_lnepsnuc_dlnd
    !d_epsnuc_dlnd

--- a/star/other/other_net_get.f90
+++ b/star/other/other_net_get.f90
@@ -70,7 +70,7 @@
          real(dp), intent(in) :: weak_rate_factor
          real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
          real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
-         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after subtract reaction neutrinos
+         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including losses to reaction neutrinos
          real(dp), intent(out) :: d_eps_nuc_dT
          real(dp), intent(out) :: d_eps_nuc_dRho
          real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos)       

--- a/star/rsp2_utils/profile_columns.list
+++ b/star/rsp2_utils/profile_columns.list
@@ -79,7 +79,7 @@
    ye ! average charge per baryon = proton fraction
    opacity ! opacity measured at center of zone
    log_opacity ! log10(opacity)
-   eps_nuc ! ergs/g/sec from nuclear reactions (neutrinos subtracted)
+   eps_nuc ! ergs/g/sec from nuclear reactions (including losses to reaction neutrinos)
    non_nuc_neu ! non-nuclear-reaction neutrino losses
    !nonnucneu_plas ! plasmon neutrinos (for collective reactions like gamma_plasmon => nu_e + nubar_e)
    !nonnucneu_brem ! bremsstrahlung (for reactions like e- + (z,a) => e- + (z,a) + nu + nubar)

--- a/star_data/public/star_data_def.inc
+++ b/star_data/public/star_data_def.inc
@@ -905,7 +905,7 @@
             real(dp), intent(in) :: weak_rate_factor
             real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
             real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
-            real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after subtract reaction neutrinos
+            real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning including losses by reaction neutrinos
             real(dp), intent(out) :: d_eps_nuc_dT
             real(dp), intent(out) :: d_eps_nuc_dRho
             real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos)       

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -227,14 +227,14 @@
 
       real(dp), pointer :: eps_nuc(:) ! sum of reaction_eps_nuc for all reactions in net
          ! thermal ergs per gram per second from nuclear reactions
-         ! (nuclear reaction neutrinos have been subtracted)
+         ! (including losses to neutrinos produced in the reactions)
       real(dp), pointer :: eps_nuc_categories(:,:) ! (num_categories, nz)
       real(dp), pointer :: d_epsnuc_dlnd(:) ! partial wrt density
       real(dp), pointer :: d_epsnuc_dlnT(:) ! partial wrt temperature
       real(dp), pointer :: d_epsnuc_dx(:,:)  ! (species,nz)
          ! d_ex_dx(j, k) is partial of eps_nuc(k) wrt species(j)
 
-      real(dp), pointer :: eps_nuc_neu_total(:) ! erg/gm/sec as neutrinos from nuclear reactions
+      real(dp), pointer :: eps_nuc_neu_total(:) ! erg/gm/sec, (positive) energy lost to neutrinos in nuclear reactions
 
       real(dp), pointer :: dxdt_nuc(:,:) ! (species,nz)
          ! rate of change of mass fractions from nuclear reactions
@@ -259,7 +259,7 @@
       real(dp), pointer :: luminosity_by_category(:,:) ! (num_categories, nz)
 
       ! non-nuclear-reaction neutrino losses
-      real(dp), pointer :: non_nuc_neu(:)
+      real(dp), pointer :: non_nuc_neu(:) ! positive
       real(dp), pointer :: d_nonnucneu_dlnd(:)
       real(dp), pointer :: d_nonnucneu_dlnT(:)
    


### PR DESCRIPTION
While trying to work out which way to [fix](67e15faf84d52bcb4c303aceaf261b8a014aac8a) an inconsistency in how `burning_regions` were determined, I found the docs quite confusing about which variables already include neutrino losses. The confusing statements are usually something along the lines of "subtracting" neutrino losses, where I was confused about whether that meant the reaction neutrino losses were a *negative* number being added back in (by subtracting the negative variable) or a *positive* number being accounted for where they hadn't already.

This PR is to fix these. I'm open to changes on the wording or anyone adding other potentially confusing occurrences.

I'm tagging @rjfarmer and @fxt as the owners of `neu`, `net` and `rates`, and therefore the people who probably have the strongest opinions about what everything means.