### PR TITLE
Add raw rates to history and profile file outputs 

### DIFF
--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -283,9 +283,7 @@
       !photo
       !pnhe4
       !other
-
-
-
+      
 
    !## nuclear reactions at center
 

--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -287,28 +287,13 @@
    !## information about individual reactions
    
           ! adds columns for all of the reactions that are in the current net 
-      !add_eps_nuc_rates  ! energy from reactions, erg/g/s
-      !add_eps_neu_rates  ! energy lost to neutrinos, erg/g/s
       !add_raw_rates      ! raw reaction rates,       reactions/second
-      !add_screened_rates ! screened reaction rates,  reactions/second
    
           ! individual reactions (as many as desired)
           ! use list_net_reactions = .true. in star_job to list all reactions in the current net 
-          ! erg/g/s
-      !eps_nuc_rate r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
-      !eps_nuc_rate r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
-         
-          ! erg/g/s
-      !eps_neu_rate r_h1_h1_ec_h2 
-      !eps_neu_rate r_h1_h1_wk_h2
-         
           ! reactions/second
       !raw_rate r_h1_h1_ec_h2 
       !raw_rate r_h1_h1_wk_h2
-         
-          ! reactions/second
-      !screened_rate r_h1_h1_ec_h2 
-      !screened_rate r_h1_h1_wk_h2
 
    !## nuclear reactions at center
 

--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -283,7 +283,32 @@
       !photo
       !pnhe4
       !other
-      
+   
+   !## information about individual reactions
+   
+          ! adds columns for all of the reactions that are in the current net 
+      !add_eps_nuc        ! energy from the reaction, erg/g/s
+      !add_eps_neu        ! energy lost to neutrinos, erg/g/s
+      !add_raw_rates      ! raw reaction rates,       reactions/second
+      !add_screened_rates ! screened reaction rates,  reactions/second
+   
+          ! individual reactions (as many as desired)
+          ! use list_net_reactions = .true. in star_job to list all reactions in the current net 
+          ! erg/g/s
+      !eps_nuc r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
+      !eps_nuc r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
+         
+          ! erg/g/s
+      !reaction_neu r_h1_h1_ec_h2 
+      !reaction_neu r_h1_h1_wk_h2
+         
+          ! reactions/second
+      !raw_rate r_h1_h1_ec_h2 
+      !raw_rate r_h1_h1_wk_h2
+         
+          ! reactions/second
+      !screened_rate r_h1_h1_ec_h2 
+      !screened_rate r_h1_h1_wk_h2
 
    !## nuclear reactions at center
 

--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -287,20 +287,20 @@
    !## information about individual reactions
    
           ! adds columns for all of the reactions that are in the current net 
-      !add_eps_nuc        ! energy from the reaction, erg/g/s
-      !add_eps_neu        ! energy lost to neutrinos, erg/g/s
+      !add_eps_nuc_rates  ! energy from reactions, erg/g/s
+      !add_eps_neu_rates  ! energy lost to neutrinos, erg/g/s
       !add_raw_rates      ! raw reaction rates,       reactions/second
       !add_screened_rates ! screened reaction rates,  reactions/second
    
           ! individual reactions (as many as desired)
           ! use list_net_reactions = .true. in star_job to list all reactions in the current net 
           ! erg/g/s
-      !eps_nuc r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
-      !eps_nuc r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
+      !eps_nuc_rate r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
+      !eps_nuc_rate r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
          
           ! erg/g/s
-      !reaction_neu r_h1_h1_ec_h2 
-      !reaction_neu r_h1_h1_wk_h2
+      !eps_neu_rate r_h1_h1_ec_h2 
+      !eps_neu_rate r_h1_h1_wk_h2
          
           ! reactions/second
       !raw_rate r_h1_h1_ec_h2 

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -283,29 +283,13 @@
       !other    
 
    ! adds columns for all of the reactions that are in the current net 
-   !add_eps_nuc_rates  ! energy from reactions, erg/g/s
-   !add_eps_neu_rates  ! energy lost to neutrinos, erg/g/s
    !add_raw_rates      ! raw reaction rates,       reactions/second
-   !add_screened_rates ! screened reaction rates,  reactions/second
 
    ! individual reactions (as many as desired)
-   ! use list_net_reactions = .true. in star_job to list all reactions in the current net 
-   ! erg/g/s
-      !eps_nuc_rate r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
-      !eps_nuc_rate r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
-      
-   ! erg/g/s
-      !eps_neu_rate r_h1_h1_ec_h2 
-      !eps_neu_rate r_h1_h1_wk_h2
-      
+   ! use list_net_reactions = .true. in star_job to list all reactions in the current net    
    ! reactions/second
       !raw_rate r_h1_h1_ec_h2 
       !raw_rate r_h1_h1_wk_h2
-      
-   ! reactions/second
-      !screened_rate r_h1_h1_ec_h2 
-      !screened_rate r_h1_h1_wk_h2
-
 
    !burn_num_iters ! Number of split_burn iterations taken
    !burn_avg_epsnuc

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -282,6 +282,31 @@
       !pnhe4
       !other    
 
