### PR TITLE
Create `astero_results_directory` option

### DIFF
--- a/astero/defaults/astero_search.defaults
+++ b/astero/defaults/astero_search.defaults
@@ -1171,6 +1171,13 @@
 
    ! output controls
 
+   ! astero_results_directory
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~
+   ! Directory in which to save ``astero`` outputs.
+   ! If it doesn't exist, it will be created. ::
+
+      astero_results_directory = 'outputs'
+
    ! write_best_model_data_for_each_sample
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ! ::
@@ -1187,11 +1194,9 @@
    ! ~~~~~~~~~~~~~~~~~~~~~
    ! sample_results_postfix
    ! ~~~~~~~~~~~~~~~~~~~~~~
-   ! Prefix and postfix for sample results filenames.
-   ! You can include a directory in the prefix if desired
-   ! but you must create the directory yourself. ::
+   ! Prefix and postfix for sample results filenames. ::
 
-      sample_results_prefix = 'outputs/sample_'
+      sample_results_prefix = 'sample_'
       sample_results_postfix = '.data'
 
    ! model_num_digits

--- a/astero/private/adipls_support.f90
+++ b/astero/private/adipls_support.f90
@@ -265,7 +265,9 @@
                model_num_digits, model_num_digits
             write(num_string,format_string) s% model_number
 
-            filename = trim(fgong_prefix) // trim(num_string) // trim(fgong_postfix)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+
+            filename = trim(astero_results_directory) // '/' // trim(fgong_prefix) // trim(num_string) // trim(fgong_postfix)
 
             call star_write_pulse_data(s%id, 'FGONG', filename, global_data, point_data, ierr)
 

--- a/astero/private/astero_run_support.f90
+++ b/astero/private/astero_run_support.f90
@@ -437,6 +437,7 @@
          subroutine do1_grid(ierr)
             integer, intent(out) :: ierr
             real(dp) :: chi2
+            character(len=256) :: filename
             
             include 'formats'
             ierr = 0
@@ -449,7 +450,10 @@
             
             call save_best_for_sample(sample_number, 0)
 
-            call save_sample_results_to_file(-1,from_file_output_filename,ierr)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+            filename = trim(astero_results_directory) // '/' // trim(from_file_output_filename)
+         
+            call save_sample_results_to_file(-1, filename, ierr)
             if (ierr /= 0) then
                write(*,*) 'failed in save_sample_results_to_file'
                return
@@ -680,6 +684,7 @@
          
          subroutine do1_grid(ierr)
             integer, intent(out) :: ierr
+            character(len=256) :: filename
             include 'formats'
             ierr = 0
             
@@ -716,7 +721,10 @@
             
             call save_best_for_sample(sample_number, 0)
 
-            call save_sample_results_to_file(i_total,scan_grid_output_filename,ierr)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+            filename = trim(astero_results_directory) // '/' // trim(scan_grid_output_filename)
+
+            call save_sample_results_to_file(i_total, filename, ierr)
             if (ierr /= 0) then
                write(*,*) 'failed in save_sample_results_to_file'
                return
@@ -733,13 +741,18 @@
          double precision, intent(in) :: x(*)
          double precision, intent(out) :: f
          
+         character(len=256) :: filename
          integer :: ierr
 
          call bobyqa_or_newuoa_fun(n,x,f)
 
          write(*,'(A)')
          ierr = 0
-         call save_sample_results_to_file(-1,bobyqa_output_filename,ierr)
+
+         if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+         filename = trim(astero_results_directory) // '/' // trim(bobyqa_output_filename)
+
+         call save_sample_results_to_file(-1, filename, ierr)
          if (ierr /= 0) then
             write(*,*) 'failed in save_sample_results_to_file'
             call mesa_error(__FILE__,__LINE__,'bobyqa_fun')
@@ -753,13 +766,18 @@
          double precision, intent(in) :: x(*)
          double precision, intent(out) :: f
          
+         character(len=256) :: filename
          integer :: ierr
          
          call bobyqa_or_newuoa_fun(n,x,f)
 
          write(*,'(A)')
          ierr = 0
-         call save_sample_results_to_file(-1,newuoa_output_filename,ierr)
+
+         if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+         filename = trim(astero_results_directory) // '/' // trim(newuoa_output_filename)
+
+         call save_sample_results_to_file(-1, filename, ierr)
          if (ierr /= 0) then
             write(*,*) 'failed in save_sample_results_to_file'
             call mesa_error(__FILE__,__LINE__,'newuoa_fun')
