### PR TITLE
Fixes for rotation (Radec's and Mathieu's issues)

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -3918,10 +3918,10 @@
     smooth_D_SSI = 0
     smooth_D_ES = 0
     smooth_D_GSF = 0
-    smooth_D_ST = 3
-    smooth_nu_ST = 3
-    smooth_D_omega = 3
-    smooth_am_nu_rot = 3
+    smooth_D_ST = 0
+    smooth_nu_ST = 0
+    smooth_D_omega = 0
+    smooth_am_nu_rot = 0
 
 
       ! ST_time_smooth_frac
@@ -3932,7 +3932,7 @@
 
       ! ::
 
-    ST_time_smooth_frac = 0.2d0
+    ST_time_smooth_frac = 0.5d0
 
 
       ! simple_i_rot_flag

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -3932,7 +3932,7 @@
 
       ! ::
 
-    ST_time_smooth_frac = 0.8d0
+    ST_time_smooth_frac = 0.2d0
 
 
       ! simple_i_rot_flag

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -3924,15 +3924,18 @@
     smooth_am_nu_rot = 0
 
 
-      ! ST_time_smooth_frac
+      ! ST_angsmt
       ! ~~~~~~~~~~~~~~~~
+      ! ST_angsml
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! Temporal smoothing of ST coefficients. if /=1d0, ST mixing coefficient is
-      ! set to ST_time_smooth_frac*new_val+(1-ST_time_smooth_frac)*old_val
+      ! Temporal smoothing of ST coefficients.
+      ! See rotation_mix_info.f90 for details
 
       ! ::
 
-    ST_time_smooth_frac = 0.5d0
+    ST_angsmt = 0.2d0
+    ST_angsml = 1d-3
 
 
       ! simple_i_rot_flag

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -3924,6 +3924,17 @@
     smooth_am_nu_rot = 3
 
 
+      ! ST_time_smooth_frac
+      ! ~~~~~~~~~~~~~~~~
+
+      ! Temporal smoothing of ST coefficients. if /=1d0, ST mixing coefficient is
+      ! set to ST_time_smooth_frac*new_val+(1-ST_time_smooth_frac)*old_val
+
+      ! ::
+
+    ST_time_smooth_frac = 0.8d0
+
+
       ! simple_i_rot_flag
       ! ~~~~~~~~~~~~~~~~~
 

--- a/star/private/adjust_mesh.f90
+++ b/star/private/adjust_mesh.f90
@@ -439,6 +439,12 @@
             s% prev_mesh_dq(k) = prv% prev_mesh_dq(k)
          end do
 
+         ! restore ST info (for time smoothing)
+         do k=1, s% prev_mesh_nz
+            s% prev_mesh_D_ST_start(k) = prv% prev_mesh_D_ST_start(k)
+            s% prev_mesh_nu_ST_start(k) = prv% prev_mesh_nu_ST_start(k)
+         end do
+
          if (s% show_mesh_changes) then
             ! note: do_mesh_adjust can change cell_type from unchanged to revised
             ! so need to recount

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -1108,6 +1108,8 @@
             if (failed('brunt_B')) exit
             call do1(s% unsmoothed_brunt_B, c% unsmoothed_brunt_B)
             if (failed('unsmoothed_brunt_B')) exit
+            call do1(s% smoothed_brunt_B, c% smoothed_brunt_B)
+            if (failed('smoothed_brunt_B')) exit
             
             call do1(s% RTI_du_diffusion_kick, c% RTI_du_diffusion_kick)
             if (failed('RTI_du_diffusion_kick')) exit

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -394,11 +394,6 @@
          if (failed('omega_old')) return
          call do1D(s, s% j_rot_old, nz, action, ierr)
          if (failed('j_rot_old')) return
-         ! These are needed for time-smoothing of ST mixing
-         call do1D(s, s% D_ST_start_old, nz, action, ierr)
-         if (failed('D_ST_old')) return
-         call do1D(s, s% nu_ST_start_old, nz, action, ierr)
-         if (failed('nu_ST_old')) return
          ierr = 0
 
          contains
@@ -811,10 +806,6 @@
             if (failed('D_ST')) exit
             call do1(s% nu_ST, c% nu_ST)
             if (failed('nu_ST')) exit
-            call do1(s% D_ST_start, c% D_ST_start)
-            if (failed('D_ST_start')) exit
-            call do1(s% nu_ST_start, c% nu_ST_start)
-            if (failed('nu_ST_start')) exit
             call do1(s% omega_shear, c% omega_shear)
             if (failed('omega_shear')) exit
 
@@ -822,6 +813,12 @@
             if (failed('dynamo_B_r')) exit
             call do1(s% dynamo_B_phi, c% dynamo_B_phi)
             if (failed('dynamo_B_phi')) exit