+   ! adds columns for all of the reactions that are in the current net 
+   !add_eps_nuc        ! energy from the reaction, erg/g/s
+   !add_eps_neu        ! energy lost to neutrinos, erg/g/s
+   !add_raw_rates      ! raw reaction rates,       reactions/second
+   !add_screened_rates ! screened reaction rates,  reactions/second
+
+   ! individual reactions (as many as desired)
+   ! use list_net_reactions = .true. in star_job to list all reactions in the current net 
+   ! erg/g/s
+      !eps_nuc r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
+      !eps_nuc r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
+      
+   ! erg/g/s
+      !reaction_neu r_h1_h1_ec_h2 
+      !reaction_new r_h1_h1_wk_h2
+      
+   ! reactions/second
+      !raw_rate r_h1_h1_ec_h2 
+      !raw_rate r_h1_h1_wk_h2
+      
+   ! reactions/second
+      !screened_rate r_h1_h1_ec_h2 
+      !screened_rate r_h1_h1_wk_h2
+
+
    !burn_num_iters ! Number of split_burn iterations taken
    !burn_avg_epsnuc
    !log_burn_avg_epsnuc

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -283,20 +283,20 @@
       !other    
 
    ! adds columns for all of the reactions that are in the current net 
-   !add_eps_nuc        ! energy from the reaction, erg/g/s
-   !add_eps_neu        ! energy lost to neutrinos, erg/g/s
+   !add_eps_nuc_rates  ! energy from reactions, erg/g/s
+   !add_eps_neu_rates  ! energy lost to neutrinos, erg/g/s
    !add_raw_rates      ! raw reaction rates,       reactions/second
    !add_screened_rates ! screened reaction rates,  reactions/second
 
    ! individual reactions (as many as desired)
    ! use list_net_reactions = .true. in star_job to list all reactions in the current net 
    ! erg/g/s
-      !eps_nuc r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
-      !eps_nuc r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
+      !eps_nuc_rate r_h1_h1_ec_h2 ! proton-proton (pp) reaction 
+      !eps_nuc_rate r_h1_h1_wk_h2 ! proton-electron-proton (pep) reaction 
       
    ! erg/g/s
-      !reaction_neu r_h1_h1_ec_h2 
-      !reaction_neu r_h1_h1_wk_h2
+      !eps_neu_rate r_h1_h1_ec_h2 
+      !eps_neu_rate r_h1_h1_wk_h2
       
    ! reactions/second
       !raw_rate r_h1_h1_ec_h2 

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -296,7 +296,7 @@
       
    ! erg/g/s
       !reaction_neu r_h1_h1_ec_h2 
-      !reaction_new r_h1_h1_wk_h2
+      !reaction_neu r_h1_h1_wk_h2
       
    ! reactions/second
       !raw_rate r_h1_h1_ec_h2 

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -934,6 +934,15 @@
                else ! location of top
                   col_name = 'mix_qtop_' // trim(str)
                end if
+            else if (c > eps_neu_offset) then
+               i = c - eps_neu_offset
+               col_name = 'eps_neu_' // trim(reaction_name(i))
+            else if (c > eps_nuc_offset) then
+               i = c - eps_nuc_offset
+               col_name = 'eps_nuc_' // trim(reaction_name(i))
+            else if (c > screened_rate_offset) then
+               i = c - screened_rate_offset
+               col_name = 'screened_rate_' // trim(reaction_name(i))
             else if (c > raw_rate_offset) then
                i = c - raw_rate_offset
                col_name = 'raw_rate_' // trim(reaction_name(i))
@@ -1204,10 +1213,27 @@
             v_flag = .false.
          end if
          
-         if (c > raw_rate_offset) THEN
+         if (c > eps_neu_offset) THEN
+             i = c - eps_neu_offset
+             val = 0
+             do k = 1, s% nz
+                val = 0 ! TODO
+             end do
+         else if (c > eps_nuc_offset) THEN
+             i = c - eps_nuc_offset
+             val = 0
+             do k = 1, s% nz
+                val = 0 ! TODO
+             end do
+         else if (c > screened_rate_offset) THEN
+             i = c - screened_rate_offset
+             val = 0
+             do k = 1, s% nz
+                val = 0 ! TODO
+             end do
+         else if (c > raw_rate_offset) THEN
              i = c - raw_rate_offset
              ! i is the reaction id 
-             !val = 1d0 ! get rate
              val = 0
              tf => tf2
              do k = 1, s% nz
@@ -1215,6 +1241,7 @@
                 call get_raw_rate(i, s% which_rates(i), s% t(k), tf, raw_rate, ierr)
                 val = val + raw_rate
              end do
+             !deallocate(tf)
          else if (c > log_lum_band_offset) THEN
             ! We want log Teff, Log g, M/H, Lum/lsun at the photosphere
             k = s% photosphere_cell_k

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -934,12 +934,12 @@
                else ! location of top
                   col_name = 'mix_qtop_' // trim(str)
                end if