@@ -1030,6 +1048,7 @@
          integer, intent(in) :: op_code
          integer, intent(out) :: ierr
          
+         character(len=256) :: filename
          integer :: prev_sample_number
          include 'formats'
          
@@ -1145,7 +1164,10 @@
          
          call save_best_for_sample(sample_number, op_code)
 
-         call save_sample_results_to_file(-1, simplex_output_filename, ierr)
+         if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+         filename = trim(astero_results_directory) // '/' // trim(simplex_output_filename)
+
+         call save_sample_results_to_file(-1, filename, ierr)
          if (ierr /= 0) then
             write(*,*) 'failed in save_sample_results_to_file'
             call mesa_error(__FILE__,__LINE__)

--- a/astero/private/extras_support.f90
+++ b/astero/private/extras_support.f90
@@ -999,22 +999,27 @@
          type (star_info), pointer :: s
          integer :: ierr
          logical :: write_controls_info_with_profile
+         character (len=256) :: filename
          
          include 'formats'
          
          if (save_model_for_best_model) then
             ierr = 0
-            call star_write_model(s% id, best_model_save_model_filename, ierr)
+            filename = trim(astero_results_directory) // '/' // trim(best_model_save_model_filename)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+            call star_write_model(s% id, filename, ierr)
             if (ierr /= 0) then
                write(*,*) 'failed in star_write_model'
                call mesa_error(__FILE__,__LINE__)
             end if
-            write(*, '(a,i7)') 'save ' // trim(best_model_save_model_filename), s% model_number
+            write(*, '(a,i7)') 'save ' // filename, s% model_number
          end if
          
          if (write_fgong_for_best_model) then
             ierr = 0
-            call star_export_pulse_data(s%id, 'FGONG', best_model_fgong_filename, &
+            filename = trim(astero_results_directory) // '/' // trim(best_model_fgong_filename)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+            call star_export_pulse_data(s%id, 'FGONG', filename, &
                add_center_point, keep_surface_point, add_atmosphere, ierr)
             if (ierr /= 0) then
                write(*,*) 'failed in star_export_pulse_data'
@@ -1024,7 +1029,9 @@
          
          if (write_gyre_for_best_model) then
             ierr = 0
-            call star_export_pulse_data(s%id, 'GYRE', best_model_gyre_filename, &
+            filename = trim(astero_results_directory) // '/' // trim(best_model_gyre_filename)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+            call star_export_pulse_data(s%id, 'GYRE', filename, &
                add_center_point, keep_surface_point, add_atmosphere, ierr)
             if (ierr /= 0) then
                write(*,*) 'failed in star_export_pulse_data'
@@ -1034,9 +1041,11 @@
          
          if (write_profile_for_best_model) then
             ierr = 0
+            filename = trim(astero_results_directory) // '/' // trim(best_model_profile_filename)
+            if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
             write_controls_info_with_profile = s% write_controls_info_with_profile
             s% write_controls_info_with_profile = .false.
-            call star_write_profile_info(s% id, best_model_profile_filename, ierr)
+            call star_write_profile_info(s% id, filename, ierr)
             s% write_controls_info_with_profile = write_controls_info_with_profile
             if (ierr /= 0) then
                write(*,*) 'failed in star_write_profile_info'
@@ -1075,9 +1084,12 @@
          ierr = 0
          iounit = alloc_iounit(ierr)
          if (ierr /= 0) return
+
+         if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+
          write(format_string,'( "(i",i2.2,".",i2.2,")" )') num_digits, num_digits
          write(num_string,format_string) num
-         filename = trim(sample_results_prefix) // trim(num_string) // trim(sample_results_postfix)
+         filename = trim(astero_results_directory) // '/' // trim(sample_results_prefix) // trim(num_string) // trim(sample_results_postfix)
          open(unit=iounit, file=trim(filename), action='write', status='replace', iostat=ierr)
          if (ierr == 0) then
             call show_best(iounit)
@@ -1419,6 +1431,7 @@
          integer, intent(out) :: ierr
          integer :: iounit, ckm
          type (star_info), pointer :: s
+         character (len=256) :: filename
          include 'formats'
          ierr = 0
          call star_ptr(id, s, ierr)
@@ -1436,16 +1449,18 @@
             call get_all_el_info(s,ierr)
             if (ierr /= 0) return
             call store_best_info(s)
