### PR TITLE
Fix `build_atm` to take Teff as input

### DIFF
--- a/atm/private/atm_t_tau_uniform.f90
+++ b/atm/private/atm_t_tau_uniform.f90
@@ -261,7 +261,7 @@ contains
   ! opacity
 
   subroutine build_T_tau_uniform( &
-       tau_surf, L, R, M, cgrav, kap, Pextra_factor, tau_outer, &
+       tau_surf, L, R, Teff, M, cgrav, kap, Pextra_factor, tau_outer, &
        T_tau_id, eos_proc, kap_proc, errtol, dlogtau, &
        atm_structure_num_pts, atm_structure, &
        ierr)
@@ -273,6 +273,7 @@ contains
     real(dp), intent(in)      :: tau_surf
     real(dp), intent(in)      :: L
     real(dp), intent(in)      :: R
+    real(dp), intent(in)      :: Teff
     real(dp), intent(in)      :: M
     real(dp), intent(in)      :: cgrav
     real(dp), intent(in)      :: kap
@@ -296,7 +297,6 @@ contains
     integer, parameter :: IOUT = 1
     integer, parameter :: LOUT = 0
 
-    real(dp)          :: Teff
     real(dp)          :: g
     integer           :: liwork
     integer           :: lwork
@@ -325,9 +325,9 @@ contains
        call mesa_error(__FILE__,__LINE__)
     end if
 
-    ! Evaluate the effective temperature & gravity
+    ! Evaluate the gravity
 
-    call eval_Teff_g(L, R, M, cgrav, Teff, g)
+    g = cgrav*M/(R*R)
 
     ! Allocte atm_structure at its initial size
 

--- a/atm/private/atm_t_tau_varying.f90
+++ b/atm/private/atm_t_tau_varying.f90
@@ -515,7 +515,7 @@ contains
   ! opacity
 
   subroutine build_T_tau_varying( &
-       tau_surf, L, R, M, cgrav, lnP_surf, tau_outer, &
+       tau_surf, L, R, Teff, M, cgrav, lnP_surf, tau_outer, &
        T_tau_id, eos_proc, kap_proc, errtol, dlogtau, &
        atm_structure_num_pts, atm_structure, &
        ierr)
@@ -527,6 +527,7 @@ contains
     real(dp), intent(in)      :: tau_surf
     real(dp), intent(in)      :: L
     real(dp), intent(in)      :: R
+    real(dp), intent(in)      :: Teff
     real(dp), intent(in)      :: M
     real(dp), intent(in)      :: cgrav
     real(dp), intent(in)      :: lnP_surf
@@ -549,7 +550,6 @@ contains
     integer, parameter :: IOUT = 1
     integer, parameter :: LOUT = 0
 
-    real(dp)          :: Teff
     real(dp)          :: g
     integer           :: liwork
     integer           :: lwork
@@ -583,9 +583,9 @@ contains
        call mesa_error(__FILE__,__LINE__)
     end if
 
-    ! Evaluate the effective temperature & gravity
+    ! Evaluate the gravity
 
-    call eval_Teff_g(L, R, M, cgrav, Teff, g)
+    g = cgrav*M/(R*R)
 
     ! Allocte atm_structure at its initial size
 

--- a/docs/source/test_suite.rst
+++ b/docs/source/test_suite.rst
@@ -201,6 +201,14 @@ This test suite example checks the inward propagation of a carbon burning front 
 This test suite example builds a Type IIp supernova model, including Rayleigh-Taylor Instability mixing, for subsquent use in STELLA.
 
 
+:ref:`check_pulse_atm`
+^^^^^^^^^^^^^^^^^^^^^^
+
+This test checks that the atmosphere structure written to the
+pulsation output closely matches what is expected for the
+:math:`T(\tau)` relation specified by ``atm_T_tau_relation``.
+
+
 :ref:`conserve_angular_momentum`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/test_suite/check_pulse_atm.rst
+++ b/docs/source/test_suite/check_pulse_atm.rst
@@ -1,0 +1,1 @@
+../../../star/test_suite/check_pulse_atm/README.rst