-            else if (c > eps_neu_offset) then
-               i = c - eps_neu_offset
-               col_name = 'eps_neu_' // trim(reaction_name(i))
-            else if (c > eps_nuc_offset) then
-               i = c - eps_nuc_offset
-               col_name = 'eps_nuc_' // trim(reaction_name(i))
+            else if (c > eps_neu_rate_offset) then
+               i = c - eps_neu_rate_offset
+               col_name = 'eps_neu_rate_' // trim(reaction_name(i))
+            else if (c > eps_nuc_rate_offset) then
+               i = c - eps_nuc_rate_offset
+               col_name = 'eps_nuc_rate_' // trim(reaction_name(i))
             else if (c > screened_rate_offset) then
                i = c - screened_rate_offset
                col_name = 'screened_rate_' // trim(reaction_name(i))
@@ -1213,14 +1213,14 @@
             v_flag = .false.
          end if
          
-         if (c > eps_neu_offset) THEN
-             i = c - eps_neu_offset
+         if (c > eps_neu_rate_offset) THEN
+             i = c - eps_neu_rate_offset
              val = 0
              do k = 1, s% nz
                 val = 0 ! TODO
              end do
-         else if (c > eps_nuc_offset) THEN
-             i = c - eps_nuc_offset
+         else if (c > eps_nuc_rate_offset) THEN
+             i = c - eps_nuc_rate_offset
              val = 0
              do k = 1, s% nz
                 val = 0 ! TODO
@@ -1241,7 +1241,7 @@
                 call get_raw_rate(i, s% which_rates(i), s% t(k), tf, raw_rate, ierr)
                 val = val + raw_rate
              end do
-             !deallocate(tf)
+             nullify(tf)
          else if (c > log_lum_band_offset) THEN
             ! We want log Teff, Log g, M/H, Lum/lsun at the photosphere
             k = s% photosphere_cell_k

--- a/star/private/history_specs.f90
+++ b/star/private/history_specs.f90
@@ -59,10 +59,10 @@
       
       integer, parameter :: raw_rate_offset = log_lum_band_offset + idel
       integer, parameter :: screened_rate_offset = raw_rate_offset + idel
-      integer, parameter :: eps_nuc_offset = screened_rate_offset + idel
-      integer, parameter :: eps_neu_offset = eps_nuc_offset + idel
+      integer, parameter :: eps_nuc_rate_offset = screened_rate_offset + idel
+      integer, parameter :: eps_neu_rate_offset = eps_nuc_rate_offset + idel
 
-      integer, parameter :: start_of_special_cases = eps_neu_offset + idel
+      integer, parameter :: start_of_special_cases = eps_neu_rate_offset + idel
       ! mixing and burning regions must be given the largest offsets
       ! so they can be distinguished from the other ones
 
@@ -294,8 +294,8 @@
                cycle
             end if
 
-            if (string == 'add_eps_nuc') then
-               call do_rate(eps_nuc_offset,'eps_nuc_', spec_err)
+            if (string == 'add_eps_nuc_rates') then
+               call do_rate(eps_nuc_rate_offset,'eps_nuc_rate_', spec_err)
                if (spec_err /= 0) then
                   call error; return
                end if
@@ -303,8 +303,8 @@
                cycle
             end if
 
-            if (string == 'add_eps_neu') then
-               call do_rate(eps_neu_offset,'eps_neu_', spec_err)
+            if (string == 'add_eps_neu_rates') then
+               call do_rate(eps_neu_rate_offset,'eps_neu_rate_', spec_err)
                if (spec_err /= 0) then
                   call error; return
                end if
@@ -472,7 +472,7 @@
             end do
          end subroutine do_colors
 
-         subroutine do_rate(offset,prefix,ierr) ! raw_rate, screened_rate, eps_nuc, eps_neu
+         subroutine do_rate(offset,prefix,ierr) ! raw_rate, screened_rate, eps_nuc_rate, eps_neu_rate
             use rates_def, only: reaction_name
             integer, intent(in) :: offset
             character(len=*) :: prefix
@@ -522,11 +522,11 @@
          else if (string=='screened_rate') then
             call do1_rate(screened_rate_offset)
 
-         else if (string=='eps_nuc') then
-            call do1_rate(eps_nuc_offset)
+         else if (string=='eps_nuc_rate') then
+            call do1_rate(eps_nuc_rate_offset)
 
-         else if (string=='eps_neu') then
-            call do1_rate(eps_neu_offset)
+         else if (string=='eps_neu_rate') then
+            call do1_rate(eps_neu_rate_offset)
 
          else if (string=='abs_mag') then
             call do1_color(abs_mag_offset)

--- a/star/private/history_specs.f90
+++ b/star/private/history_specs.f90
@@ -58,8 +58,11 @@
       integer, parameter :: log_lum_band_offset = lum_band_offset + idel
       
       integer, parameter :: raw_rate_offset = log_lum_band_offset + idel
+      integer, parameter :: screened_rate_offset = raw_rate_offset + idel
+      integer, parameter :: eps_nuc_offset = screened_rate_offset + idel
+      integer, parameter :: eps_neu_offset = eps_nuc_offset + idel
 
-      integer, parameter :: start_of_special_cases = raw_rate_offset + idel
+      integer, parameter :: start_of_special_cases = eps_neu_offset + idel
       ! mixing and burning regions must be given the largest offsets
       ! so they can be distinguished from the other ones
 
@@ -274,7 +277,34 @@
             end if
 
             if (string == 'add_raw_rates') then