+
+            !for ST time smoothing
+            call do1(s% D_ST_start, c% D_ST_start)
+            if (failed('D_ST_start')) exit
+            call do1(s% nu_ST_start, c% nu_ST_start)
+            if (failed('nu_ST_start')) exit
 
             call do1(s% opacity, c% opacity)
             if (failed('opacity')) exit
@@ -1383,6 +1380,11 @@
             if (failed('prev_mesh_mlt_vc')) exit
             call do1(s% prev_mesh_dq, c% prev_mesh_dq)
             if (failed('prev_mesh_dq')) exit
+            ! These are needed for time-smoothing of ST mixing
+            call do1(s% prev_mesh_D_ST_start, c% prev_mesh_D_ST_start)
+            if (failed('prev_mesh_D_ST_start')) exit
+            call do1(s% prev_mesh_nu_ST_start, c% prev_mesh_nu_ST_start)
+            if (failed('prev_mesh_nu_ST_start')) exit
 
             if (s% fill_arrays_with_NaNs) s% need_to_setvars = .true.
             return

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -384,6 +384,8 @@
          if (failed('xh_old')) return
          call do2D(s, s% xa_old, species, nz, action, ierr)
          if (failed('xa_old')) return
+         call do1D(s, s% q_old, nz, action, ierr)
+         if (failed('q_old')) return
          call do1D(s, s% dq_old, nz, action, ierr)
          if (failed('dq_old')) return
          call do1D(s, s% mlt_vc_old, nz, action, ierr)
@@ -392,6 +394,11 @@
          if (failed('omega_old')) return
          call do1D(s, s% j_rot_old, nz, action, ierr)
          if (failed('j_rot_old')) return
+         ! These are needed for time-smoothing of ST mixing
+         call do1D(s, s% D_ST_old, nz, action, ierr)
+         if (failed('D_ST_old')) return
+         call do1D(s, s% nu_ST_old, nz, action, ierr)
+         if (failed('nu_ST_old')) return
          ierr = 0
 
          contains

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -395,9 +395,9 @@
          call do1D(s, s% j_rot_old, nz, action, ierr)
          if (failed('j_rot_old')) return
          ! These are needed for time-smoothing of ST mixing
-         call do1D(s, s% D_ST_old, nz, action, ierr)
+         call do1D(s, s% D_ST_start_old, nz, action, ierr)
          if (failed('D_ST_old')) return
-         call do1D(s, s% nu_ST_old, nz, action, ierr)
+         call do1D(s, s% nu_ST_start_old, nz, action, ierr)
          if (failed('nu_ST_old')) return
          ierr = 0
 
@@ -811,6 +811,10 @@
             if (failed('D_ST')) exit
             call do1(s% nu_ST, c% nu_ST)
             if (failed('nu_ST')) exit
+            call do1(s% D_ST_start, c% D_ST_start)
+            if (failed('D_ST_start')) exit
+            call do1(s% nu_ST_start, c% nu_ST_start)
+            if (failed('nu_ST_start')) exit
             call do1(s% omega_shear, c% omega_shear)
             if (failed('omega_shear')) exit
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -281,7 +281,7 @@
     D_visc_factor, D_DSI_factor, D_SH_factor, D_SSI_factor, D_ES_factor, D_GSF_factor, D_ST_factor, &
     am_nu_non_rotation_factor, skip_rotation_in_convection_zones, am_nu_DSI_factor, am_nu_SH_factor,&
     am_nu_SSI_factor, am_nu_ES_factor, am_nu_GSF_factor, am_nu_ST_factor, am_nu_visc_factor, smooth_am_nu_rot, &
-    ST_time_smooth_frac, am_nu_omega_rot_factor, am_nu_omega_non_rot_factor, am_nu_j_rot_factor, am_nu_j_non_rot_factor, &
+    ST_angsml, ST_angsmt, am_nu_omega_rot_factor, am_nu_omega_non_rot_factor, am_nu_j_rot_factor, am_nu_j_non_rot_factor, &
     smooth_nu_ST, smooth_D_ST, smooth_D_SH, smooth_D_DSI, smooth_D_ES, smooth_D_SSI, smooth_D_GSF, smooth_D_omega, &
     do_adjust_J_lost, premix_omega, angular_momentum_error_warn, angular_momentum_error_retry, &
     simple_i_rot_flag, recalc_mixing_info_each_substep, adjust_J_fraction, &
@@ -1693,7 +1693,8 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% smooth_D_ES = smooth_D_ES
  s% smooth_D_omega = smooth_D_omega
  s% smooth_am_nu_rot = smooth_am_nu_rot
- s% ST_time_smooth_frac = ST_time_smooth_frac
+ s% ST_angsmt = ST_angsmt
+ s% ST_angsml = ST_angsml
 
  s% simple_i_rot_flag = simple_i_rot_flag
  s% do_adjust_J_lost = do_adjust_J_lost
