### PR TITLE
adding sentence about ending inlist file with carriage return

### DIFF
--- a/docs/source/using_mesa/running.rst
+++ b/docs/source/using_mesa/running.rst
@@ -286,9 +286,11 @@ do this your inlist might look like:
      Dutch_scaling_factor = 0.8
    
    / ! end of controls namelist
+   
 
 If you want to try this out, save the preceding text as a file named
-``inlist_load`` in your work directory. Then edit your main inlist
+``inlist_load`` in your work directory. Make sure your file ends with 
+a carriage return (to an empty line). Then edit your main inlist
 file so that it will use ``inlist_load`` instead of ``inlist_project``
 everywhere within inlist (i.e., extra_star_job_inlist1_name and
 extra_controls_inlist1_name).

--- a/docs/source/using_mesa/running.rst
+++ b/docs/source/using_mesa/running.rst
@@ -290,7 +290,7 @@ do this your inlist might look like:
 
 If you want to try this out, save the preceding text as a file named
 ``inlist_load`` in your work directory. Make sure your file ends with 
-a carriage return (to an empty line). Then edit your main inlist
+a blank new line. Then edit your main inlist
 file so that it will use ``inlist_load`` instead of ``inlist_project``
 everywhere within inlist (i.e., extra_star_job_inlist1_name and
 extra_controls_inlist1_name).


### PR DESCRIPTION
I spent a few hours trying to debug starting the inlist for starting from an existing model only to finally discover the issue was that my file didn't end with a blank line (I'm sure this is obvious to regular fortran users). The inlist modeled in the documentation doesn't include this return and I'm not sure how to get the RST to render it, so I added a sentence to try to head off this issue.