-               call do_raw_rate(raw_rate_offset,'raw_rate_', spec_err)
+               call do_rate(raw_rate_offset,'raw_rate_', spec_err)
+               if (spec_err /= 0) then
+                  call error; return
+               end if
+               call count_specs
+               cycle
+            end if
+
+            if (string == 'add_screened_rates') then
+               call do_rate(screened_rate_offset,'screened_rate_', spec_err)
+               if (spec_err /= 0) then
+                  call error; return
+               end if
+               call count_specs
+               cycle
+            end if
+
+            if (string == 'add_eps_nuc') then
+               call do_rate(eps_nuc_offset,'eps_nuc_', spec_err)
+               if (spec_err /= 0) then
+                  call error; return
+               end if
+               call count_specs
+               cycle
+            end if
+
+            if (string == 'add_eps_neu') then
+               call do_rate(eps_neu_offset,'eps_neu_', spec_err)
                if (spec_err /= 0) then
                   call error; return
                end if
@@ -442,8 +472,7 @@
             end do
          end subroutine do_colors
 
-         subroutine do_raw_rate(offset,prefix,ierr)
-            !use rates_lib, only: rates_reaction_id
+         subroutine do_rate(offset,prefix,ierr) ! raw_rate, screened_rate, eps_nuc, eps_neu
             use rates_def, only: reaction_name
             integer, intent(in) :: offset
             character(len=*) :: prefix
@@ -455,7 +484,7 @@
                   offset + k,trim(prefix)//trim(reaction_name(k)), ierr)
                if (ierr /= 0) return
             end do
-         end subroutine do_raw_rate
+         end subroutine do_rate
 
 
          subroutine error
@@ -488,7 +517,16 @@
          special_case = .false.
 
          if (string=='raw_rate') then
-            call do1_raw_rate(raw_rate_offset)
+            call do1_rate(raw_rate_offset)
+
+         else if (string=='screened_rate') then
+            call do1_rate(screened_rate_offset)
+
+         else if (string=='eps_nuc') then
+            call do1_rate(eps_nuc_offset)
+
+         else if (string=='eps_neu') then
+            call do1_rate(eps_neu_offset)
 
          else if (string=='abs_mag') then
             call do1_color(abs_mag_offset)
@@ -612,7 +650,7 @@
             ierr = -1
          end subroutine do1_color
 
-         subroutine do1_raw_rate(offset)
+         subroutine do1_rate(offset)
             use rates_lib, only: rates_reaction_id
             integer, intent(in) :: offset
             t = token(iounit, n, i, buffer, string)
@@ -627,7 +665,7 @@
             end if
             write(*,*) 'bad filter name: ' // trim(string)
             ierr = -1
-         end subroutine do1_raw_rate
+         end subroutine do1_rate
 
 
       end function do1_history_spec

--- a/star/private/profile.f90
+++ b/star/private/profile.f90
@@ -129,14 +129,14 @@
                end if
                call count_specs
                
-            case ('add_eps_neu')
-               call insert_spec(eps_neu_offset, 'add_eps_neu', spec_err)
+            case ('add_eps_neu_rates')
+               call insert_spec(eps_neu_rate_offset, 'add_eps_neu_rate', spec_err)
                if (spec_err /= 0) then
                   ierr = -1; call error; return
                end if
                
-            case ('add_eps_nuc')
-               call insert_spec(eps_nuc_offset, 'add_eps_nuc', spec_err)
+            case ('add_eps_nuc_rates')
+               call insert_spec(eps_nuc_rate_offset, 'add_eps_nuc_rate', spec_err)
                if (spec_err /= 0) then
                   ierr = -1; call error; return
                end if
@@ -306,8 +306,8 @@
                numcols = numcols + s% species
             else if (s% profile_column_spec(j) == raw_rate_offset .or. &
                      s% profile_column_spec(j) == screened_rate_offset .or. & 
-                     s% profile_column_spec(j) == eps_nuc_offset .or. & 
-                     s% profile_column_spec(j) == eps_neu_offset) then
+                     s% profile_column_spec(j) == eps_nuc_rate_offset .or. & 
+                     s% profile_column_spec(j) == eps_neu_rate_offset) then
                numcols = numcols + s% num_reactions
             else
                numcols = numcols + 1
@@ -631,8 +631,8 @@
                      end do
                   else if (s% profile_column_spec(j) == raw_rate_offset .or. &
                            s% profile_column_spec(j) == screened_rate_offset .or. &
-                           s% profile_column_spec(j) == eps_nuc_offset .or. &
-                           s% profile_column_spec(j) == eps_neu_offset) then
+                           s% profile_column_spec(j) == eps_nuc_rate_offset .or. &
+                           s% profile_column_spec(j) == eps_neu_rate_offset) then
                      do jj = 1, s% num_reactions
                         col = col+1
                         call do_rate_col(i, j, jj, kk)
@@ -808,12 +808,12 @@
                if (c > extra_offset) then
                   i = c - extra_offset
                   col_name = trim(s% profile_extra_name(i))