@@ -3362,7 +3363,8 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  smooth_D_ES = s% smooth_D_ES
  smooth_D_omega = s% smooth_D_omega
  smooth_am_nu_rot = s% smooth_am_nu_rot
- ST_time_smooth_frac = s% ST_time_smooth_frac
+ ST_angsmt = s% ST_angsmt
+ ST_angsml = s% ST_angsml
 
  simple_i_rot_flag = s% simple_i_rot_flag
  do_adjust_J_lost = s% do_adjust_J_lost

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -281,7 +281,7 @@
     D_visc_factor, D_DSI_factor, D_SH_factor, D_SSI_factor, D_ES_factor, D_GSF_factor, D_ST_factor, &
     am_nu_non_rotation_factor, skip_rotation_in_convection_zones, am_nu_DSI_factor, am_nu_SH_factor,&
     am_nu_SSI_factor, am_nu_ES_factor, am_nu_GSF_factor, am_nu_ST_factor, am_nu_visc_factor, smooth_am_nu_rot, &
-    am_nu_omega_rot_factor, am_nu_omega_non_rot_factor, am_nu_j_rot_factor, am_nu_j_non_rot_factor, &
+    ST_time_smooth_frac, am_nu_omega_rot_factor, am_nu_omega_non_rot_factor, am_nu_j_rot_factor, am_nu_j_non_rot_factor, &
     smooth_nu_ST, smooth_D_ST, smooth_D_SH, smooth_D_DSI, smooth_D_ES, smooth_D_SSI, smooth_D_GSF, smooth_D_omega, &
     do_adjust_J_lost, premix_omega, angular_momentum_error_warn, angular_momentum_error_retry, &
     simple_i_rot_flag, recalc_mixing_info_each_substep, adjust_J_fraction, &
@@ -1693,6 +1693,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% smooth_D_ES = smooth_D_ES
  s% smooth_D_omega = smooth_D_omega
  s% smooth_am_nu_rot = smooth_am_nu_rot
+ s% ST_time_smooth_frac = ST_time_smooth_frac
 
  s% simple_i_rot_flag = simple_i_rot_flag
  s% do_adjust_J_lost = do_adjust_J_lost
@@ -3361,6 +3362,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  smooth_D_ES = s% smooth_D_ES
  smooth_D_omega = s% smooth_D_omega
  smooth_am_nu_rot = s% smooth_am_nu_rot
+ ST_time_smooth_frac = s% ST_time_smooth_frac
 
  simple_i_rot_flag = s% simple_i_rot_flag
  do_adjust_J_lost = s% do_adjust_J_lost

--- a/star/private/evolve.f90
+++ b/star/private/evolve.f90
@@ -2262,7 +2262,7 @@
       integer function finish_step(id, ierr)
          ! returns keep_going or terminate
          ! if don't return keep_going, then set result_reason to say why.
-         use evolve_support, only: output
+         use evolve_support, only: output, store_ST_info
          use profile, only: do_save_profiles
          use history, only: write_history_info
          use utils_lib, only: free_iounit, number_iounits_allocated
@@ -2343,6 +2343,10 @@
          s% screening_mode_value = -1 ! force a new lookup for next step
          s% doing_first_model_of_run = .false.
 
+         call store_ST_info(s, ierr)
+         if (ierr /= 0) then
+            call mesa_error(__FILE__,__LINE__,'finish_step')
+         end if
 
          contains
 

--- a/star/private/evolve.f90
+++ b/star/private/evolve.f90
@@ -2262,7 +2262,7 @@
       integer function finish_step(id, ierr)
          ! returns keep_going or terminate
          ! if don't return keep_going, then set result_reason to say why.
-         use evolve_support, only: output, store_ST_info
+         use evolve_support, only: output
          use profile, only: do_save_profiles
          use history, only: write_history_info
          use utils_lib, only: free_iounit, number_iounits_allocated
@@ -2342,11 +2342,6 @@
 
          s% screening_mode_value = -1 ! force a new lookup for next step
          s% doing_first_model_of_run = .false.
-
-         call store_ST_info(s, ierr)
-         if (ierr /= 0) then
-            call mesa_error(__FILE__,__LINE__,'finish_step')
-         end if
 
          contains
 

--- a/star/private/evolve.f90
+++ b/star/private/evolve.f90
@@ -1851,6 +1851,16 @@
                s% prev_mesh_species_or_nvar_hydro_changed = .false.
             end do
             s% prev_mesh_nz = s% nz
+            ! also store ST information for time smoothing
+            if (s% have_ST_start_info) then
+               do k=1, s% nz
+                  s% prev_mesh_D_ST_start(k) = s% D_ST_start(k)
+                  s% prev_mesh_nu_ST_start(k) = s% nu_ST_start(k)
+               end do
+               s% prev_mesh_have_ST_start_info = .true.
+            else
+               s% prev_mesh_have_ST_start_info = .false.
+            end if
          end if
          
          if (s% okay_to_remesh) then

