### PR TITLE
fixing outdated energy equation option in running MESA documentation

### DIFF
--- a/docs/source/using_mesa/inlist_example
+++ b/docs/source/using_mesa/inlist_example
@@ -28,7 +28,7 @@
 &controls
 
 ! energy
-      use_dedt_form_of_energy_eqn = .true.
+      energy_eqn_option = 'dedt'
 ! mass and metallicity
       initial_mass = 2.0
       initial_z = 2d-2

--- a/docs/source/using_mesa/running.rst
+++ b/docs/source/using_mesa/running.rst
@@ -276,7 +276,7 @@ do this your inlist might look like:
      ! see star/defaults/controls.defaults
 
      ! options for energy conservation (see MESA V, Section 3)
-     use_dedt_form_of_energy_eqn = .true.
+     energy_eqn_option = 'dedt'
      use_gold_tolerances = .true.
    
      ! configure mass loss on RGB & AGB


### PR DESCRIPTION
In getting started with MESA, I noticed that in the loading a model section of the running mesa documentation, an outdated option syntax was used. I believe I've replaced it with the correct option.