-               else if (c > eps_neu_offset) then
-                  i = c - eps_neu_offset
-                  col_name = 'eps_neu_' // trim(reaction_name(i))
-               else if (c > eps_nuc_offset) then
-                  i = c - eps_nuc_offset
-                  col_name = 'eps_nuc_' // trim(reaction_name(i))
+               else if (c > eps_neu_rate_offset) then
+                  i = c - eps_neu_rate_offset
+                  col_name = 'eps_neu_rate_' // trim(reaction_name(i))
+               else if (c > eps_nuc_rate_offset) then
+                  i = c - eps_nuc_rate_offset
+                  col_name = 'eps_nuc_rate_' // trim(reaction_name(i))
                else if (c > screened_rate_offset) then
                   i = c - screened_rate_offset
                   col_name = 'screened_rate_' // trim(reaction_name(i))
@@ -948,10 +948,10 @@
             if (pass == 1) then
                if (write_flag) write(io, fmt=int_fmt, advance='no') col
             else if (pass == 2) then
-               if (c >= eps_neu_offset) then
-                  col_name = 'eps_neu_' // trim(reaction_name(jj))
-               else if (c >= eps_nuc_offset) then
-                  col_name = 'eps_nuc_' // trim(reaction_name(jj))
+               if (c >= eps_neu_rate_offset) then
+                  col_name = 'eps_neu_rate_' // trim(reaction_name(jj))
+               else if (c >= eps_nuc_rate_offset) then
+                  col_name = 'eps_nuc_rate_' // trim(reaction_name(jj))
                else if (c >= screened_rate_offset) then
                   col_name = 'screened_rate_' // trim(reaction_name(jj))
                else if (c >= raw_rate_offset) then
@@ -963,9 +963,9 @@
                   names(col) = trim(col_name)
                end if
             else if (pass == 3) then
-               if (c >= eps_neu_offset) then
+               if (c >= eps_neu_rate_offset) then
                   val = 0d0 ! TODO
-               else if (c >= eps_nuc_offset) then
+               else if (c >= eps_nuc_rate_offset) then
                   val = 0d0 ! TODO
                else if (c >= screened_rate_offset) then
                   val = 0d0 ! TODO
@@ -974,7 +974,7 @@
                   call eval_tfactors(tf, log10(s% t(k)), s% t(k))
                   call get_raw_rate(jj, s% which_rates(jj), s% t(k), tf, raw_rate, ierr)
                   val = raw_rate
-                  deallocate(tf)
+                  nullify(tf)
                end if
                if (write_flag) then
                   write(io, fmt=dbl_fmt, advance='no') val

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -261,11 +261,11 @@
          use mod_typical_charge, only: eval_typical_charge
          use rsp_def, only: rsp_WORK, rsp_WORKQ, rsp_WORKT, rsp_WORKC
          
-         use net_def, only: Net_Info
-         use net_lib, only: net_work_size, get_reaction_id_table_ptr, get_net_rate_ptrs
-         use rates_def, only: T_Factors, reaction_name, std_reaction_Qs, std_reaction_neuQs
-         use rates_lib, only: get_raw_rate, eval_tfactors, rates_reaction_id, screening_option
-         use eos_def, only : i_eta
+         !use net_def, only: Net_Info
+         !use net_lib, only: net_work_size, get_reaction_id_table_ptr, get_net_rate_ptrs
+         use rates_def, only: T_Factors!, reaction_name, std_reaction_Qs, std_reaction_neuQs
+         use rates_lib, only: get_raw_rate, eval_tfactors!, rates_reaction_id, screening_option
+         !use eos_def, only : i_eta
          
          type (star_info), pointer :: s
          integer, intent(in) :: c, k
@@ -276,18 +276,17 @@
          real(dp) :: raw_rate
          type (T_Factors), pointer :: tf
          type (T_Factors), target :: tf2
-         !real(dp), pointer :: work(:)
-         integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
-         integer :: net_lwork
-         real(dp), target :: net_work_ary
-         real(dp), pointer :: net_work(:)
-         real(dp), pointer, dimension(:) :: &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho
-         integer :: ir
-         real(dp) :: log10_rho, log10_T, d_eps_nuc_dRho, d_eps_nuc_dT
-         type (Net_Info), target :: net_info_target
-         type (Net_Info), pointer :: netinfo
+         !integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
+         !integer :: net_lwork
+         !real(dp), target :: net_work_ary
+         !real(dp), pointer :: net_work(:)
+         !real(dp), pointer, dimension(:) :: &
+         !   rate_screened, rate_screened_dT, rate_screened_dRho, &
+         !   rate_raw, rate_raw_dT, rate_raw_dRho
+         !integer :: ir
+         !real(dp) :: log10_rho, log10_T, d_eps_nuc_dRho, d_eps_nuc_dT
+         !type (Net_Info), target :: net_info_target
+         !type (Net_Info), pointer :: netinfo
 
          real(dp) :: cno, z, x, frac, eps, eps_alt, L_rad, L_edd, Pbar_00, Pbar_p1, &
             P_face, rho_face, dr, v, r00, rp1, v00, vp1, A00, Ap1, Amid, &
@@ -321,64 +320,66 @@
          int_flag = .false.
          rsp_or_w = s% RSP_flag .or. s% RSP2_flag
          
