### PR TITLE
Enabled Uq in TDC.

### DIFF
--- a/star/private/hydro_momentum.f90
+++ b/star/private/hydro_momentum.f90
@@ -426,11 +426,8 @@
          
          end if ! v_flag
 
-         Uq_ad = 0d0
-         if (s% RSP2_flag) then ! Uq(k) is turbulent viscosity drag at face k
-            Uq_ad = compute_Uq_face(s, k, ierr)
-            if (ierr /= 0) return
-         end if
+         Uq_ad = compute_Uq_face(s, k, ierr)
+         if (ierr /= 0) return
          
          other_ad = extra_ad - accel_ad + Uq_ad
          other = other_ad%val


### PR DESCRIPTION
Uq is the turbulent viscosity term in RSP & TDC. Currently it's only on in RSP, but all the logic is there. This PR enables it for TDC. If this passes on Testhub I think it can be merged.