### PR TITLE
Create basic build action for Linux

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,62 @@
+name: Build on Linux with SDK
+
+on: [push, pull_request, release]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: ["sdk"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+        with:
+          lfs: true
+      - name: Checkout LFS objects
+        run: |
+          git lfs checkout
+
+      - name: Install dependencies Linux
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install wget binutils make perl libx11-6 libx11-dev zlib1g zlib1g-dev tcsh
+        shell: bash
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            mesasdk-x86_64-linux-20.12.1.tar.gz
+          key: ${{ runner.os }}-${{ hashFiles('mesasdk-x86_64-linux-20.12.1.tar.gz') }}
+
+      - name: Get SDK ${{ runner.os }}
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+            wget -q https://zenodo.org/record/4587206/files/mesasdk-x86_64-linux-20.12.1.tar.gz
+        shell: bash
+
+      - name: Unpack SDK ${{ runner.os }}
+        run: |
+            tar xvf mesasdk-x86_64-linux-20.12.1.tar.gz
+        shell: bash
+
+      - name: Compile
+        shell: bash
+        run: |
+          # Linux runners have 2 cores
+          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+          export OMP_NUM_THREADS=2
+          export NPROCS=2
+          export "MESASDK_ROOT=$(readlink -f mesasdk)"
+          source "${MESASDK_ROOT}/bin/mesasdk_init.sh"
+          export "MESA_DIR=$(readlink -f ./)"
+          # Everything is run as root so we need to disable the root check in the install script
+          sed -i 's/\${EUID:-\$(id -u)}/1/' install
+          ./install
+          if [ ! -f lib/libbinary.a ]; then
+            exit 1
+          fi


### PR DESCRIPTION
This adds a GitHub Action that tests that MESA compiles with the SDK under the latest version of Ubuntu. Most of the work to set this up was actually done by @rjfarmer, who tried to set something up to integrate with TestHub. If the TestHub integration starts working, we should disable this.

Note that this is *not* the same as installing MESA on a clean install of Ubuntu because the GitHub runner environment has other software installed too.

Comments welcome, and feel free to tweak the script directly. There are also GitHub runners available for Mac OS 11 and 10.5 but I leave that to a Mac expert.