-         if (c < eps_neu_rate_offset + idel .and. c > screened_rate_offset) then
-             if (s% screening_mode_value < 0) then
-                s% screening_mode_value = screening_option(s% screening_mode, ierr)
-                if (ierr /= 0) then
-                   write(*,*) 'failed in screening_option'
-                   stop 1
-                end if
-             end if
-             
-             net_work => net_work_ary
-             netinfo => net_info_target
-          
-             log10_rho = s% lnd(k)/ln10
-             log10_T = s% lnT(k)/ln10
-             
-             net_lwork = net_work_size(s% net_handle, ierr)
-             
-             call net_get( &
-                s% net_handle, .false., netinfo, species, s% num_reactions, s% xa(1:species,k), &
-                s% T(k), log10_T, s% rho(k), log10_Rho, &
-                s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
-                s% eta(k), s% d_eos_dlnd(i_eta,k), s% d_eos_dlnT(i_eta,k), &
-                s% rate_factors, s% weak_rate_factor, &
-                std_reaction_Qs, std_reaction_neuQs, &
-                s% eps_nuc(k), d_eps_nuc_dRho, d_eps_nuc_dT, s% d_epsnuc_dx(:,k), & 
-                s% dxdt_nuc(:,k), s% d_dxdt_nuc_dRho(:,k), s% d_dxdt_nuc_dT(:,k), s% d_dxdt_nuc_dx(:,:,k), &
-                s% screening_mode_value, &
-                s% eps_nuc_categories(:,k), &
-                s% eps_nuc_neu_total(k), net_lwork, net_work, ierr)
-             if (ierr /= 0) then
-                write(*,*) 'failed in net_get'
-                stop 1
-             end if
-         
-             call get_net_rate_ptrs(s% net_handle, &
-                rate_screened, rate_screened_dT, rate_screened_dRho, &
-                rate_raw, rate_raw_dT, rate_raw_dRho, net_lwork, net_work, &
-                ierr)
-             if (ierr /= 0) then
-                write(*,*) 'failed in get_net_rate_ptrs'
-                stop 1
-             end if
-             ir = rates_reaction_id(reaction_name(i))
-         end if
+         ! TODO: implement eps_neu_rate, eps_nuc_rate, screened_rate
+         !if (c < eps_neu_rate_offset + idel .and. c > screened_rate_offset) then
+         !    if (s% screening_mode_value < 0) then
+         !       s% screening_mode_value = screening_option(s% screening_mode, ierr)
+         !       if (ierr /= 0) then
+         !          write(*,*) 'failed in screening_option'
+         !          stop 1
+         !       end if
+         !    end if
+         !    
+         !    net_work => net_work_ary
+         !    netinfo => net_info_target
+         ! 
+         !    log10_rho = s% lnd(k)/ln10
+         !    log10_T = s% lnT(k)/ln10
+         !    
+         !    net_lwork = net_work_size(s% net_handle, ierr)
+         !    
+         !    call net_get( &
+         !       s% net_handle, .false., netinfo, species, s% num_reactions, s% xa(1:species,k), &
+         !       s% T(k), log10_T, s% rho(k), log10_Rho, &
+         !       s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
+         !       s% eta(k), s% d_eos_dlnd(i_eta,k), s% d_eos_dlnT(i_eta,k), &
+         !       s% rate_factors, s% weak_rate_factor, &
+         !       std_reaction_Qs, std_reaction_neuQs, &
+         !       s% eps_nuc(k), d_eps_nuc_dRho, d_eps_nuc_dT, s% d_epsnuc_dx(:,k), & 
+         !       s% dxdt_nuc(:,k), s% d_dxdt_nuc_dRho(:,k), s% d_dxdt_nuc_dT(:,k), s% d_dxdt_nuc_dx(:,:,k), &
+         !       s% screening_mode_value, &
+         !       s% eps_nuc_categories(:,k), &
+         !       s% eps_nuc_neu_total(k), net_lwork, net_work, ierr)
+         !    if (ierr /= 0) then
+         !       write(*,*) 'failed in net_get'
+         !       stop 1
+         !    end if
+         !
+         !    call get_net_rate_ptrs(s% net_handle, &
+         !       rate_screened, rate_screened_dT, rate_screened_dRho, &
+         !       rate_raw, rate_raw_dT, rate_raw_dRho, net_lwork, net_work, &
+         !       ierr)
+         !    if (ierr /= 0) then
+         !       write(*,*) 'failed in get_net_rate_ptrs'
+         !       stop 1
+         !    end if
+         !    ir = rates_reaction_id(reaction_name(i))
+         !end if
 
          if (c > extra_offset) then
             i = c - extra_offset
             val = s% profile_extra(k,i)
+         ! TODO: implement eps_neu_rate, eps_nuc_rate, screened_rate
          else if (c > eps_neu_rate_offset) then
             i = c - eps_neu_rate_offset
-            val = rate_screened(i) * std_reaction_neuQs(ir) * Qconv
+            val = 0 !rate_screened(i) * std_reaction_neuQs(ir) * Qconv
          else if (c > eps_nuc_rate_offset) then
             i = c - eps_nuc_rate_offset
-            val = rate_screened(i) * &
-                (std_reaction_Qs(ir) - std_reaction_neuQs(ir)) * Qconv
+            val = 0 !rate_screened(i) * &
+                !(std_reaction_Qs(ir) - std_reaction_neuQs(ir)) * Qconv
          else if (c > screened_rate_offset) then
             i = c - screened_rate_offset
