### PR TITLE
Pre compute some powers of (integer) Z

### DIFF
--- a/eos/private/skye_coulomb.f90
+++ b/eos/private/skye_coulomb.f90
@@ -1,5 +1,6 @@
 module skye_coulomb
    use math_lib
+   use math_def
    use auto_diff
    use const_def, only: dp, PI, rbohr, qe, amu, me
    use skye_coulomb_solid
@@ -269,8 +270,8 @@ module skye_coulomb
       ! Output
       type(auto_diff_real_2var_order3) :: F
 
-      GAMI = pow(Zion,5d0/3d0) * qe * qe / (rbohr * boltzm * temp * RS) ! ion Coulomb parameter Gamma_i
-      COTPT=sqrt(3d0 * me_in_amu / CMI)/pow(Zion,7d0/6d0) ! auxiliary coefficient
+      GAMI = pre_z(int(Zion))% z5_3 * qe * qe / (rbohr * boltzm * temp * RS) ! ion Coulomb parameter Gamma_i
+      COTPT=sqrt(3d0 * me_in_amu / CMI)/pre_z(int(Zion))%z7_6 ! auxiliary coefficient
       TPT=GAMI*COTPT/sqrt(RS)                   ! T_p/T
 
       if ((LIQSOL == 0 .and. GAMI < max_gamma_for_liquid) .or. (LIQSOL == 1 .and. GAMI > min_gamma_for_solid)) then
@@ -299,7 +300,7 @@ module skye_coulomb
          temp_boundary%d1val1 = 1d0 
 
          ! Compute new (differentiable) Gamma and TPT at the boundary
-         g = pow(Zion,5d0/3d0) * qe * qe / (rbohr * boltzm * temp_boundary * RS) ! ion Coulomb parameter Gamma_i
+         g = pre_z(int(Zion))% z5_3 * qe * qe / (rbohr * boltzm * temp_boundary * RS) ! ion Coulomb parameter Gamma_i
          tp=g*COTPT/sqrt(RS)                  ! T_p/T
 
          ! Compute boundary free energy

--- a/eos/private/skye_coulomb_liquid.f90
+++ b/eos/private/skye_coulomb_liquid.f90
@@ -1,5 +1,6 @@
 module skye_coulomb_liquid
    use math_lib
+   use math_def
    use auto_diff
    use const_def
 
@@ -81,21 +82,21 @@ module skye_coulomb_liquid
          type(auto_diff_real_2var_order3) :: TPT, g, g1, g2, h, gr, xr
          type(auto_diff_real_2var_order3) :: F
 
-         a = 1.11d0 * pow(Z, 0.475d0)
-         b = 0.2d0 + 0.078d0 * pow2(log(Z))
-         nu = 1.16d0 + 0.08d0 * log(Z)
-         cDH = (Z / sqrt(3d0)) * (pow(1d0 + Z, 1.5d0) - 1d0 - pow(Z, 1.5d0))
-         cTF = (18d0 / 175d0) * pow(12d0 / pi, 2d0/3d0) * pow(Z, 7d0/3d0) * (1d0 - pow(Z, -1d0/3d0) + 0.2d0 * pow(Z, -0.5d0))
+         a = 1.11d0 * pre_z(int(Z))% z0p475
+         b = 0.2d0 + 0.078d0 * pre_z(int(Z))% sqlogz
+         nu = 1.16d0 + 0.08d0 * pre_z(int(Z))% logz
+         cDH = (Z / sqrt(3d0)) * (pre_z(int(Z))% zp1_3_2 - 1d0 - pre_z(int(Z))% z3_2)
+         cTF = (18d0 / 175d0) * pow(12d0 / pi, 2d0/3d0) * pre_z(int(Z))% z7_3 * (1d0 - pre_z(int(Z))% zm1_3 + 0.2d0 * pre_z(int(Z))% zm1_2)
 