--- a/star/private/evolve_support.f90
+++ b/star/private/evolve_support.f90
@@ -65,12 +65,6 @@
             
             call copy_to_old(s% mlt_vc, s% mlt_vc_old, ierr)
             if (ierr /= 0) return
-            
-            call copy_to_old(s% D_ST_start, s% D_ST_start_old, ierr)
-            if (ierr /= 0) return
-            
-            call copy_to_old(s% nu_ST_start, s% nu_ST_start_old, ierr)
-            if (ierr /= 0) return
 
             call enlarge_if_needed_2(s% xh_old,s% nvar_hydro,nz,nz_alloc_extra,ierr)
             if (ierr /= 0) return

--- a/star/private/evolve_support.f90
+++ b/star/private/evolve_support.f90
@@ -54,6 +54,9 @@
             call copy_to_old(s% dq, s% dq_old, ierr)
             if (ierr /= 0) return
 
+            call copy_to_old(s% q, s% q_old, ierr)
+            if (ierr /= 0) return
+
             call copy_to_old(s% omega, s% omega_old, ierr)
             if (ierr /= 0) return
 
@@ -61,6 +64,12 @@
             if (ierr /= 0) return
             
             call copy_to_old(s% mlt_vc, s% mlt_vc_old, ierr)
+            if (ierr /= 0) return
+            
+            call copy_to_old(s% D_ST, s% D_ST_old, ierr)
+            if (ierr /= 0) return
+            
+            call copy_to_old(s% nu_ST, s% nu_ST_old, ierr)
             if (ierr /= 0) return
 
             call enlarge_if_needed_2(s% xh_old,s% nvar_hydro,nz,nz_alloc_extra,ierr)

--- a/star/private/evolve_support.f90
+++ b/star/private/evolve_support.f90
@@ -31,7 +31,7 @@
       implicit none
 
       private
-      public :: set_current_to_old, new_generation, output, output_to_file, store_ST_info
+      public :: set_current_to_old, new_generation, output, output_to_file
 
 
       contains
@@ -66,10 +66,10 @@
             call copy_to_old(s% mlt_vc, s% mlt_vc_old, ierr)
             if (ierr /= 0) return
             
-            call copy_to_old(s% D_ST, s% D_ST_old, ierr)
+            call copy_to_old(s% D_ST_start, s% D_ST_start_old, ierr)
             if (ierr /= 0) return
             
-            call copy_to_old(s% nu_ST, s% nu_ST_old, ierr)
+            call copy_to_old(s% nu_ST_start, s% nu_ST_start_old, ierr)
             if (ierr /= 0) return
 
             call enlarge_if_needed_2(s% xh_old,s% nvar_hydro,nz,nz_alloc_extra,ierr)
@@ -156,50 +156,6 @@
          end subroutine copy_to_old
 
       end subroutine new_generation
-
-      subroutine store_ST_info(s, ierr)
-         use utils_lib
-         type (star_info), pointer :: s
-         integer, intent(out) :: ierr
-         integer :: j, nz
-
-         include 'formats'
-
-         ierr = 0
-         nz = s% nz
-         
-         if (.not. s% rsp_flag) then
-
-            call copy_to_old(s% D_ST, s% D_ST_old, ierr)
-            if (ierr /= 0) return
-            
-            call copy_to_old(s% nu_ST, s% nu_ST_old, ierr)
-            if (ierr /= 0) return
-         
-         end if
-
-         contains
-
-         subroutine copy_to_old(ptr, ptr_old, ierr)
-            real(dp), pointer, dimension(:) :: ptr, ptr_old
-            integer, intent(out) :: ierr
-            logical :: first_time
-            ierr = 0
-            first_time = (.not. associated(ptr_old))
-            call realloc_if_needed_1(ptr_old,nz,nz_alloc_extra,ierr)
-            if (ierr /= 0) return
-            if (s% fill_arrays_with_NaNs) then
-               call fill_with_NaNs(ptr_old)
-            else if (s% zero_when_allocate) then
-               ptr_old(:) = 0
-            else if (first_time) then
-               ptr_old(1:nz) = -9d99
-            end if
-            do j = 1, s% nz
-               ptr_old(j) = ptr(j)
-            end do
-         end subroutine copy_to_old
-      end subroutine store_ST_info
 
       subroutine set_current_to_old(s)
          use star_utils, only: total_angular_momentum, set_m_and_dm, set_dm_bar, set_qs

--- a/star/private/init.f90
+++ b/star/private/init.f90
@@ -240,6 +240,9 @@
          nullify(s% prev_mesh_omega)
          nullify(s% prev_mesh_dq)
 