-            val = rate_screened(i)
+            val = 0 !rate_screened(i)
          else if (c > raw_rate_offset) then
             i = c - raw_rate_offset
             tf => tf2

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -260,7 +260,13 @@
          use rates_def
          use mod_typical_charge, only: eval_typical_charge
          use rsp_def, only: rsp_WORK, rsp_WORKQ, rsp_WORKT, rsp_WORKC
-         use rates_lib, only: get_raw_rate, eval_tfactors
+         
+         use net_def, only: Net_Info
+         use net_lib, only: net_work_size, get_reaction_id_table_ptr, get_net_rate_ptrs
+         use rates_def, only: T_Factors, reaction_name, std_reaction_Qs, std_reaction_neuQs
+         use rates_lib, only: get_raw_rate, eval_tfactors, rates_reaction_id, screening_option
+         use eos_def, only : i_eta
+         
          type (star_info), pointer :: s
          integer, intent(in) :: c, k
          real(dp), intent(out) :: val
@@ -270,6 +276,18 @@
          real(dp) :: raw_rate
          type (T_Factors), pointer :: tf
          type (T_Factors), target :: tf2
+         !real(dp), pointer :: work(:)
+         integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
+         integer :: net_lwork
+         real(dp), target :: net_work_ary
+         real(dp), pointer :: net_work(:)
+         real(dp), pointer, dimension(:) :: &
+            rate_screened, rate_screened_dT, rate_screened_dRho, &
+            rate_raw, rate_raw_dT, rate_raw_dRho
+         integer :: ir
+         real(dp) :: log10_rho, log10_T, d_eps_nuc_dRho, d_eps_nuc_dT
+         type (Net_Info), target :: net_info_target
+         type (Net_Info), pointer :: netinfo
 
          real(dp) :: cno, z, x, frac, eps, eps_alt, L_rad, L_edd, Pbar_00, Pbar_p1, &
             P_face, rho_face, dr, v, r00, rp1, v00, vp1, A00, Ap1, Amid, &
@@ -302,26 +320,66 @@
 
          int_flag = .false.
          rsp_or_w = s% RSP_flag .or. s% RSP2_flag
+         
+         if (c < eps_neu_rate_offset + idel .and. c > screened_rate_offset) then
+             if (s% screening_mode_value < 0) then
+                s% screening_mode_value = screening_option(s% screening_mode, ierr)
+                if (ierr /= 0) then
+                   write(*,*) 'failed in screening_option'
+                   stop 1
+                end if
+             end if
+             
+             net_work => net_work_ary
+             netinfo => net_info_target
+          
+             log10_rho = s% lnd(k)/ln10
+             log10_T = s% lnT(k)/ln10
+             
+             net_lwork = net_work_size(s% net_handle, ierr)
+             
+             call net_get( &
+                s% net_handle, .false., netinfo, species, s% num_reactions, s% xa(1:species,k), &
+                s% T(k), log10_T, s% rho(k), log10_Rho, &
+                s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
+                s% eta(k), s% d_eos_dlnd(i_eta,k), s% d_eos_dlnT(i_eta,k), &
+                s% rate_factors, s% weak_rate_factor, &
+                std_reaction_Qs, std_reaction_neuQs, &
+                s% eps_nuc(k), d_eps_nuc_dRho, d_eps_nuc_dT, s% d_epsnuc_dx(:,k), & 
+                s% dxdt_nuc(:,k), s% d_dxdt_nuc_dRho(:,k), s% d_dxdt_nuc_dT(:,k), s% d_dxdt_nuc_dx(:,:,k), &
+                s% screening_mode_value, &
+                s% eps_nuc_categories(:,k), &
+                s% eps_nuc_neu_total(k), net_lwork, net_work, ierr)
+             if (ierr /= 0) then
+                write(*,*) 'failed in net_get'
+                stop 1
+             end if
+         
+             call get_net_rate_ptrs(s% net_handle, &
+                rate_screened, rate_screened_dT, rate_screened_dRho, &
+                rate_raw, rate_raw_dT, rate_raw_dRho, net_lwork, net_work, &
+                ierr)
+             if (ierr /= 0) then
+                write(*,*) 'failed in get_net_rate_ptrs'
+                stop 1
+             end if
+             ir = rates_reaction_id(reaction_name(i))
+         end if
 
-         write(*,*) 'c =', c
          if (c > extra_offset) then
-            write(*,*) 'extra offset'
             i = c - extra_offset
             val = s% profile_extra(k,i)
          else if (c > eps_neu_rate_offset) then
-            write(*,*) 'eps_neu'
             i = c - eps_neu_rate_offset
-            val = 0d0 ! TODO
+            val = rate_screened(i) * std_reaction_neuQs(ir) * Qconv
          else if (c > eps_nuc_rate_offset) then
-            write(*,*) 'eps_nuc'
             i = c - eps_nuc_rate_offset
-            val = 0d0 ! TODO
+            val = rate_screened(i) * &
+                (std_reaction_Qs(ir) - std_reaction_neuQs(ir)) * Qconv
          else if (c > screened_rate_offset) then
