### PR TITLE
Very slightly optimize interpolation routine in `eos/private/pc_support.f90`

### DIFF
--- a/eos/private/pc_support.f90
+++ b/eos/private/pc_support.f90
@@ -432,7 +432,6 @@
       real(dp), intent(inout), dimension(nvals) :: fval, df_dx, df_dy
       integer, intent(out) :: ierr
 
-      real(dp), parameter :: z36th = 1d0/36d0
       real(dp) :: xp, xpi, xp2, xpi2, ax, axbar, bx, bxbar, cx, cxi, hx2, cxd, cxdi, hx, hxi
       real(dp) :: yp, ypi, yp2, ypi2, ay, aybar, by, bybar, cy, cyi, hy2, cyd, cydi, hy, hyi
       real(dp) :: sixth_hx2, sixth_hy2, z36th_hx2_hy2
@@ -492,15 +491,15 @@
                
       sixth_hx2 = one_sixth*hx2
       sixth_hy2 = one_sixth*hy2
-      z36th_hx2_hy2 = z36th*hx2*hy2
+      z36th_hx2_hy2 = sixth_hx2*sixth_hy2
       
       sixth_hx = one_sixth*hx
       sixth_hxi_hy2 = one_sixth*hxi*hy2
-      z36th_hx_hy2 = z36th*hx*hy2
+      z36th_hx_hy2 = sixth_hx*sixth_hy2
       
-      sixth_hx2_hyi = one_sixth*hx2*hyi
+      sixth_hx2_hyi = sixth_hx2*hyi
       sixth_hy = one_sixth*hy
-      z36th_hx2_hy = z36th*hx2*hy
+      z36th_hx2_hy = sixth_hx2*sixth_hy
       
       ip1 = i+1
       jp1 = j+1


### PR DESCRIPTION
A while ago, @adamjermyn pointed out that (#102) there are many instances of the same interpolation method. I independently (#161) streamlined one of them very slightly and we said we wouldn't bother with the others because they should be refactored. But most of the others have since changed form anyway, leaving only this instance in `eos/private/pc_support.f90` that can be streamlined like `eosdt_support.f90` was.

Presuming this passes the test suite, I'll merge very soon.