### PR TITLE
Update astero results format to match profiles and histories

### DIFF
--- a/astero/defaults/astero_search.defaults
+++ b/astero/defaults/astero_search.defaults
@@ -1178,6 +1178,20 @@
 
       astero_results_directory = 'outputs'
 
+   ! astero_results_dbl_format
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~
+   ! astero_results_int_format
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~
+   ! astero_results_txt_format
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   ! Formats for writing floats (reals), integers and characters
+   ! (strings) to the results file.
+
+   astero_results_dbl_format = '(1pes26.16)'
+   astero_results_int_format = '(i26)'
+   astero_results_txt_format = '(a26)'
+
    ! write_best_model_data_for_each_sample
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ! ::

--- a/astero/private/astero_run_support.f90
+++ b/astero/private/astero_run_support.f90
@@ -511,7 +511,8 @@
          just_counting = .false.
          
          if (restart_scan_grid_from_file) then
-            call read_samples_from_file(scan_grid_output_filename, ierr)
+            call read_samples_from_file( &
+               trim(astero_results_directory) // '/' // trim(scan_grid_output_filename), ierr)
             if (ierr /= 0) return
             scan_grid_skip_number = sample_number
             sample_number = 0
@@ -1327,7 +1328,8 @@
          end if
                   
          if (restart_simplex_from_file) then
-            call read_samples_from_file(simplex_output_filename, ierr)
+            call read_samples_from_file( &
+               trim(astero_results_directory) // '/' // trim(simplex_output_filename), ierr)
             if (ierr /= 0) return
             if (sample_number < nvar+1) then
                write(*,2) 'sorry: too few points. for simplex restart need at least', nvar+1

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -1369,42 +1369,29 @@
          ! column numbers
          write(fmt,'(a)') '(99' // trim(astero_results_int_format) // ')'
 
-         k = 1
-         do i = 1, 41
-            write(iounit, fmt, advance='no') k
-            k = k+1
-         end do
+         k = 41 ! fixed columns
 
          if (chi2_seismo_fraction > 0) then
 
             do l = 0, 3
-               do j = 1, nl(l)
-                  do i = 1, 6
-                     write(iounit, fmt, advance='no') k
-                     k = k+1
-                  end do
-               end do
+               k = k + 6*nl(l)
             end do
 
-            do j = 1, ratios_n
-               do i = 1, 6
-                  write(iounit, fmt, advance='no') k
-                  k = k+1
-               end do
-            end do
+            k = k + 6*ratios_n
 
             if (chi2_seismo_r_02_fraction > 0) then
-               do j = 1, nl(0)
-                  do i = 1, 3
-                     write(iounit, fmt, advance='no') k
-                     k = k+1
-                  end do
-               end do
+               k = k + 3*nl(0)
             end if
 
          end if
 
-         write(iounit, '(a)')
+         if (search_type == 'simplex') k = k+1
+
+         do i = 1, k
+            write(iounit, fmt, advance='no') i
+         end do
+
+         write(iounit, '(a)') ! end of column numbers line
 
          ! column names
          write(fmt,'(a)') '(99' // trim(astero_results_txt_format) // ')'
@@ -1496,8 +1483,12 @@
             end if
          
          end if
+
+         if (search_type == 'simplex') then
+            write(iounit, astero_results_txt_format, advance='no') 'step_type'
+         end if
          
-         write(iounit, '(a)') ! end of line
+         write(iounit, '(a)') ! end of column names line
                                           
       end subroutine show_sample_header
       
@@ -1601,8 +1592,12 @@
             end if
          
          end if
-            
-         write(iounit, '(a12)') trim(info_str)
+
+         if (search_type == 'simplex') then
+            write(iounit, astero_results_txt_format, advance='no') trim(info_str)
+         end if
+
+         write(iounit, '(a)') ! end of line
       
       end subroutine show1_sample_results
       

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -1404,7 +1404,7 @@
 
          end if
 
-         write(iounit, '(a)') 
+         write(iounit, '(a)')
 
          ! column names
          write(fmt,'(a)') '(99' // trim(astero_results_txt_format) // ')'

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -1359,13 +1359,17 @@
       
       
       subroutine show_sample_header(iounit)
-         integer, intent(in) ::iounit
+         integer, intent(in) :: iounit
          
          integer :: j, l
+         character (len=strlen) :: fmt
          character (len=10) :: str
          character (len=1) :: l_str
+
+         write(fmt,'(a)') '(2x,a6,99' // trim(astero_results_txt_format) // ')'
       
-         write(iounit,'(2x,a6,10a26,a16,22a26,7a20)',advance='no') &
+         ! write(iounit,'(2x,a6,10a26,a16,22a26,7a20)',advance='no') &
+         write(iounit, fmt, advance='no') &
             'sample', &
             
             'chi2', &
@@ -1412,6 +1416,8 @@
             'ratios_l0_first', &
             'ratios_l1_first'
          
+         write(fmt,'(a)') '(99' // trim(astero_results_txt_format) // ')'
+
          if (chi2_seismo_fraction > 0) then
 
             do l=0,3
@@ -1419,7 +1425,7 @@
                do j=1,nl(l)
                   write(str,'(i3)') j
                   str = adjustl(str)
-                  write(iounit,'(99a26)',advance='no') &
+                  write(iounit, fmt, advance='no') &
                      'l' // l_str // '_order_' // trim(str), &
                      'l' // l_str // '_obs_' // trim(str), &
                      'l' // l_str // '_obs_sigma_' // trim(str), &
@@ -1430,14 +1436,9 @@
             end do
 
             do j=1,ratios_n
-               if (j < 10) then
-                  write(str,'(i1)') j
-               else if (j < 100) then
-                  write(str,'(i2)') j
-               else
-                  write(str,'(i3)') j
-               end if
-               write(iounit,'(99a26)',advance='no') &
+               write(str,'(i3)') j
+               str = adjustl(str)
+               write(iounit, fmt, advance='no') &
                   'r01_obs_' // trim(str), &
                   'r01_obs_sigmas_' // trim(str), &
                   'r01_' // trim(str), &
@@ -1448,14 +1449,9 @@
 
             if (chi2_seismo_r_02_fraction > 0) then
                do j=1,nl(0)
-                  if (j < 10) then
-                     write(str,'(i1)') j
-                  else if (j < 100) then
-                     write(str,'(i2)') j
-                  else
-                     write(str,'(i3)') j
-                  end if
-                  write(iounit,'(99a26)',advance='no') &
+                  write(str,'(i3)') j
+                  str = adjustl(str)
+                  write(iounit, fmt, advance='no') &
                      'r02_obs_' // trim(str), &
                      'r02_obs_sigmas_' // trim(str), &
                      'r02_' // trim(str)
@@ -1464,7 +1460,7 @@
          
          end if
          
-         write(iounit,*) ! end of line
+         write(iounit, '(a)') ! end of line
                                           
       end subroutine show_sample_header
       
@@ -1474,7 +1470,7 @@
          integer, intent(in) :: i, iounit
             
          integer :: j, k, l, op_code, ierr
-         character (len=256) :: info_str
+         character (len=256) :: info_str, fmt
          
          ierr = 0
 
@@ -1488,8 +1484,14 @@
                ierr = 0
             end if
          end if
+
+         write(fmt,'(a)') '(1x,i7,10' // trim(astero_results_dbl_format) // &
+            ',' // trim(astero_results_int_format) // &
+            ',22' // trim(astero_results_dbl_format) // &
+            ',7' // trim(astero_results_int_format) // ')'
          
-         write(iounit,'(3x,i5,10(1pes26.16),i16,22(1pes26.16),7i20)',advance='no') i, &
+         ! write(iounit,'(3x,i5,10(1pes26.16),i16,22(1pes26.16),7i20)',advance='no') i, &
+         write(iounit, fmt, advance='no') i, &
             sample_chi2(i), &
             sample_mass(i), &
             sample_init_Y(i), &
@@ -1532,26 +1534,32 @@
             ratios_l1_first
             
          if (iounit == 6) return
-         
+
          if (chi2_seismo_fraction > 0) then
+
+            write(fmt,'(a)') '(' // trim(astero_results_int_format) // &
+                ',99' // trim(astero_results_dbl_format) // ')'
 
             do l = 0, 3
                do k = 1, nl(l)
-                  write(iounit,'(i26,99(1pes26.16))',advance='no') &
+                  ! write(iounit,'(i26,99(1pes26.16))',advance='no') &
+                  write(iounit, fmt, advance='no') &
                      sample_order(l,k,i), freq_target(l,k), freq_sigma(l,k), &
                      sample_freq(l,k,i), sample_freq_corr(l,k,i), sample_inertia(l,k,i)
                end do
             end do
 
+            write(fmt,'(a)') '(99' // trim(astero_results_dbl_format) // ')'
+
             do k=1,ratios_n
-               write(iounit,'(99(1pes26.16))',advance='no') &
+               write(iounit, fmt, advance='no') &
                   ratios_r01(k), sigmas_r01(k), sample_ratios_r01(k,i), &
                   ratios_r10(k), sigmas_r10(k), sample_ratios_r10(k,i)
             end do
 
             if (chi2_seismo_r_02_fraction > 0) then
                do k=1,nl(0)
-                  write(iounit,'(99(1pes26.16))',advance='no') &
+                  write(iounit, fmt, advance='no') &
                      ratios_r02(k), sigmas_r02(k), sample_ratios_r02(k,i)
                end do
             end if
@@ -1869,7 +1877,7 @@
          character (len=*), intent(in) :: results_fname
          integer, intent(out) :: ierr
          integer :: iounit, num, i, j, model_number
-         character (len=100) :: line
+         character (len=strlen) :: line
          
          include 'formats'
          
@@ -1944,7 +1952,7 @@
          integer, intent(out) :: ierr
             
          integer :: i, k, l
-         character (len=256) :: info_str
+         character (len=256) :: info_str, fmt
          real(dp) :: logR
          
          include 'formats'
@@ -1957,8 +1965,14 @@
             ierr = -1
             return
          end if
+
+         write(fmt,'(a)') '(10' // trim(astero_results_dbl_format) // &
+            ',' // trim(astero_results_int_format) // &
+            ',22' // trim(astero_results_dbl_format) // &
+            ',7' // trim(astero_results_int_format) // ')'
          
-         read(iounit,'(10(1pes26.16),i16,22(1pes26.16),7i20)',advance='no',iostat=ierr) &
+         ! read(iounit,'(10(1pes26.16),i16,22(1pes26.16),7i20)',advance='no',iostat=ierr) &
+         read(iounit, fmt, advance='no', iostat=ierr) &
             sample_chi2(i), &
             sample_mass(i), &
             sample_init_Y(i), &
@@ -2005,31 +2019,38 @@
 
          if (chi2_seismo_fraction > 0) then
 
+            write(fmt,'(a)') '(' // trim(astero_results_int_format) // &
+                ',99' // trim(astero_results_dbl_format) // ')'
+
             do l = 0, 3
-               do k = 1, nl(0)
-                  read(iounit,'(i26,99(1pes26.16))',advance='no',iostat=ierr) &
+               do k = 1, nl(l)
+                  read(iounit, fmt, advance='no', iostat=ierr) &
                      sample_order(l,k,i), freq_target(l,k), freq_sigma(l,k), &
                      sample_freq(l,k,i), sample_freq_corr(l,k,i), sample_inertia(l,k,i)
                   if (failed('freqs')) return
                end do
             end do
 
+            write(fmt,'(a)') '(99' // trim(astero_results_dbl_format) // ')'
+
             do k=1,ratios_n
-               read(iounit,'(99(1pes26.16))',advance='no',iostat=ierr) &
+               read(iounit, fmt, advance='no', iostat=ierr) &
                   ratios_r01(k), sigmas_r01(k), sample_ratios_r01(k,i), &
                   ratios_r10(k), sigmas_r10(k), sample_ratios_r10(k,i)
                if (failed('ratios_r010')) return
             end do
 
-            do k=1,nl(0)
-               read(iounit,'(99(1pes26.16))',advance='no',iostat=ierr) &
-                  ratios_r02(k), sigmas_r02(k), sample_ratios_r02(k,i)
-               if (failed('ratios_r02')) return
-            end do
+            if (chi2_seismo_r_02_fraction > 0.0_dp) then
+               do k=1,nl(0)
+                  read(iounit, fmt, advance='no', iostat=ierr) &
+                     ratios_r02(k), sigmas_r02(k), sample_ratios_r02(k,i)
+                  if (failed('ratios_r02')) return
+               end do
+            end if
          
          end if
             
-         read(iounit,'(a12)',iostat=ierr) info_str
+         read(iounit, '(a12)', iostat=ierr) info_str
          if (ierr /= 0) then
             ierr = 0
             sample_op_code(i) = 0

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -1977,17 +1977,18 @@
          end if
 
          read(iounit, fmt='(a)') line
+         read(iounit, fmt='(a)') line
          
-         read(iounit, fmt='(i8)', iostat=ierr) num
+         read(iounit, fmt=astero_results_int_format, iostat=ierr) num
          if (ierr /= 0) then
-            write(*,*) 'failed to read number of samples on line 2 of ' // trim(results_fname)
+            write(*,*) 'failed to read number of samples on line 3 of ' // trim(results_fname)
             call done
             return
          end if
          
          write(*,2) 'number of samples in file', num
 
-         do j = 3, 5
+         do j = 4, 6
             read(iounit, fmt='(a)', iostat=ierr) line
             if (ierr /= 0) then
                write(*,'(a,i1,a)') 'failed to line ', j, ' of ' // trim(results_fname)
@@ -2045,7 +2046,7 @@
          include 'formats'
          
          ierr = 0
-         read(iounit,fmt='(i8)',advance='no',iostat=ierr) i
+         read(iounit,fmt=astero_results_int_format,advance='no',iostat=ierr) i
          if (ierr /= 0) return
          if (i <= 0 .or. i > size(sample_chi2,dim=1)) then
             write(*,2) 'invalid sample number', i

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -252,6 +252,10 @@
       ! output controls
       character (len=256) :: astero_results_directory
 
+      character (len=strlen) :: astero_results_dbl_format
+      character (len=strlen) :: astero_results_int_format
+      character (len=strlen) :: astero_results_txt_format
+
       logical :: write_best_model_data_for_each_sample
       integer :: num_digits
       character (len=256) :: sample_results_prefix, sample_results_postfix
@@ -471,6 +475,9 @@
 
          astero_results_directory, &
 
+         astero_results_dbl_format, &
+         astero_results_int_format, &
+         astero_results_txt_format, &
          write_best_model_data_for_each_sample, &
          num_digits, &
          sample_results_prefix, sample_results_postfix, &

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -1367,12 +1367,10 @@
          character (len=1) :: l_str
 
          ! column numbers
-         write(iounit, '(i8)', advance='no') 1
-
          write(fmt,'(a)') '(99' // trim(astero_results_int_format) // ')'
 
-         k = 2
-         do i = 1, 40
+         k = 1
+         do i = 1, 41
             write(iounit, fmt, advance='no') k
             k = k+1
          end do
@@ -1396,8 +1394,8 @@
             end do
 
             if (chi2_seismo_r_02_fraction > 0) then
-               do j = 1, ratios_n
-                  do i = 1, 6
+               do j = 1, nl(0)
+                  do i = 1, 3
                      write(iounit, fmt, advance='no') k
                      k = k+1
                   end do
@@ -1411,9 +1409,8 @@
          ! column names
          write(fmt,'(a)') '(99' // trim(astero_results_txt_format) // ')'
 
-         write(iounit, '(2x,a6)', advance='no') 'sample'
-      
          write(iounit, fmt, advance='no') &
+            'sample', &
             'chi2', &
             'mass', &
             'init_Y', &
@@ -1525,7 +1522,8 @@
             end if
          end if
 
-         write(fmt,'(a)') '(1x,i7,10' // trim(astero_results_dbl_format) // &
+         write(fmt,'(a)') '(' // trim(astero_results_int_format) // &
+            ',10' // trim(astero_results_dbl_format) // &
             ',' // trim(astero_results_int_format) // &
             ',22' // trim(astero_results_dbl_format) // &
             ',7' // trim(astero_results_int_format) // ')'
@@ -1620,17 +1618,11 @@
          call set_sample_index_by_chi2
 
          do j = 1, 3 ! line number
-            ! first column is special because it's narrow
-            select case (j)
-            case (1)
-               write(iounit, '(i8)', advance='no') 1
-            case (2)
-               write(iounit, '(a8)', advance='no') 'samples'
-            case (3)
-               write(iounit, '(i8)', advance='no') sample_number
-            end select
+            i = 1 ! column number, incremented after each column is written
 
-            i = 2 ! column number, incremented after each column is written
+            call write_int('samples', sample_number)
+
+            ! for scan_grid, we also write total size of grid
             if (i_total > 0) call write_int('total', i_total)
 
             call write_txt('version_number', version_number)

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -1619,24 +1619,73 @@
          ! sort results by increasing sample_chi2
          call set_sample_index_by_chi2
 
-         write(txt_fmt,'(a)') '(a8,99' // trim(astero_results_txt_format) // ')'
-         write(int_fmt,'(a)') '(i8,99' // trim(astero_results_int_format) // ')'
+         do j = 1, 3 ! line number
+            ! first column is special because it's narrow
+            select case (j)
+            case (1)
+               write(iounit, '(i8)', advance='no') 1
+            case (2)
+               write(iounit, '(a8)', advance='no') 'samples'
+            case (3)
+               write(iounit, '(i8)', advance='no') sample_number
+            end select
 
-         if (i_total > 0) then
-            write(iounit, txt_fmt) 'samples', 'total'
-            write(iounit, int_fmt) sample_number, i_total
-         else
-            write(iounit, txt_fmt) 'samples'
-            write(iounit, int_fmt) sample_number
-         end if
+            i = 2 ! column number, incremented after each column is written
+            if (i_total > 0) call write_int('total', i_total)
 
-         write(iounit, '(a)')
+            call write_txt('version_number', version_number)
+            call write_txt('compiler', compiler_name)
+            call write_txt('build', compiler_version_name)
+            call write_txt('MESA_SDK_version', mesasdk_version_name)
+            call write_txt('math_backend',math_backend)
+            call write_txt('date', date)
+            call write_txt('search_type', search_type)
+
+            write(iounit, '(a)') ! new line
+         end do
+
+         write(iounit, '(a)') ! blank line between header and sample data
 
          call show_sample_header(iounit)
          do j = 1, sample_number
             i = sample_index_by_chi2(j)
             call show1_sample_results(i, iounit)
          end do
+
+         contains
+
+         subroutine write_txt(name, val)
+            character(len=*), intent(in) :: name, val
+
+            select case (j)
+            case (1)
+               write(iounit, astero_results_int_format, advance='no') i
+            case (2)
+               write(iounit, astero_results_txt_format, advance='no') name
+            case (3)
+               write(iounit, astero_results_txt_format, advance='no') '"'//trim(val)//'"'
+            end select
+
+            i = i+1
+
+         end subroutine write_txt
+
+         subroutine write_int(name, val)
+            character(len=*), intent(in) :: name
+            integer, intent(in) :: val
+
+            select case (j)
+            case (1)
+               write(iounit, astero_results_int_format, advance='no') i
+            case (2)
+               write(iounit, astero_results_txt_format, advance='no') name
+            case (3)
+               write(iounit, astero_results_int_format, advance='no') val
+            end select
+
+            i = i+1
+
+         end subroutine write_int
 
       end subroutine show_all_sample_results
       

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -27,6 +27,18 @@ astero
 ``astero``'s results are saved (like ``log_directory`` in ``star``).  The default is ``outputs``, so if you
 can't seem to find your ``astero`` output, have a look there.
 
+``&astero_search_controls`` also now has options ::
+
+    astero_results_dbl_format = '(1pes26.16)'
+    astero_results_int_format = '(i26)'
+    astero_results_txt_format = '(a26)'
+
+by which the user can set the formats of floats, integers and strings in the ``astero`` results file,
+much like ``star_history_*_format`` does for history files.
+
+The format of the ``astero`` results file has changed to match histories and profiles.
+The contents of the file are unchanged.
+
 rates
 -----
 


### PR DESCRIPTION
This PR changes `astero`'s results files to match profiles and histories, which includes adding options
```f90
astero_results_dbl_format = '(1pes26.16)'
astero_results_int_format = '(i26)'
astero_results_txt_format = '(a26)'
```
to mimic `star_{profile,history}_{dbl,int,txt}_format` (although I've chosen shorter defaults) and adding some of the metadata included in profiles and histories.

E.g., whereas the old format was
```
         87  samples
  sample                      chi2                      mass                    init_Y                  init_FeH                     alpha                      f_ov ...
      48    1.1644430477133496D+02    1.2679054916867951D+00    2.6789933811428168D-01    1.4110372493129281D-01    2.0063468653270946D+00    0.0000000000000000D+00 ...
      39    1.1800399138147311D+02    1.2678509704695662D+00    2.6791400721946457D-01    1.4110035977099705D-01    2.0064553912921435D+00    0.0000000000000000D+00 ...
...
 ```
the new format (for a different run, hence different numbers) is
```
                         1                         2                         3                         4                         5                         6                         7                         8
                   samples            version_number                  compiler                     build          MESA_SDK_version              math_backend                      date               search_type
                         6                 "aad7b14"                "gfortran"                  "10.2.0"     "x86_64-linux-21.4.1"                  "CRMATH"                "20220405"                 "simplex"

                         1                         2                         3                         4                         5                         6                         7                         8                         9                   >
                    sample                      chi2                      mass                    init_Y                  init_FeH                     alpha                      f_ov                 my_param1                 my_param2 ...
                         4    5.9027693768932049E-02    9.7999999999999998E-01    2.6700000000000002E-01    0.0000000000000000E+00    1.8000000000000000E+00    1.4999999999999999E-02    0.0000000000000000E+00    0.0000000000000000E+00 ...
                         6    7.5075692275630435E-02    9.9500000000000000E-01    2.6700000000000002E-01    0.0000000000000000E+00    1.7500000000000000E+00    1.4999999999999999E-02    0.0000000000000000E+00    0.0000000000000000E+00 ...
```

The changes are logged and the test suite is [passing](https://testhub.mesastar.org/whb%2Fastero-results-formats/commits/aad7b14).