-         g = ge * pow(Z, 5d0/3d0)
-         COTPT = sqrt(3d0 * me_in_amu / mi) / pow(Z, 7d0/6d0)
+         g = ge * pre_z(int(Z))% z5_3
+         COTPT = sqrt(3d0 * me_in_amu / mi) / pre_z(int(Z))% z7_6
          TPT = g * COTPT / sqrt(rs)
 
          xr = pow(9d0 * pi / 4d0, 1d0/3d0) * fine / rs
          gr = sqrt(1d0 + pow2(xr))
          g1 = 1d0 + 0.78d0 * sqrt(ge / z) / (21d0 + ge * pow3(Z / rs))
-         g2 = 1d0 + ((Z - 1d0) / 9d0) * (1d0 + 1d0 / (0.001d0 * pow2(Z) + 2d0 * ge)) * (pow3(rs) / (1d0 + 6d0 * pow2(rs)))
-         h = (1d0 + 0.2d0 * pow2(xr)) / (1d0 + 0.18d0 * xr * pow(Z, -0.25d0) + 0.37d0 * pow(Z, -0.5d0) * pow2(xr) + 0.2d0 * pow2(xr))
+         g2 = 1d0 + ((Z - 1d0) / 9d0) * (1d0 + 1d0 / (0.001d0 * pre_z(int(Z))% z2 + 2d0 * ge)) * (pow3(rs) / (1d0 + 6d0 * pow2(rs)))
+         h = (1d0 + 0.2d0 * pow2(xr)) / (1d0 + 0.18d0 * xr * pre_z(int(Z))% zm1_4 + 0.37d0 * pre_z(int(Z))% zm1_2 * pow2(xr) + 0.2d0 * pow2(xr))
 
          F = -ge * (cDH * sqrt(ge) + cTF * a * pow(ge, nu) * g1 * h) / (1d0 + (b * sqrt(ge) + a * g2 * pow(ge, nu) / rs) / gr)
 

--- a/eos/private/skye_coulomb_solid.f90
+++ b/eos/private/skye_coulomb_solid.f90
@@ -1,5 +1,6 @@
 module skye_coulomb_solid
    use math_lib
+   use math_def
    use auto_diff
    use const_def
 
@@ -163,22 +164,22 @@ module skye_coulomb_solid
          type(auto_diff_real_2var_order3) :: TPT, x, f_inf, A, Q, xr, eta, supp, g, alpha, Fliq, gr, switch
          type(auto_diff_real_2var_order3) :: F
 
-         s = 1d0 / (1d0 + 1d-2 * pow(log(Z), 1.5d0) + 0.097d0 / pow2(Z))
-         b1 = 1d0 - 1.1866d0 * pow(Z, -0.267d0) + 0.27d0 / Z
-         b2 = 1d0 + (2.25d0 * pow(Z, -1d0/3d0)) * (1d0 + 0.684d0 * pow5(Z) + 0.222d0 * pow6(Z)) / (1d0 + 0.222d0 * pow6(Z))
-         b3 = 41.5d0 / (1d0 + log(Z))
-         b4 = 0.395d0 * log(Z) + 0.347d0 * pow(Z, -1.5d0)
+         s = 1d0 / (1d0 + 1d-2 * pre_z(int(Z))% logz_3_2 + 0.097d0 / pre_z(int(Z))% z2)
+         b1 = 1d0 - 1.1866d0 * pre_z(int(Z))% zm0p267 + 0.27d0 / Z
+         b2 = 1d0 + (2.25d0 * pre_z(int(Z))% zm1_3) * (1d0 + 0.684d0 * pre_z(int(Z))% z5 + 0.222d0 * pre_z(int(Z))% z6) / (1d0 + 0.222d0 * pre_z(int(Z))% z6)
+         b3 = 41.5d0 / (1d0 + pre_z(int(Z))% logz)
+         b4 = 0.395d0 * pre_z(int(Z))% logz + 0.347d0 * pre_z(int(Z))% zm3_2
 
-         g = ge * pow(Z, 5d0/3d0)
+         g = ge * pre_z(int(Z))% z5_3
 
-         COTPT = sqrt(3d0 * me_in_amu / mi) / pow(Z, 7d0/6d0)
+         COTPT = sqrt(3d0 * me_in_amu / mi) / pre_z(int(Z))% z7_6
          TPT = g * COTPT / sqrt(RS)
          supp = safe_exp(-pow2(0.205d0 * TPT))
          Q = sqrt((pow2(0.205d0 * TPT) + log(1d0 + supp)) / log(eulernum - (eulernum - 2d0) * supp))
 
          xr = pow(9d0 * pi / 4d0, 1d0/3d0) * fine / rs
          A = (b3 + 17.9d0 * pow2(xr)) / (1d0 + b4 * pow2(xr))
