### PR TITLE
Add `ierr` output to `star_lib:star_get_history_output` (and maybe similar procedures)

### DIFF
--- a/astero/test_suite/astero_adipls/src/run_star_extras.f90
+++ b/astero/test_suite/astero_adipls/src/run_star_extras.f90
@@ -79,7 +79,8 @@
             !    val = s% delta_Pg
             ! fall back to history column if user doesn't define name
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/astero_gyre/src/run_star_extras.f90
+++ b/astero/test_suite/astero_gyre/src/run_star_extras.f90
@@ -84,7 +84,8 @@
             !    val = s% delta_Pg
             ! fall back to history column if user doesn't define name
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/example_astero/src/run_star_extras.f90
+++ b/astero/test_suite/example_astero/src/run_star_extras.f90
@@ -108,7 +108,8 @@
                end do
 
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/fast_from_file/src/run_star_extras.f90
+++ b/astero/test_suite/fast_from_file/src/run_star_extras.f90
@@ -115,7 +115,8 @@
                end do
 
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/fast_newuoa/src/run_star_extras.f90
+++ b/astero/test_suite/fast_newuoa/src/run_star_extras.f90
@@ -108,7 +108,8 @@
                end do
 
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/fast_scan_grid/src/run_star_extras.f90
+++ b/astero/test_suite/fast_scan_grid/src/run_star_extras.f90
@@ -115,7 +115,8 @@
                end do
 
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/fast_simplex/src/run_star_extras.f90
+++ b/astero/test_suite/fast_simplex/src/run_star_extras.f90
@@ -115,7 +115,8 @@
                end do
 
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/astero/test_suite/surface_effects/src/run_star_extras.f90
+++ b/astero/test_suite/surface_effects/src/run_star_extras.f90
@@ -85,7 +85,8 @@
             !    val = s% delta_Pg
             ! fall back to history column if user doesn't define name
             case default
-               val = star_get_history_output(s, name)
+               val = star_get_history_output(s, name, ierr)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
          end select
 
       end subroutine set_constraint_value

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -2970,30 +2970,36 @@
       end function star_get_profile_val
 
 
-      real(dp) function star_get_profile_output(s,name,k)
+      real(dp) function star_get_profile_output(s, name, k, ierr)
          use profile, only : get_profile_val
          type (star_info), pointer :: s
          character(len=*),intent(in) :: name
          integer,intent(in) :: k
+         integer, intent(out), optional :: ierr
          integer :: id
+         if (present(ierr)) ierr = 0
          star_get_profile_output = -HUGE(star_get_profile_output)
-         id = star_get_profile_id(s,name)
-         if(id<0) return
+         id = star_get_profile_id(s, name)
+         if (id < 0) then
+            if (present(ierr)) ierr = 1
+            return
+         end if
          star_get_profile_output = get_profile_val(s,id,k)
       end function star_get_profile_output
 
-      real(dp) function star_get_profile_output_by_id(id, name, k)
+      real(dp) function star_get_profile_output_by_id(id, name, k, ierr_opt)
          integer, intent(in) :: id
          type (star_info), pointer :: s
          character(len=*),intent(in) :: name
          integer,intent(in) :: k
+         integer, intent(out), optional :: ierr_opt
          integer :: ierr
          star_get_profile_output_by_id = -HUGE(star_get_profile_output_by_id)
          call star_ptr(id, s, ierr)
-         if (ierr /= 0) then
-            return
-         end if
-         star_get_profile_output_by_id = star_get_profile_output(s, name, k)
+         if (present(ierr_opt)) ierr_opt = ierr
+         if (ierr /= 0) return
+         star_get_profile_output_by_id = star_get_profile_output(s, name, k, ierr)
+         if (present(ierr_opt)) ierr_opt = ierr
       end function star_get_profile_output_by_id
 
 
@@ -3036,15 +3042,18 @@
          end if
       end function star_get_history_output
 
-      real(dp) function star_get_history_output_by_id(id, name)
+      real(dp) function star_get_history_output_by_id(id, name, ierr_opt)
          integer, intent(in) :: id
          character(len=*),intent(in) :: name
          type(star_info), pointer :: s
+         integer, intent(out), optional :: ierr_opt
          integer :: ierr
          star_get_history_output_by_id = -HUGE(star_get_history_output_by_id)
          call star_ptr(id, s, ierr)
+         if (present(ierr_opt)) ierr_opt = ierr
          if (ierr /= 0) return
          star_get_history_output_by_id = star_get_history_output(s, name, ierr)
+         if (present(ierr_opt)) ierr_opt = ierr
       end function star_get_history_output_by_id
       
       

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -3017,7 +3017,7 @@
          integer :: int_values(num_rows), specs(num_rows)
          logical :: is_int_value(num_rows)
          logical :: failed_to_find_value(num_rows)