--- a/star/private/atm_support.f90
+++ b/star/private/atm_support.f90
@@ -1048,10 +1048,10 @@ contains
   !****
 
   subroutine build_atm( &
-       s, L, R, M, cgrav, ierr)
+       s, L, R, Teff, M, cgrav, ierr)
 
     type(star_info), pointer :: s
-    real(dp), intent(in)     :: L, R, M, cgrav
+    real(dp), intent(in)     :: L, R, Teff, M, cgrav
     integer, intent(out)     :: ierr
        
     ! Create the atmosphere structure by dispatching to the
@@ -1062,7 +1062,7 @@ contains
     case ('T_tau')
 
        call build_T_tau( &
-            s, s% tau_factor*s% tau_base, L, R, M, cgrav, &
+            s, s% tau_factor*s% tau_base, L, R, Teff, M, cgrav, &
             s% atm_T_tau_relation, s% atm_T_tau_opacity, &
             s% atm_structure_num_pts, s% atm_structure, &
             ierr)
@@ -1081,7 +1081,7 @@ contains
   !****
 
   subroutine build_T_tau( &
-       s, tau_surf, L, R, M, cgrav, T_tau_relation, T_tau_opacity, &
+       s, tau_surf, L, R, Teff, M, cgrav, T_tau_relation, T_tau_opacity, &
        atm_structure_num_pts, atm_structure, &
        ierr)
 
@@ -1090,14 +1090,13 @@ contains
          atm_build_T_tau_varying
     
     type(star_info), pointer :: s
-    real(dp), intent(in)     :: tau_surf, L, R, M, cgrav
+    real(dp), intent(in)     :: tau_surf, L, R, Teff, M, cgrav
     character(*), intent(in) :: T_tau_relation
     character(*), intent(in) :: T_tau_opacity
     integer, intent(out)     :: atm_structure_num_pts
     real(dp), pointer        :: atm_structure(:,:)
     integer, intent(out)     :: ierr
 
-    real(dp) :: Teff
     real(dp) :: kap
     real(dp) :: lnT_surf
     real(dp) :: dlnT_dL
@@ -1124,6 +1123,7 @@ contains
     if (ierr /= 0) then
        s% retry_message = 'Call to get_T_tau failed in build_T_tau'
        if (s% report_ierr) write(*, *) s% retry_message
+       return
     end if
 
     ! Get the T-tau id