-         f_inf = aTF * pow(Z, 2d0/3d0) * b1 * sqrt(1d0 + b2 / pow2(xr))
+         f_inf = aTF * pre_z(int(Z))% z2_3 * b1 * sqrt(1d0 + b2 / pow2(xr))
 
          F = -f_inf * g * (1d0 + A * pow(Q / g, s))
 

--- a/math/make/makefile_base
+++ b/math/make/makefile_base
@@ -13,9 +13,9 @@ include $(MESA_DIR)/utils/makefile_header
 # SOURCES
 
 ifeq ($(USE_CRMATH),YES)
-     SRCS = math_lib_crmath.f90 math_io.f90 math_pown.f90
+     SRCS = math_lib_crmath.f90 math_io.f90 math_pown.f90 math_def.f90
 else
-     SRCS = math_lib_intrinsic.f90 math_io.f90 math_pown.f90
+     SRCS = math_lib_intrinsic.f90 math_io.f90 math_pown.f90 math_def.f90
 endif
 
 ifeq ($(USE_SHARED), YES)
@@ -53,6 +53,7 @@ clean:
 
 install:
 	@$(CP_IF_NEWER) math_lib.mod $(MESA_DIR)/include
+	@$(CP_IF_NEWER) math_def.mod $(MESA_DIR)/include
 	@$(CP_IF_NEWER) $(LIB) $(MESA_DIR)/lib
 
 nodeps : $(.DEFAULT_GOAL)
@@ -96,6 +97,8 @@ SRC_PATH = $(MOD_PUBLIC_DIR):$(MOD_PRIVATE_DIR)
 vpath %.f90 $(SRC_PATH)
 
 vpath %.mod $(MESA_DIR)/include
+
+vpath %.inc $(SRC_PATH)
 
 NODEPS = $(or $(filter nodeps,$(MAKECMDGOALS)),$(filter clean,$(MAKECMDGOALS)))
 

--- a/math/public/math_def.f90
+++ b/math/public/math_def.f90
@@ -1,0 +1,63 @@
+! ***********************************************************************
+!
+!   Copyright (C) 2010-2022  The MESA Team
+!
+!   MESA is free software; you can use it and/or modify
+!   it under the combined terms and restrictions of the MESA MANIFESTO
+!   and the GNU General Library Public License as published
+!   by the Free Software Foundation; either version 2 of the License,
+!   or (at your option) any later version.
+!
+!   You should have received a copy of the MESA MANIFESTO along with
+!   this software; if not, it is available at the mesa website:
+!   http://mesa.sourceforge.net/
+!
+!   MESA is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+!   See the GNU Library General Public License for more details.
+!
+!   You should have received a copy of the GNU Library General Public License
+!   along with this software; if not, write to the Free Software
+!   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+!
+! ***********************************************************************
+
+
+module math_def
+
+   ! Uses
+   use const_def
+ 
+   ! No implicit typing
+ 
+   implicit none
+
+   integer, parameter :: max_precomp_ints = 1000
+
+   type precomp_int
+      real(dp) :: z2,z3,z4,z5,z6,z7,z8
+
+      real(dp) :: z1_3, z2_3, z4_3, z5_3, z7_3
+      real(dp) :: zm1_3, zm2_3, zm4_3, zm5_3, zm7_3
+
+      real(dp) :: z7_6
+
+      real(dp) :: z1_5, z2_5, z3_5, z4_5
+
+      real(dp) :: z1_2, z3_2, zm1_2, zm1_4, zm3_2
+
+      real(dp) :: logz, sqlogz ! pow2(log(z))
+      real(dp) :: logz_3_2 ! pow(log(Z), 1.5d0)
+
+      real(dp) :: z0p475, zp1_3_2, zm0p267
+
+   end type precomp_int
+
+
+   type(precomp_int),dimension(max_precomp_ints) :: pre_z ! Set in the math_lib
+
+
+
+
+end module math_def