-         ierr = 0
+         if (present(ierr)) ierr = 0
          call get_history_specs(s, num_rows, (/name/), specs, .false.)
          call get_history_values( &
             s, num_rows, specs, &

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -3006,16 +3006,18 @@
       end function star_get1_history_value
       
 
-      real(dp) function star_get_history_output(s,name)
-         ! If error return -huge(double)
+      real(dp) function star_get_history_output(s, name, ierr)
+         ! If error return -huge(double) and ierr = 1
          use history, only: get_history_specs, get_history_values, get1_hist_value
          type (star_info), pointer :: s   
-         character(len=*),intent(in) :: name
-         integer,parameter :: num_rows=1
+         character(len=*), intent(in) :: name
+         integer, intent(out) :: ierr
+         integer, parameter :: num_rows = 1
          real(dp) :: values(num_rows)
          integer :: int_values(num_rows), specs(num_rows)
          logical :: is_int_value(num_rows)
          logical :: failed_to_find_value(num_rows)
+         ierr = 0
          call get_history_specs(s, num_rows, (/name/), specs, .false.)
          call get_history_values( &
             s, num_rows, specs, &
@@ -3023,6 +3025,7 @@
          if (failed_to_find_value(num_rows)) then
             if (.not. get1_hist_value(s, name, values(num_rows))) then
                star_get_history_output = -HUGE(star_get_history_output)
+               ierr = 1
                return
             end if
          end if
@@ -3041,7 +3044,7 @@
          star_get_history_output_by_id = -HUGE(star_get_history_output_by_id)
          call star_ptr(id, s, ierr)
          if (ierr /= 0) return
-         star_get_history_output_by_id = star_get_history_output(s, name)
+         star_get_history_output_by_id = star_get_history_output(s, name, ierr)
       end function star_get_history_output_by_id
       
       

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -3007,11 +3007,11 @@
       
 
       real(dp) function star_get_history_output(s, name, ierr)
-         ! If error return -huge(double) and ierr = 1
+         ! If error return -huge(double) and ierr = 1, if provided
          use history, only: get_history_specs, get_history_values, get1_hist_value
          type (star_info), pointer :: s   
          character(len=*), intent(in) :: name
-         integer, intent(out) :: ierr
+         integer, intent(out), optional :: ierr
          integer, parameter :: num_rows = 1
          real(dp) :: values(num_rows)
          integer :: int_values(num_rows), specs(num_rows)
@@ -3025,7 +3025,7 @@
          if (failed_to_find_value(num_rows)) then
             if (.not. get1_hist_value(s, name, values(num_rows))) then
                star_get_history_output = -HUGE(star_get_history_output)
-               ierr = 1
+               if (present(ierr)) ierr = 1
                return
             end if
          end if

--- a/star/test_suite/zams_to_cc_80/src/run_star_extras.f90
+++ b/star/test_suite/zams_to_cc_80/src/run_star_extras.f90
@@ -159,11 +159,11 @@
             testhub_extras_names(1) = 'fe_core_mass'
             testhub_extras_vals(1) = s% fe_core_mass
             testhub_extras_names(2) = 'compactness'
-            testhub_extras_vals(2) = star_get_history_output(s,'compactness_parameter')
+            testhub_extras_vals(2) = star_get_history_output(s, 'compactness_parameter', ierr)
             testhub_extras_names(3) = 'mu4'
-            testhub_extras_vals(3) = star_get_history_output(s,'mu4')
+            testhub_extras_vals(3) = star_get_history_output(s, 'mu4', ierr)
             testhub_extras_names(4) = 'm4'
-            testhub_extras_vals(4) = star_get_history_output(s,'m4')
+            testhub_extras_vals(4) = star_get_history_output(s, 'm4', ierr)
          end select
 
 

--- a/star/test_suite/zams_to_cc_80/src/run_star_extras.f90
+++ b/star/test_suite/zams_to_cc_80/src/run_star_extras.f90
@@ -159,11 +159,11 @@
             testhub_extras_names(1) = 'fe_core_mass'
             testhub_extras_vals(1) = s% fe_core_mass
             testhub_extras_names(2) = 'compactness'
-            testhub_extras_vals(2) = star_get_history_output(s, 'compactness_parameter', ierr)
+            testhub_extras_vals(2) = star_get_history_output(s, 'compactness_parameter')
             testhub_extras_names(3) = 'mu4'
-            testhub_extras_vals(3) = star_get_history_output(s, 'mu4', ierr)
+            testhub_extras_vals(3) = star_get_history_output(s, 'mu4')
             testhub_extras_names(4) = 'm4'
-            testhub_extras_vals(4) = star_get_history_output(s, 'm4', ierr)
+            testhub_extras_vals(4) = star_get_history_output(s, 'm4')
          end select
 
 


### PR DESCRIPTION
I recently made use of `star_lib`'s `star_get_history_output` function, which has the call signature
```f90
    real(dp) function star_get_history_output(s, name)
```
If it fails to find a history column with the requested `name`, it returns `-HUGE(0.0d0)`. This PR changes the call signature to
```f90
    real(dp) function star_get_history_output(s, name, ierr)
```
where `ierr` is optional and, if included, returns `ierr = 1` if the column wasn't found so that the caller can more easily handle a failure.

This isn't the only procedure where I can't see a robust way of handling errors. Others that caught my eye are
```f90
    real(dp) function star_get_history_output_by_id(id, name) ! closely related
    real(dp) function star_get_profile_output(s,name,k)
    real(dp) function star_get_profile_output_by_id(id, name, k)
```
I'm happy to be dissuaded from changing these too but I think we want to discuss it. We [started discussing `ierr` more generally](https://github.com/MESAHub/mesa/issues/76#issuecomment-718084612) a bit in issue #76 but it was a digression there.

Obviously, I'd personally like to have `ierr` in these routines. Some routines don't have `ierr` but have unambiguously garbage output, which is also fine by me. e.g., `star_history_specs` returns indices < 0 if it didn't find something.

If anyone really doesn't like impure functions (i.e., functions that modify arguments), I can change these to subroutines.

Or I can unpack the machinery in `star_get_history_output` into my own routine and handle the failing case there. As it is, implementing `ierr` as an optional argument doesn't impede the purely functional way of doing things.