@@ -1143,7 +1143,7 @@ contains
     case ('fixed', 'iterated')
 
        call atm_build_T_tau_uniform( &
-            tau_surf, L, R, M, cgrav, kap, s% Pextra_factor, s% atm_build_tau_outer, &
+            tau_surf, L, R, Teff, M, cgrav, kap, s% Pextra_factor, s% atm_build_tau_outer, &
             T_tau_id, eos_proc_for_build_T_tau, kap_proc_for_build_T_tau, &
             s% atm_build_errtol, s% atm_build_dlogtau, &
             atm_structure_num_pts, atm_structure, &
@@ -1157,7 +1157,7 @@ contains
     case ('varying')
 
        call atm_build_T_tau_varying( &
-            tau_surf, L, R, M, cgrav, lnP_surf, s% atm_build_tau_outer, &
+            tau_surf, L, R, Teff, M, cgrav, lnP_surf, s% atm_build_tau_outer, &
             T_tau_id, eos_proc_for_build_T_tau, kap_proc_for_build_T_tau, &
             s% atm_build_errtol, s% atm_build_dlogtau, &
             atm_structure_num_pts, atm_structure, &

--- a/star/private/pulse_cafein.f90
+++ b/star/private/pulse_cafein.f90
@@ -94,7 +94,7 @@ contains
     ! Determine data dimensiones
 
     if (add_atmosphere) then
-       call build_atm(s, s%L(1), s%r(1), s%m_grav(1), s%cgrav(1), ierr)
+       call build_atm(s, s%L(1), s%r(1), s%Teff, s%m_grav(1), s%cgrav(1), ierr)
        if (ierr /= 0) then
           write(*,*) 'failed in build_atm'
           return

--- a/star/private/pulse_fgong.f90
+++ b/star/private/pulse_fgong.f90
@@ -132,7 +132,7 @@ contains
     ! Determine data dimensiones
 
     if (add_atmosphere) then
-       call build_atm(s, s%L(1), s%r(1), s%m_grav(1), s%cgrav(1), ierr)
+       call build_atm(s, s%L(1), s%r(1), s%Teff, s%m_grav(1), s%cgrav(1), ierr)
        if (ierr /= 0) then
           write(*,*) 'failed in build_atm'
           return

--- a/star/private/pulse_gyre.f90
+++ b/star/private/pulse_gyre.f90
@@ -95,7 +95,7 @@ contains
     ! Determine data dimensiones
 
     if (add_atmosphere) then
-       call build_atm(s, s%L(1), s%r(1), s%m_grav(1), s%cgrav(1), ierr)
+       call build_atm(s, s%L(1), s%r(1), s%Teff, s%m_grav(1), s%cgrav(1), ierr)
        if (ierr /= 0) then
           write(*,*) 'failed in build_atm'
           return

--- a/star/private/pulse_osc.f90
+++ b/star/private/pulse_osc.f90
@@ -135,7 +135,7 @@ contains
     ! Determine data dimensiones
 
     if (add_atmosphere) then
-       call build_atm(s, s%L(1), s%r(1), s%m_grav(1), s%cgrav(1), ierr)
+       call build_atm(s, s%L(1), s%r(1), s%Teff, s%m_grav(1), s%cgrav(1), ierr)
        if (ierr /= 0) then
           write(*,*) 'failed in build_atm'
           return

--- a/star/private/pulse_saio.f90
+++ b/star/private/pulse_saio.f90
@@ -90,7 +90,7 @@ contains
     ! Determine data dimensiones
 
     if (add_atmosphere) then
-       call build_atm(s, s%L(1), s%r(1), s%m_grav(1), s%cgrav(1), ierr)
+       call build_atm(s, s%L(1), s%r(1), s%Teff, s%m_grav(1), s%cgrav(1), ierr)
        if (ierr /= 0) then
           write(*,*) 'failed in build_atm'
           return

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -686,13 +686,13 @@
          call write_controls(s, filename, ierr)
       end subroutine star_write_controls
 
-      subroutine star_build_atm(s, L, R, M, cgrav, ierr)
+      subroutine star_build_atm(s, L, R, Teff, M, cgrav, ierr)
          ! sets s% atm_structure_num_pts and s% atm_structure
         use atm_support
          type (star_info), pointer :: s
-         real(dp), intent(in) :: L, R, M, cgrav
+         real(dp), intent(in) :: L, R, Teff, M, cgrav
          integer, intent(out) :: ierr
-         call build_atm(s, L, R, M, cgrav, ierr)
+         call build_atm(s, L, R, Teff, M, cgrav, ierr)
        end subroutine star_build_atm
 
       

--- a/star/test_suite/check_pulse_atm/README.rst
+++ b/star/test_suite/check_pulse_atm/README.rst
@@ -1,0 +1,51 @@
+.. _check_pulse_atm:
+
+***************
+check_pulse_atm
+***************
+
+.. |Ttau| replace:: :math:`T(\tau)`
+.. |tau| replace:: :math:`\tau`
+
+This test checks that the atmosphere structure written to the
+pulsation output matches the |Ttau| relation specified by
+``atm_T_tau_relation``.  It is based on the ``T_tau_gradr`` test case
+but checks reconstructed atmosphere in the pulsation data file, rather
+than the structure of the interior model, which in this case doesn't
+include the atmosphere.
+
+The test changes ``atm_T_tau_relation`` every 5 steps and changes ``atm_T_tau_opacity`` every 20 steps to cycle through
+all the available options.  Every 5 steps, it
+
+1. saves the pulsation output,
+2. reads it back in,
+3. computes the root-mean-squared differences (rms, stored as ``T_rms``) between the pulsation data's temperature profile and the target |Ttau| relation in layers with |tau| < 0.1, and
+4. compares this to a target value set by ``x_ctrl(1)``.
+   
+If new ``atm_T_tau_relation`` or ``atm_T_tau_opacity`` options are
+added to MESA, they must be added to this test case by hand.  That is,
+the implementation does not automatically track all the available
+options.
+
+If the test fails because ``T_rms`` is slightly larger than the tolerance,
+there are two possibly benign explanations.
+
+1. The interpolation error in ``T_face`` contributes too much to ``chi2``.
+   The tolerance can be increased or the resolution of the atmosphere integration increased.
+2. There are layers included in the sum that are becoming convective,
+   in which case the temperature gradient won't follow the (radiative)
+   |Ttau| relation.  The sum can be restricted to smaller optical
+   depths.
+   
+If the test fails because ``T_rms`` is much larger (orders of magnitude
+larger) than the tolerance, then there might be a bug
+in the implementation of the integration of the atmosphere and how it's
+written to the pulsation output.
+
+Most options are deliberately left at their default values because
+they shouldn't influence the test's result.
+
+The test currently only checks the FGONG output.
+It should be extended to cover the other pulsation data formats, too.
+
+Last-Updated: 2022-03-09 (commit 97a1c26) by Warrick Ball

--- a/star/test_suite/check_pulse_atm/ck
+++ b/star/test_suite/check_pulse_atm/ck
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# this provides the definition of check_one
+# check_one
+MESA_DIR=../../..
+source "${MESA_DIR}/star/test_suite/test_suite_helpers"
+
+check_one

--- a/star/test_suite/check_pulse_atm/clean
+++ b/star/test_suite/check_pulse_atm/clean
@@ -1,0 +1,2 @@
+cd make
+make clean

--- a/star/test_suite/check_pulse_atm/inlist_check_pulse_atm
+++ b/star/test_suite/check_pulse_atm/inlist_check_pulse_atm
@@ -1,0 +1,55 @@
+
+&star_job
+
+      show_log_description_at_start = .false. 
+
+      save_model_when_terminate = .true.
+      required_termination_code_string = ''
+      save_model_filename = 'final.mod'
+
+      set_to_this_tau_factor = 0.1d0
+      set_tau_factor = .true.
+      set_initial_tau_factor = .true.
+
+/ ! end of star_job namelist
+
+
+&eos
+/ ! end of eos namelist
+
+&kap
+      Zbase = 0.02d0
+/ ! end of kap namelist
+
+
+&controls
+      x_ctrl(1) = 0.05d0
+
+      initial_mass = 1.0d0
+      initial_y = 0.28d0
+      initial_z = 0.02d0
+      
+      ! limit max_model_number as part of test_suite
+      max_model_number = 75
+
+      atm_T_tau_opacity = 'varying'
+      atm_T_tau_relation = 'Trampedach_solar'
+      use_T_tau_gradr_factor = .true.
+
+      pulse_data_format = 'FGONG'
+      add_atmosphere_to_pulse_data = .true.
+      fgong_ivers = 1300
+
+      photo_interval = 100
+      profile_interval = 100
+      history_interval = 5
+      terminal_interval = 5
+      write_header_frequency = 50
+
+/ ! end of controls namelist
+
+
+&pgstar
+
+
+/ ! end of pgstar namelist

--- a/star/test_suite/check_pulse_atm/inlist_check_pulse_atm_header
+++ b/star/test_suite/check_pulse_atm/inlist_check_pulse_atm_header
@@ -1,0 +1,41 @@
+
+&star_job
+
+      mesa_dir = '../../..'
+
+      read_extra_star_job_inlist2 = .true.
+      extra_star_job_inlist2_name = 'inlist_check_pulse_atm'
+
+/ ! end of star_job namelist
+
+
+&eos
+
+      read_extra_eos_inlist1 = .true.
+      extra_eos_inlist1_name = 'inlist_check_pulse_atm'
+
+/ ! end of eos namelist
+
+
+&kap
+
+      read_extra_kap_inlist1 = .true.
+      extra_kap_inlist1_name = 'inlist_check_pulse_atm'
+
+/ ! end of kap namelist
+
+
+&controls
+
+      read_extra_controls_inlist1 = .true.
+      extra_controls_inlist1_name = 'inlist_check_pulse_atm'
+
+/ ! end of controls namelist
+
+
+&pgstar
+
+      read_extra_pgstar_inlist1 = .true.
+      extra_pgstar_inlist1_name = 'inlist_check_pulse_atm'
+
+/ ! end of pgstar namelist

--- a/star/test_suite/check_pulse_atm/make/makefile
+++ b/star/test_suite/check_pulse_atm/make/makefile
@@ -1,0 +1,6 @@
+
+MESA_DIR = ../../../..
+
+STAR = star
+
+include $(MESA_DIR)/star/work_standard_makefile

--- a/star/test_suite/check_pulse_atm/mk
+++ b/star/test_suite/check_pulse_atm/mk
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function check_okay {
+	if [ $? -ne 0 ]
+	then
+		echo
+		echo "FAILED"
+		echo
+		exit 1
+	fi
+}
+
+cd make; make; check_okay

--- a/star/test_suite/check_pulse_atm/re
+++ b/star/test_suite/check_pulse_atm/re
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+photo_directory=photos
+
+function most_recent_photo {
+    ls -t "$photo_directory" | head -1
+}
+
+if [ $# -eq 0 ]
+then
+    photo=$(most_recent_photo)
+else
+    photo=$1
+fi
+
+if [ -z "$photo" ] || ! [ -f "$photo_directory/$photo" ]
+then
+    echo "specified photo does not exist"
+    exit 1
+fi
+
+echo "restart from $photo"
+if ! cp "$photo_directory/$photo" restart_photo
+then
+    echo "failed to copy photo"
+    exit 1
+fi
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+./star
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"

--- a/star/test_suite/check_pulse_atm/rn
+++ b/star/test_suite/check_pulse_atm/rn
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# this provides the definition of do_one (run one part of test)
+# do_one [inlist] [output model] [LOGS directory]
+MESA_DIR=../../..
+source "${MESA_DIR}/star/test_suite/test_suite_helpers"
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+
+do_one inlist_check_pulse_atm final.mod
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+
+echo 'finished T_tau_gradr'

--- a/star/test_suite/check_pulse_atm/rn1
+++ b/star/test_suite/check_pulse_atm/rn1
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+rm -f restart_photo
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+./star
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"

--- a/star/test_suite/check_pulse_atm/src/run.f90
+++ b/star/test_suite/check_pulse_atm/src/run.f90
@@ -1,0 +1,15 @@
+      program run
+      use run_star_support, only: do_read_star_job
+      use run_star, only: do_run_star
+      
+      implicit none
+      
+      integer :: ierr
+      
+      ierr = 0
+      call do_read_star_job('inlist', ierr)
+      if (ierr /= 0) stop 1
+      
+      call do_run_star
+      
+      end program

--- a/star/test_suite/do1_test_source
+++ b/star/test_suite/do1_test_source
@@ -27,6 +27,7 @@ do_one 20M_z2m2_high_rotation "stop because have dropped below central lower lim
 do_one accreted_material_j "star_mass_max_limit" "final.mod" auto
 do_one adjust_net "finished with expected number of species" "final.mod" auto
 do_one cburn_inward "Terminate as flame reached half way" "final.mod" auto
+do_one check_pulse_atm "all values are within tolerance" "final.mod" skip
 do_one check_redo "stop because have dropped below central lower limit for h1" "final.mod" auto
 do_one conductive_flame "all values are within tolerance" "final.mod" auto
 do_one conserve_angular_momentum "stop because he_core_mass >= he_core_mass_limit" "final.mod" auto


### PR DESCRIPTION
Some time ago, `Teff` changed from an output from `atm` to an input to `atm`, because `atm` doesn't necessarily know where the photosphere of a star is. Many of these changes weren't reflected in the `build_atm` routines that are used to compute the atmospheric structure that's appended to the pulsation formats (e.g. FGONG), as noted in #375. This PR fixes the immediate issues and completes the transition. It also adds a new test case `check_pulse_atm` that writes the FGONG file, then reads it back in and checks that the atmosphere structure matches the selected T(τ) relation.

In the future I'll extend the test to check other formats, too, but for now it only checks FGONG.

I'll leave this open for a few days for comments.