--- a/math/public/math_lib_crmath.f90
+++ b/math/public/math_lib_crmath.f90
@@ -32,6 +32,7 @@ module math_lib
   use math_pown
   use math_io
   use utils_lib
+  use math_def
 
   use crmath
 
@@ -129,6 +130,8 @@ contains
     call crmath_init()
 
     ln10_m = log(10._dp)
+
+    call precompute_some_zs()
 
   end subroutine math_init
 
@@ -277,5 +280,9 @@ contains
     end if
 
   end function pow_r_
+
+
+  include 'precompute_zs.inc'
+
 
 end module math_lib

--- a/math/public/math_lib_intrinsic.f90
+++ b/math/public/math_lib_intrinsic.f90
@@ -148,6 +148,8 @@ contains
 
     ln10_m = LOG(10._dp)
 
+    call precompute_some_zs()
+
   end subroutine math_init
 
   !****
@@ -351,5 +353,8 @@ contains
     atanpi_x = ATAN(x)/PI
 
   end function atanpi_
+
+  include 'precompute_zs.inc'
+
 
 end module math_lib

--- a/math/public/precompute_zs.inc
+++ b/math/public/precompute_zs.inc
@@ -1,0 +1,52 @@
+subroutine  precompute_some_zs()
+    integer :: int_i
+    real(dp) :: i
+ 
+      do int_i=1,max_precomp_ints
+         i = real(int_i,kind=dp)
+
+         pre_z(int_i)% z2 = i*i
+         pre_z(int_i)% z3 = pre_z(int_i)% z2 * i
+         pre_z(int_i)% z4 = pre_z(int_i)% z3 * i
+         pre_z(int_i)% z5 = pre_z(int_i)% z4 * i
+         pre_z(int_i)% z6 = pre_z(int_i)% z5 * i
+         pre_z(int_i)% z7 = pre_z(int_i)% z6 * i
+         pre_z(int_i)% z8 = pre_z(int_i)% z7 * i
+
+         pre_z(int_i)% z1_3 = pow(i,1d0/3d0)
+         pre_z(int_i)% z2_3 = pow(i,2d0/3d0)
+         pre_z(int_i)% z4_3 = pow(i,4d0/3d0)
+         pre_z(int_i)% z5_3 = pow(i,5d0/3d0)
+         pre_z(int_i)% z7_3 = pow(i,7d0/3d0)
+
+         pre_z(int_i)% zm1_3 = pow(i,-1d0/3d0)
+         pre_z(int_i)% zm2_3 = pow(i,-2d0/3d0)
+         pre_z(int_i)% zm4_3 = pow(i,-4d0/3d0)
+         pre_z(int_i)% zm5_3 = pow(i,-5d0/3d0)
+         pre_z(int_i)% zm7_3 = pow(i,-7d0/3d0)
+
+         pre_z(int_i)% z7_6 = pow(i,7d0/6d0)
+
+         pre_z(int_i)% z1_5 = pow(i,1d0/5d0)
+         pre_z(int_i)% z2_5 = pow(i,2d0/5d0)
+         pre_z(int_i)% z3_5 = pow(i,3d0/5d0)
+         pre_z(int_i)% z4_5 = pow(i,4d0/5d0)
+
+         pre_z(int_i)% logz = log(i)
+         pre_z(int_i)% sqlogz = pow2(pre_z(int_i)% logz)
+         pre_z(int_i)% logz_3_2 = pow(pre_z(int_i)% logz, 3d0/2d0)
+
+         pre_z(int_i)% z1_2 = pow(i,0.5d0)
+         pre_z(int_i)% z3_2 = pow(i,1.5d0)
+
+         pre_z(int_i)% zm1_2 = pow(i,-0.5d0)
+         pre_z(int_i)% zm1_4 = pow(i,-0.25d0)
+         pre_z(int_i)% zm3_2 = pow(i,-3d0/2d0)
+
+         pre_z(int_i)% z0p475 = pow(i,0.475d0)
+         pre_z(int_i)% zp1_3_2 = pow(1d0 + i, 3d0/2d0)
+         pre_z(int_i)% zm0p267 = pow(i, -0.267d0)
+
+      end do
+ 
+ end subroutine  precompute_some_zs