+         nullify(s% D_ST_start)
+         nullify(s% prev_mesh_D_ST_start)
+
          nullify(s% other_star_info)
 
          nullify(s% bcyclic_odd_storage)
@@ -516,6 +519,9 @@
          s% okay_to_set_mixing_info = .true.
          s% okay_to_set_mlt_vc = .false. ! not until have set mlt_cv_old
          s% have_mlt_vc = .false.
+
+         s% have_ST_start_info = .false.
+         s% prev_mesh_have_ST_start_info = .false.
 
          s% just_wrote_terminal_header = .false.
          s% doing_relax = .false.

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -146,7 +146,8 @@
          read(iounit, iostat=ierr) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
-            s% D_ST_start(1:nz), s% nu_ST_start(1:nz) ! needed for ST time smoothing
+            s% D_ST_start(1:nz), s% nu_ST_start(1:nz), & ! needed for ST time smoothing
+            s% have_ST_start_info
 
          call read_part_number(iounit)
          if (failed('rsp_num_periods')) return

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -145,7 +145,8 @@
 
          read(iounit, iostat=ierr) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
-            s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz)
+            s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
+            s% D_ST(1:nz), s% D_ST_old(1:nz), s% nu_ST(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
 
          call read_part_number(iounit)
          if (failed('rsp_num_periods')) return

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -146,7 +146,7 @@
          read(iounit, iostat=ierr) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
-            s% D_ST(1:nz), s% D_ST_old(1:nz), s% nu_ST(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
+            s% D_ST_old(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
 
          call read_part_number(iounit)
          if (failed('rsp_num_periods')) return

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -146,7 +146,7 @@
          read(iounit, iostat=ierr) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
-            s% D_ST_old(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
+            s% D_ST_start(1:nz), s% nu_ST_start(1:nz) ! needed for ST time smoothing
 
          call read_part_number(iounit)
          if (failed('rsp_num_periods')) return

--- a/star/private/photo_out.f90
+++ b/star/private/photo_out.f90
@@ -83,7 +83,7 @@
          write(iounit) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
-            s% D_ST_old(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
+            s% D_ST_start(1:nz), s% nu_ST_start(1:nz) ! needed for ST time smoothing
 
          call write_part_number(iounit)
          write(iounit) &

--- a/star/private/photo_out.f90
+++ b/star/private/photo_out.f90
@@ -83,7 +83,8 @@
          write(iounit) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
-            s% D_ST_start(1:nz), s% nu_ST_start(1:nz) ! needed for ST time smoothing
+            s% D_ST_start(1:nz), s% nu_ST_start(1:nz), & ! needed for ST time smoothing
+            s% have_ST_start_info
 
          call write_part_number(iounit)
          write(iounit) &

--- a/star/private/photo_out.f90
+++ b/star/private/photo_out.f90
@@ -82,7 +82,8 @@
          call write_part_number(iounit)
          write(iounit) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
-            s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz)
+            s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
+            s% D_ST(1:nz), s% D_ST_old(1:nz), s% nu_ST(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
 
          call write_part_number(iounit)
          write(iounit) &

--- a/star/private/photo_out.f90
+++ b/star/private/photo_out.f90
@@ -83,7 +83,7 @@
          write(iounit) &
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
-            s% D_ST(1:nz), s% D_ST_old(1:nz), s% nu_ST(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
+            s% D_ST_old(1:nz), s% nu_ST_old(1:nz) ! needed for ST time smoothing
 
          call write_part_number(iounit)
          write(iounit) &

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -142,7 +142,7 @@
          s% eps_mdot(1:nz) = 0
          call fill_ad_with_zeros(s% eps_grav_ad,1,-1)
          s% ergs_error(1:nz) = 0
-         s% have_ST_start_info = .false.
+         if (.not. restart) s% have_ST_start_info = .false.
          if (s% do_element_diffusion) s% edv(:,1:nz) = 0
          if (s% u_flag) then
             call fill_ad_with_zeros(s% u_face_ad,1,-1)

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -142,6 +142,7 @@
          s% eps_mdot(1:nz) = 0
          call fill_ad_with_zeros(s% eps_grav_ad,1,-1)
          s% ergs_error(1:nz) = 0
+         s% have_ST_start_info = .false.
          if (s% do_element_diffusion) s% edv(:,1:nz) = 0
          if (s% u_flag) then
             call fill_ad_with_zeros(s% u_face_ad,1,-1)

--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -4116,6 +4116,7 @@
 
          s% doing_relax = .false.
          s% need_to_setvars = .true. ! just to be safe
+         s% have_ST_start_info = .false. ! for ST time smoothing
 
          if (.not. (s% termination_code == t_relax_finished_okay .or. &
                     s% termination_code == t_extras_check_model)) ierr = -1

--- a/star/private/rotation_mix_info.f90
+++ b/star/private/rotation_mix_info.f90
@@ -211,9 +211,10 @@
                               end do
                               ! linear interpolation
                               alfa = (s% m(k)/s% mstar_old - s% q_old(k0))/(s% q_old(k0-1)-s% q_old(k0))
-                              D_ST_old = (alfa-1)*s% D_ST_old(k0) + alfa*s% D_ST_old(k0-1)
-                              nu_ST_old = (alfa-1)*s% nu_ST_old(k0) + alfa*s% nu_ST_old(k0-1)
+                              D_ST_old = (1d0-alfa)*s% D_ST_old(k0) + alfa*s% D_ST_old(k0-1)
+                              nu_ST_old = (1d0-alfa)*s% nu_ST_old(k0) + alfa*s% nu_ST_old(k0-1)
                            end if
+                           !write(*,*) "check D_ST",k, s%m(k), s% D_ST(k), D_ST_old, alfa
                            s% D_ST(k) = s% ST_time_smooth_frac*s% D_ST(k) + (1-s% ST_time_smooth_frac)*D_ST_old
                            s% nu_ST(k) = s% ST_time_smooth_frac*s% nu_ST(k) + (1-s% ST_time_smooth_frac)*nu_ST_old
                         end do

--- a/star/private/rotation_mix_info.f90
+++ b/star/private/rotation_mix_info.f90
@@ -590,7 +590,7 @@
             do i = 2, nz-1
                ri0 = (rho(i)*delta(i)/P(i))*pow2(dlnR_domega(i)*grav(i))
                Ri_T(i) = ri0*max(0d0,-gradT_sub_grada(i)) ! turn off Ri_T in convection zones
-               Ri_mu(i) = ri0*f_mu*s% gradL_composition_term(i)
+               Ri_mu(i) = ri0*f_mu*s% smoothed_brunt_B(i)
             end do
             Ri_T(1) = 0; Ri_T(nz) = 0
             Ri_mu(1) = 0; Ri_mu(nz) = 0
@@ -651,7 +651,7 @@
                         ve0(i) = grada(i)*omega(i)*omega(i)*r(i)*r(i)*r(i)*L(i)*bracket_term/denom
                      end if
                      ve_mu(i) = (scale_height(i)/t_kh(i))* &
-                              (f_mu*s% gradL_composition_term(i))/(gradT_sub_grada(i))
+                              (f_mu*s% smoothed_brunt_B(i))/(gradT_sub_grada(i))
                   end if
                   if (is_bad(ve0(i))) then
                      if (s% stop_for_bad_nums) then
@@ -672,7 +672,7 @@
                      write(*,2) 'grada(i)', i, grada(i)
                      write(*,2) 'gradT(i)', i, gradT(i)
                      write(*,2) 'gradT_sub_grada(i)', i, gradT_sub_grada(i)
-                     write(*,2) 's% gradL_composition_term(i)', i, s% gradL_composition_term(i)
+                     write(*,2) 's% smoothed_brunt_B(i)', i, s% smoothed_brunt_B(i)
                      write(*,2) 'omega(i)', i, omega(i)
                      write(*,2) 's% omega(i)', i, s% omega(i)
                      write(*,2) '2*r**2*eps_nuc/L', i, 2*r(i)*r(i)*eps_nuc(i)/max(1d0,L(i))

--- a/star/private/rotation_mix_info.f90
+++ b/star/private/rotation_mix_info.f90
@@ -214,7 +214,7 @@
                               D_ST_old = (1d0-alfa)*s% D_ST_old(k0) + alfa*s% D_ST_old(k0-1)
                               nu_ST_old = (1d0-alfa)*s% nu_ST_old(k0) + alfa*s% nu_ST_old(k0-1)
                            end if
-                           !write(*,*) "check D_ST",k, s%m(k), s% D_ST(k), D_ST_old, alfa
+                           !write(*,*) "check D_ST",k, s% D_ST(k), D_ST_old, alfa, s% m(k), s% q_old(k0)*s%mstar_old, s% q_old(k0-1)*s%mstar_old
                            s% D_ST(k) = s% ST_time_smooth_frac*s% D_ST(k) + (1-s% ST_time_smooth_frac)*D_ST_old
                            s% nu_ST(k) = s% ST_time_smooth_frac*s% nu_ST(k) + (1-s% ST_time_smooth_frac)*nu_ST_old
                         end do

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -202,6 +202,7 @@
                s% D_ST_start(k) = s% D_ST(k)
                s% nu_ST_start(k) = s% nu_ST(k)
             end do
+            s% have_ST_start_info = .true.
          end if
 
          if (.not. s% j_rot_flag) &

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -196,6 +196,14 @@
 
          if (do_struct_burn_mix /= keep_going) return
 
+         if (s% rotation_flag) then
+            ! store ST mixing info for time smoothing
+            do k=1, s% nz
+               s% D_ST_start(k) = s% D_ST(k)
+               s% nu_ST_start(k) = s% nu_ST(k)
+            end do
+         end if
+
          if (.not. s% j_rot_flag) &
             do_struct_burn_mix = do_mix_omega(s,dt)
 

--- a/star/test_suite/15M_dynamo/src/run_star_extras.f90
+++ b/star/test_suite/15M_dynamo/src/run_star_extras.f90
@@ -109,8 +109,8 @@
          write(*,1) 'avg from 3.0 to 3.4 Msun'
          call check('logT', avg_val(s% lnT)/ln10, 7.2d0, 8.1d0)
          call check('logRho', avg_val(s% lnd)/ln10, 1d0, 3.0d0)
-         call check('log j_rot', safe_log10(avg_val(s% j_rot)), 15.0d0, 17.0d0)
-         call check('D_ES', safe_log10(avg_val(s% D_ES)), 3.0d0, 6.5d0) 
+         call check('log j_rot', safe_log10(avg_val(s% j_rot)), 14.5d0, 15.5d0)
+         call check('D_ES', safe_log10(avg_val(s% D_ES)), 1d0, 5d0) 
          call check('D_ST', safe_log10(avg_val(s% D_ST)), 0.12d0, 12.0d0)
          call check('nu_ST', safe_log10(avg_val(s% nu_ST)), 8.0d0, 12.0d0)
          write(*,'(A)')

--- a/star/test_suite/magnetic_braking/src/run_star_extras.f90
+++ b/star/test_suite/magnetic_braking/src/run_star_extras.f90
@@ -68,7 +68,7 @@
          integer, intent(out) :: ierr
 
          real(dp) :: bfield, vinf, eta, factor
-         real(dp) :: j_dot, check_delta_j, delta_j
+         real(dp) :: v_rot, omega_crit, j_dot, check_delta_j, delta_j
          real(dp) :: residual_jdot, torque, j_average
 
          type (star_info), pointer :: s
@@ -93,13 +93,16 @@
          factor = 0d0
          j_average = 0d0
 
+         omega_crit = star_surface_omega_crit(id, ierr) ! this forces a call to set_surf_avg_rotation_info to ensure things are up
+                                                        ! to date with the state
+         if (ierr /= 0) return
+         v_rot = s% v_rot_avg_surf
+
          ! Calculate total angular momentum
-
          j_tot = dot_product(s% j_rot(1:s% nz),s% dm_bar(1:s% nz)) ! g cm^2/s Total Stellar Angular Momentum Content
-
         
-         if ((s% mstar_dot /= 0) .and. (j_tot .gt. 1d50) .and. (s% v_rot_avg_surf  .gt. 0.8d5)) then ! Only 'brake' when mass is lost and star has non-negligible amount of angular momentum
-           write(*,*) 'j_tot: ', j_tot, s% omega_avg_surf, s% v_rot_avg_surf/1d5 
+         if ((s% mstar_dot /= 0) .and. (j_tot .gt. 1d50) .and. (v_rot  .gt. 0.8d5)) then ! Only 'brake' when mass is lost and star has non-negligible amount of angular momentum
+           write(*,*) 'j_tot: ', j_tot, s% omega(1), v_rot/1d5
           !Calculate V_inf of stellar wind (e.g. Vinf = 1.92 Vesc, see Lamers & Cassinelli 2000)
           !N.B. This is good for line-driven winds in hot stars. For different types of Vinf = Vesc might be a better choice?
           vinf = 1.92d0 * sqrt(2.0d0 * standard_cgrav * s% mstar / (s% photosphere_r * Rsun))

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -990,7 +990,7 @@
          integer :: smooth_D_DSI, smooth_D_SH, smooth_D_SSI, &
             smooth_D_ES, smooth_D_GSF, smooth_D_ST, smooth_nu_ST, smooth_D_omega, smooth_am_nu_rot
 
-         real(dp) :: ST_time_smooth_frac
+         real(dp) :: ST_angsml, ST_angsmt ! uset for ST time smoothing. See rotation_mix_info.f90 for details
 
          real(dp) :: adjust_J_fraction, min_q_for_adjust_J_lost, &
             min_J_div_delta_J

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -990,6 +990,8 @@
          integer :: smooth_D_DSI, smooth_D_SH, smooth_D_SSI, &
             smooth_D_ES, smooth_D_GSF, smooth_D_ST, smooth_nu_ST, smooth_D_omega, smooth_am_nu_rot
 
+         real(dp) :: ST_time_smooth_frac
+
          real(dp) :: adjust_J_fraction, min_q_for_adjust_J_lost, &
             min_J_div_delta_J
          logical :: simple_i_rot_flag, do_adjust_J_lost, &

--- a/star_data/public/star_data_step_input.inc
+++ b/star_data/public/star_data_step_input.inc
@@ -34,6 +34,10 @@
       real(dp), pointer, dimension(:) :: j_rot ! (nz)
         ! j_rot(k) is specific angular momentum at outer edge of cell k; = i_rot*omega
       real(dp), pointer, dimension(:) :: omega ! (nz)
+
+      real(dp), pointer, dimension(:) :: D_ST_start, prev_mesh_D_ST_start ! For time smoothing
+      real(dp), pointer, dimension(:) :: nu_ST_start, prev_mesh_nu_ST_start
+      logical :: have_ST_start_info, prev_mesh_have_ST_start_info
       
       ! convection
       real(dp), pointer, dimension(:) :: mlt_vc ! (nz)

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -484,6 +484,7 @@
       real(dp), pointer :: brunt_B(:) ! (at points)
          ! this is the Brassard et al B := -(chiY/chiT)*(dlnY/dlnP)
       real(dp), pointer :: unsmoothed_brunt_B(:) ! pre-smoothing
+      real(dp), pointer :: smoothed_brunt_B(:) ! with smoothing applied for gradL
          
          
       ! asteroseismology info

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -181,8 +181,8 @@
       real(dp), pointer :: D_ES(:) ! Eddington-Sweet circulation 
       real(dp), pointer :: D_GSF(:) ! Goldreich-Schubert-Fricke instability
        
-      real(dp), pointer :: D_ST(:) ! Spruit dynamo mixing diffusivity
-      real(dp), pointer :: nu_ST(:) ! Spruit dynamo effective viscosity 
+      real(dp), pointer :: D_ST(:), D_ST_old(:) ! Spruit dynamo mixing diffusivity
+      real(dp), pointer :: nu_ST(:), nu_ST_old(:) ! Spruit dynamo effective viscosity 
       real(dp), pointer :: omega_shear(:) ! max(1d-30,min(1d30,abs(domega_dlnr(k)/omega(k))))
 
       real(dp), pointer :: dynamo_B_r(:) ! magnetic field (Gauss)

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -181,8 +181,10 @@
       real(dp), pointer :: D_ES(:) ! Eddington-Sweet circulation 
       real(dp), pointer :: D_GSF(:) ! Goldreich-Schubert-Fricke instability
        
-      real(dp), pointer :: D_ST(:), D_ST_old(:) ! Spruit dynamo mixing diffusivity
-      real(dp), pointer :: nu_ST(:), nu_ST_old(:) ! Spruit dynamo effective viscosity 
+      real(dp), pointer :: D_ST(:) ! Spruit dynamo mixing diffusivity
+      real(dp), pointer :: nu_ST(:) ! Spruit dynamo effective viscosity 
+      real(dp), pointer :: D_ST_start(:), D_ST_start_old(:) ! For time smoothing
+      real(dp), pointer :: nu_ST_start(:), nu_ST_start_old(:) 
       real(dp), pointer :: omega_shear(:) ! max(1d-30,min(1d30,abs(domega_dlnr(k)/omega(k))))
 
       real(dp), pointer :: dynamo_B_r(:) ! magnetic field (Gauss)

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -183,8 +183,6 @@
        
       real(dp), pointer :: D_ST(:) ! Spruit dynamo mixing diffusivity
       real(dp), pointer :: nu_ST(:) ! Spruit dynamo effective viscosity 
-      real(dp), pointer :: D_ST_start(:), D_ST_start_old(:) ! For time smoothing
-      real(dp), pointer :: nu_ST_start(:), nu_ST_start_old(:) 
       real(dp), pointer :: omega_shear(:) ! max(1d-30,min(1d30,abs(domega_dlnr(k)/omega(k))))
 
       real(dp), pointer :: dynamo_B_r(:) ! magnetic field (Gauss)


### PR DESCRIPTION
These changes do two things:

- Include the effect of the Brunt on the calculation of rotational diffusion coefficients when using the Schwarzschild criterion. This is the problem Radec reported with large differences in rotational mixing between Ledoux and Schwarzschild.
- Restore time smoothing of the ST diffusion coefficients. This solves Mathieu's issue.

Attached is a comparison of a model of a 30 Msun star at 0.1 critical (adapted from Mathieu's example) ran with 15140 and HEAD of the pm/rotation_fixes branch. I also run the simulations with and without time smoothing, and it gives me consistent results. To do the time smoothing one needs to interpolate the diffusion coefficient from the old mesh in the previous step, I wrote down a simple linear interpolant in rotation_mix_info for that purpose. If anyone wants to switch that to use the built in interpolants, please go ahead (but be sure that the attached results are still reproducible).

![comparison](https://user-images.githubusercontent.com/537248/145842980-a759f216-a291-49ad-bfc6-f9f88fbd85cd.png)
[final_tests.tar.gz](https://github.com/MESAHub/mesa/files/7705015/final_tests.tar.gz)
