### PR TITLE
Simple fix to 're' sometimes not finding the most recent photo

### DIFF
--- a/star/work/re
+++ b/star/work/re
@@ -3,7 +3,7 @@
 photo_directory=photos
 
 function most_recent_photo {
-    ls -t "$photo_directory" | head -1
+    \ls -tp "$photo_directory" | grep -v / | head -1
 }
 
 if [ $# -eq 0 ]
@@ -15,7 +15,7 @@ fi
 
 if [ -z "$photo" ] || ! [ -f "$photo_directory/$photo" ]
 then
-    echo "specified photo does not exist"
+    echo "specified photo ($photo) does not exist"
     exit 1
 fi
 


### PR DESCRIPTION
I was having some problems with `re` not being able to automatically find the most recent photo.  The fix was simple, and should not change anything for people who did not have these issues.

- ` \ls` to force the "non-aliased" `ls` command.  I like to alias `ls=ls -S` in my bash_profile to always sort by file size, but this will mess-up the search for the most recent photo with the `-t` option.

- Add the `-p` option to add a "/" to directories, then `grep -v /` to ignore those and only list files. I sometimes store photos for backup in e.g. `photos/runA/x500`, so I just want to ignore these directories and only look at files to find the most recent photo.

- Printing `($photo)` in case of problems to help debugging.