--- a/rates/private/screen_chugunov.f90
+++ b/rates/private/screen_chugunov.f90
@@ -29,6 +29,7 @@
       use math_lib
       use const_def
       use rates_def, only: screen_info
+      use math_def
    
       implicit none
       private
@@ -64,42 +65,11 @@
    
       real(dp), parameter :: h0fitlim = 300d0, h0fit0 = 295d0
       real(dp), parameter :: deltah0fit = h0fitlim - h0fit0
-   
-      real(dp), dimension(:), allocatable :: z13 ! Z^1/3
-      logical :: have_initialization = .false.
-   
-   
-      public  eval_screen_chugunov, screen_chugunov_init, free_chugunov
+      
+      public  eval_screen_chugunov
    
    contains
    
-
-      subroutine screen_chugunov_init()
-         integer :: i
-      
-         if(have_initialization) return
-!$omp critical  (omp_critical_screen_chugunov_init)
-         if(.not. have_initialization) then
-            allocate(z13(0:150))
-            do i=lbound(z13,dim=1), ubound(z13,dim=1)
-               z13(i) = pow(i*1d0,x13)
-            end do
-            have_initialization = .true.
-         end if
-!$omp end critical  (omp_critical_screen_chugunov_init) 
-      
-      end subroutine  screen_chugunov_init
-   
-
-      subroutine free_chugunov()
-
-!$omp critical  (omp_critical_screen_free_chugunov)
-         if(allocated(z13)) deallocate(z13)
-         have_initialization = .false.
-!$omp end critical  (omp_critical_screen_free_chugunov)
-
-      end subroutine free_chugunov
-
    
       subroutine eval_screen_chugunov(sc, z1, z2, a1, a2, screen, dscreendt, dscreendd, ierr)
          implicit none
@@ -170,8 +140,8 @@
          !a_e = pow((3.d0 /(pi4 * zbar * ntot)),x13)
          a_e = sc% a_e
 
-         a_1 = a_e * z13(int(z1)) !pow(z1,x13)
-         a_2 = a_e * z13(int(z2)) !pow(z2,x13)
+         a_1 = a_e * pre_z(int(z1))%z1_3 !pow(z1,x13)
+         a_2 = a_e * pre_z(int(z2))%z1_3 !pow(z2,x13)
          
          da_1dd = -x13 * a_1/rho
          da_2dd = -x13 * a_2/rho

--- a/rates/public/rates_lib.f90
+++ b/rates/public/rates_lib.f90
@@ -51,7 +51,6 @@
          use load_weak, only: load_weak_data
          use load_ecapture, only: load_ecapture_data
          use rates_initialize, only: init_rates_info
-         use screening_chugunov, only: screen_chugunov_init
          
          character (len=*), intent(in) :: reactionlist_filename, jina_reaclib_filename, rates_table_dir_in
          logical, intent(in) :: use_special_weak_rates, use_suzuki_weak_rates
@@ -97,9 +96,6 @@
          if (dbg) write(*,*) 'call init_rates_info'
          call init_rates_info(reactionlist_filename, ierr)
          if (ierr /= 0) return
-         
-         if (dbg) write(*,*) 'call screen_chugunov_init'
-         call screen_chugunov_init()
         
          have_finished_initialization = .true.
          
@@ -134,7 +130,6 @@
          use rates_def
          use rates_initialize, only: free_reaction_arrays, free_raw_rates_records
          use reaclib_input, only: reaclib
-         use screening_chugunov, only: free_chugunov
          use utils_lib
 
          call integer_dict_free(skip_warnings_dict)
@@ -146,8 +141,6 @@
          call free_reaction_data(reaclib_rates)
          call free_reaction_arrays()
          call free_raw_rates_records()
-
-         call free_chugunov()
          
       end subroutine rates_shutdown
          


### PR DESCRIPTION
Many places in the EOS (and screening) compute powers of the charge Z
but given there is only a small number of Z's we can just precompute
the terms (which are saved into a new math_def module).

This saves about 5% runtime on a test case I ran.