### PR TITLE
fix to binary b_fm timestep control 

### DIFF
--- a/binary/private/binary_timestep.f90
+++ b/binary/private/binary_timestep.f90
@@ -126,7 +126,8 @@
 
          if (b% max_timestep < 0) b% max_timestep = b% s_donor% dt
 
-         b% env = s% star_mass - s% he_core_mass 
+         b% env = s% star_mass - s% he_core_mass
+         b% env_old = s% mstar_old / Msun - s% he_core_mass_old  ! donor might have switched
          if (b% env_old /= 0) then
             env_change = b% env - b% env_old
          else


### PR DESCRIPTION
the binary timestep control b_fm might be unjustly tripped if the donor was switched.

If the donor is switched at the start of the step, b% env_old is not updated to reflect the envelope mass of the new donor.