-            write(*,*) 'screened'
             i = c - screened_rate_offset
-            val = 0d0 ! TODO
+            val = rate_screened(i)
          else if (c > raw_rate_offset) then
-            write(*,*) 'raw'
             i = c - raw_rate_offset
             tf => tf2
             call eval_tfactors(tf, log10(s% t(k)), s% t(k))

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -55,9 +55,9 @@
       integer, parameter :: diffusion_D_offset = diffusion_dX_offset + idel
       integer, parameter :: raw_rate_offset = diffusion_D_offset + idel
       integer, parameter :: screened_rate_offset = raw_rate_offset + idel
-      integer, parameter :: eps_nuc_offset = screened_rate_offset + idel
-      integer, parameter :: eps_neu_offset = eps_nuc_offset + idel
-      integer, parameter :: extra_offset = eps_neu_offset + idel
+      integer, parameter :: eps_nuc_rate_offset = screened_rate_offset + idel
+      integer, parameter :: eps_neu_rate_offset = eps_nuc_rate_offset + idel
+      integer, parameter :: extra_offset = eps_neu_rate_offset + idel
 
       integer, parameter :: max_profile_offset = extra_offset + idel
 
@@ -127,11 +127,11 @@
             case ('log') ! add log of abundance
                call do1_nuclide(log_abundance_offset)
 
-            case ('eps_neu')
-                call do1_rate(eps_neu_offset)
+            case ('eps_neu_rate')
+                call do1_rate(eps_neu_rate_offset)
 
-            case ('eps_nuc')
-                call do1_rate(eps_nuc_offset)
+            case ('eps_nuc_rate')
+                call do1_rate(eps_nuc_rate_offset)
 
             case ('screened_rate')
                 call do1_rate(screened_rate_offset)
@@ -190,7 +190,7 @@
             ierr = -1
          end subroutine do1_nuclide
 
-         subroutine do1_rate(offset) ! raw_rate, screened_rate, eps_nuc, eps_neu
+         subroutine do1_rate(offset) ! raw_rate, screened_rate, eps_nuc_rate, eps_neu_rate
             use rates_lib, only: rates_reaction_id
             integer, intent(in) :: offset
             integer :: t, id
@@ -306,11 +306,11 @@
          if (c > extra_offset) then
             i = c - extra_offset
             val = s% profile_extra(k,i)
-         else if (c > eps_neu_offset) then
-            i = c - eps_neu_offset
+         else if (c > eps_neu_rate_offset) then
+            i = c - eps_neu_rate_offset
             val = 0d0 ! TODO
-         else if (c > eps_nuc_offset) then
-            i = c - eps_nuc_offset
+         else if (c > eps_nuc_rate_offset) then
+            i = c - eps_nuc_rate_offset
             val = 0d0 ! TODO
          else if (c > screened_rate_offset) then
             i = c - screened_rate_offset
@@ -321,7 +321,7 @@
             call eval_tfactors(tf, log10(s% t(k)), s% t(k))
             call get_raw_rate(i, s% which_rates(i), s% t(k), tf, raw_rate, ierr)
             val = raw_rate
-            !deallocate(tf)
+            nullify(tf)
          else if (c > diffusion_D_offset) then
             i = c - diffusion_D_offset
             ii = s% net_iso(i)

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -303,19 +303,25 @@
          int_flag = .false.
          rsp_or_w = s% RSP_flag .or. s% RSP2_flag
 
+         write(*,*) 'c =', c
          if (c > extra_offset) then
+            write(*,*) 'extra offset'
             i = c - extra_offset
             val = s% profile_extra(k,i)
          else if (c > eps_neu_rate_offset) then
+            write(*,*) 'eps_neu'
             i = c - eps_neu_rate_offset
             val = 0d0 ! TODO
          else if (c > eps_nuc_rate_offset) then
+            write(*,*) 'eps_nuc'
             i = c - eps_nuc_rate_offset
             val = 0d0 ! TODO
          else if (c > screened_rate_offset) then
+            write(*,*) 'screened'
             i = c - screened_rate_offset
             val = 0d0 ! TODO
          else if (c > raw_rate_offset) then
+            write(*,*) 'raw'
             i = c - raw_rate_offset
             tf => tf2
             call eval_tfactors(tf, log10(s% t(k)), s% t(k))


### PR DESCRIPTION
Adds the capability to output either all the raw rates from the current net, or specifically chosen ones, as specified in the history and profile columns lists. 

One can add `add_raw_rates` to either file to get all of the rates -- either zone by zone (added to `profile_columns.list`) or summed over all the zones (`history_columns.list`). Alternatively, one can specify individual rates, such as `raw_rate r_h1_h1_ec_h2`, to get only the information for that rate. 

If one requests a rate that does not exist (e.g. `r_h12_h1_wk_h2`), then it fails while reading with the error `bad rate name: r_h12_h1_wk_h2`. 

It furthermore adds the boilerplate code to set up similar outputs for `add_screened_rates`, `add_eps_nuc_rates`, `add_eps_neu_rates`, and their individual counterparts. However, the actual functionality for these three outputs have not yet been implemented, and they all return 0 if called. 

Testhub results: https://testhub.mesastar.org/epb%2Frates-output/commits/292e11a (all passing) 