+
+            filename = trim(astero_results_directory) // '/' // trim(last_model_save_info_filename)
+
             iounit = alloc_iounit(ierr)
             if (ierr /= 0) return
-            open(unit=iounit, file=trim(last_model_save_info_filename), &
+            open(unit=iounit, file=filename, &
                action='write', status='replace', iostat=ierr)
             if (ierr /= 0) then
-               write(*,'(a)') 'failed to open last_model_save_info_filename ' // &
-                  trim(last_model_save_info_filename)
+               write(*,'(a)') 'failed to open last_model_save_info_filename ' // filename
                return
             end if
-            write(*,*) 'write ' // trim(last_model_save_info_filename)
+            write(*,*) 'write ' // filename
             write(*,*) 'call show_best'
             call show_best(iounit)
             write(*,*) 'done show_best'

--- a/astero/private/gyre_support.f90
+++ b/astero/private/gyre_support.f90
@@ -171,8 +171,10 @@ contains
     ! If necessary, write an FGONG file
          
     if (write_fgong_for_each_model) then
-       
-       filename = TRIM(fgong_prefix)//TRIM(num_string(s%model_number))//TRIM(fgong_postfix)
+
+       if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+
+       filename = TRIM(astero_results_directory) // '/' // TRIM(fgong_prefix)//TRIM(num_string(s%model_number))//TRIM(fgong_postfix)
 
        call star_export_pulse_data(s%id, 'FGONG', filename, &
             add_center_point, keep_surface_point, add_atmosphere, ierr)
@@ -210,7 +212,9 @@ contains
          
     if (write_gyre_for_each_model) then
 
-       filename = TRIM(gyre_prefix)//TRIM(num_string(s%model_number))//TRIM(gyre_postfix)
+       if (.not. folder_exists(trim(astero_results_directory))) call mkdir(trim(astero_results_directory))
+
+       filename = TRIM(astero_results_directory) // '/' // TRIM(gyre_prefix)//TRIM(num_string(s%model_number))//TRIM(gyre_postfix)
 
        call star_write_pulse_data(s%id, 'GYRE', filename, &
             global_data, point_data, ierr)

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -249,6 +249,8 @@
          ratios_r02, sigmas_r02
       
       ! output controls
+      character (len=256) :: astero_results_directory
+
       logical :: write_best_model_data_for_each_sample
       integer :: num_digits
       character (len=256) :: sample_results_prefix, sample_results_postfix
@@ -465,6 +467,9 @@
          correction_scheme, surf_coef1_name, surf_coef2_name, &
          correction_b, correction_factor, &
          l0_n_obs, &
+
+         astero_results_directory, &
+
          write_best_model_data_for_each_sample, &
          num_digits, &
          sample_results_prefix, sample_results_postfix, &

--- a/astero/test_suite/do1_test_source
+++ b/astero/test_suite/do1_test_source
@@ -1,7 +1,7 @@
 #return
 
 do_one example_astero "chi square within limit" "final.mod" skip
-do_one fast_simplex "save_sample_results_to_file simplex_results.data" skip skip
+do_one fast_simplex "save_sample_results_to_file outputs/simplex_results.data" skip skip
 do_one astero_adipls "got ok match for expected frequency" "final.mod" skip
 do_one astero_gyre "got ok match for expected frequency" skip skip
 do_one surface_effects "all tests are within tolerances" skip skip

--- a/astero/test_suite/fast_simplex/inlist_astero_search_controls
+++ b/astero/test_suite/fast_simplex/inlist_astero_search_controls
@@ -635,10 +635,12 @@
             
       
    ! output controls
-   
+
+      astero_results_directory = 'outputs'
+
       write_best_model_data_for_each_sample = .true.
       num_digits = 4 ! number of digits in sample number (with leading 0's)
-      sample_results_prefix = 'outputs/sample_' 
+      sample_results_prefix = 'sample_'
          ! note that you can include a directory in the prefix if desired
       sample_results_postfix = '.data'
       
@@ -649,8 +651,8 @@
          ! note that you can include a directory in the prefix if desired
       fgong_postfix = '.data'
       
-      write_fgong_for_best_model = .false.
-      best_model_fgong_filename = ''
+      write_fgong_for_best_model = .true.
+      best_model_fgong_filename = 'best.fgong'
 
       write_gyre_for_each_model = .false.
       gyre_prefix = 'gyre_' 
@@ -658,14 +660,14 @@
       gyre_postfix = '.data'
       max_num_gyre_points = -1 ! only used if > 1
       
-      write_gyre_for_best_model = .false.
-      best_model_gyre_filename = ''
+      write_gyre_for_best_model = .true.
+      best_model_gyre_filename = 'best.gyre'
       
-      write_profile_for_best_model = .false.
-      best_model_profile_filename = ''
+      write_profile_for_best_model = .true.
+      best_model_profile_filename = 'best.profile'
       
-      save_model_for_best_model = .false.
-      best_model_save_model_filename = ''
+      save_model_for_best_model = .true.
+      best_model_save_model_filename = 'best.mod'
       
       save_info_for_last_model = .false. ! if true, treat final model as "best"
       last_model_save_info_filename = '' ! and save info about final model to this file.
@@ -684,8 +686,8 @@
    
    
       ! save all control settings to file
-         save_controls = .false. ! dumps &astero_search_controls controls to file
-         save_controls_filename = '' ! if empty, uses a default name
+         save_controls = .true. ! dumps &astero_search_controls controls to file
+         save_controls_filename = 'astero_search_controls.out' ! if empty, uses a default name
       
       
       ! composition control

--- a/astero/test_suite/fast_simplex/rn
+++ b/astero/test_suite/fast_simplex/rn
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# git can't track a truly empty folder for outputs and astero won't
-# create one, so we create it for the tests here
-mkdir -p outputs
-
 # this provides the definition of do_one (run one part of test)
 # do_one [inlist] [output model] [LOGS directory]
 MESA_DIR=../../..

--- a/astero/test_suite/fast_simplex/src/run_star_extras.f90
+++ b/astero/test_suite/fast_simplex/src/run_star_extras.f90
@@ -117,13 +117,44 @@
       
       
       subroutine extras_after_evolve(id, ierr)
+         use astero_def
+         use utils_lib, only: mv
+
          integer, intent(in) :: id
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
+         character (len=256) :: format_string, num_string, basename
          ierr = 0
          call star_ptr(id, s, ierr)
          if (ierr /= 0) return
          call test_suite_after_evolve(s, ierr)
+
+         ! demonstrate how to move some files generated for each
+         ! sample
+         write(format_string,'( "(i",i2.2,".",i2.2,")" )') num_digits, num_digits
+         write(num_string,format_string) sample_number+1 ! sample number hasn't been incremented yet
+         basename = trim(sample_results_prefix) // trim(num_string)
+         call move(best_model_fgong_filename, '.fgong')
+         call move(best_model_gyre_filename, '.gyre')
+         call move(best_model_profile_filename, '.profile')
+         call move(best_model_save_model_filename, '.mod')
+
+         contains
+
+         subroutine move(filename, extension)
+            character (len=*), intent(in) :: filename, extension
+            character (len=256) :: src, tgt
+
+            src = trim(astero_results_directory) // '/' // trim(filename)
+            tgt = trim(astero_results_directory) // '/' // trim(basename) // extension
+
+            ! file won't exist if sample quit early because of bad chi-squared,
+            ! so skip errors
+            call mv(trim(src), trim(tgt), skip_errors=.true.)
+
+            write(*,*) 'moved ' // trim(src) // ' to ' // trim(tgt)
+         end subroutine move
+
       end subroutine extras_after_evolve
       
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,13 +20,20 @@ Backwards-incompatible changes
 Module-level changes
 --------------------
 
-Rates
+astero
+------
+
+``&astero_search_controls`` now has an option ``astero_results_directory`` to specify a folder into which all of
+``astero``'s results are saved (like ``log_directory`` in ``star``).  The default is ``outputs``, so if you
+can't seem to find your ``astero`` output, have a look there.
+
+rates
 -----
 
 The 7Be(e-,nu)7Li has been switched from REACLIB rate to that of `Simonucci et al 2013 <https://ui.adsabs.harvard.edu/abs/2013ApJ...764..118S/abstract>`_. This is
 due to the fact that the REACLIB rate does not take into account the neutral ion rate below 10**7 K.
 
-Star
+star
 ----
 
 An option to include carbon-oxygen phase separation for crystallizing C/O white dwarfs is now available,


### PR DESCRIPTION
As [mentioned](https://github.com/MESAHub/mesa/pull/367#pullrequestreview-874479268) in PR #367, users currently have to create any folder for `astero` results themselves. This PR adds a new option `astero_results_directory` (by analogy with `log_directory` in `star`), which means MESA can create the relevant folder itself while the code runs.

This only affects (and was motivated by) `fast_simplex`, which is passing.