### PR TITLE
Fix to b% fm to account for the donor switching during the step

### DIFF
--- a/binary/private/binary_evolve.f90
+++ b/binary/private/binary_evolve.f90
@@ -526,7 +526,8 @@
          b% separation_old = b% separation
          b% eccentricity_old = b% eccentricity
          b% dt_old = b% dt
-         b% env_old = b% env
+         b% env_old(1) = b% env(1)
+         b% env_old(2) = b% env(2)
          b% period_old = b% period
          b% rl_relative_gap_old(1) = b% rl_relative_gap(1)
          b% rl_relative_gap_old(2) = b% rl_relative_gap(2)
@@ -596,7 +597,8 @@
          b% separation = b% separation_old
          b% eccentricity = b% eccentricity_old
          b% dt = b% dt_old
-         b% env = b% env_old
+         b% env(1) = b% env_old(1)
+         b% env(2) = b% env_old(2)
          b% period = b% period_old
          b% rl_relative_gap(1) = b% rl_relative_gap_old(1)
          b% rl_relative_gap(2) = b% rl_relative_gap_old(2)

--- a/binary/private/binary_photos.f90
+++ b/binary/private/binary_photos.f90
@@ -90,49 +90,50 @@
          write(iounit) star_def_version
 
          write(iounit, iostat=ierr) &
-             b% binary_age, b% binary_age_old, &
-             b% model_number, b% model_number_old, &
-             b% mtransfer_rate, b% mtransfer_rate_old, &
-             b% angular_momentum_j, b% angular_momentum_j_old, & 
-             b% separation, b% separation_old, &
-             b% eccentricity, b% eccentricity_old, &
-             b% rl_relative_gap(1), b% rl_relative_gap_old(1), &
-             b% rl_relative_gap(2), b% rl_relative_gap_old(2), &
-             b% r(1), b% r_old(1), &
-             b% r(2), b% r_old(2), &
-             b% rl(1), b% rl_old(1), &
-             b% rl(2), b% rl_old(2), &
-             b% m(1), b% m_old(1), &
-             b% m(2), b% m_old(2), &
-             b% dt, b% dt_old, &
-             b% env, b% env_old, &
-             b% eq_initial_bh_mass, &
-             b% period, b% period_old, & 
-             b% max_timestep, b% max_timestep_old, &
-             b% change_factor, b% change_factor_old, &
-             b% min_binary_separation, &
-             b% using_jdot_mb(1), b% using_jdot_mb_old(1), &
-             b% using_jdot_mb(2), b% using_jdot_mb_old(2), &
-             b% d_i, b% d_i_old, b% a_i, b% a_i_old, &
-             b% point_mass_i, b% point_mass_i_old, &
-             b% ignore_rlof_flag, b% ignore_rlof_flag_old, &
-             b% model_twins_flag, b% model_twins_flag_old, &
-             b% dt_why_reason, b% dt_why_reason_old, &
-             b% have_star_1, b% have_star_2, &
-             b% CE_flag, b% CE_flag_old, &
-             b% CE_init, b% CE_init_old, &
-             b% CE_nz, b% CE_initial_radius, b% CE_initial_separation, b% CE_initial_Mdonor, &
-             b% CE_initial_Maccretor, b% CE_initial_age, b% CE_initial_model_number, &
-             b% CE_b_initial_age, b% CE_b_initial_model_number, &
-             b% CE_num1, b% CE_num1_old, &
-             b% CE_num2, b% CE_num2_old, &
-             b% CE_lambda1, b% CE_lambda1_old, &
-             b% CE_lambda2, b% CE_lambda2_old, &
-             b% CE_Ebind1, b% CE_Ebind1_old, &
-             b% CE_Ebind2, b% CE_Ebind2_old, &
-             b% ixtra(:), b% ixtra_old(:), &
-             b% xtra(:), b% xtra_old(:), &
-             b% lxtra(:), b% lxtra_old(:)
+            b% binary_age, b% binary_age_old, &
+            b% model_number, b% model_number_old, &
+            b% mtransfer_rate, b% mtransfer_rate_old, &
+            b% angular_momentum_j, b% angular_momentum_j_old, &
+            b% separation, b% separation_old, &
+            b% eccentricity, b% eccentricity_old, &
+            b% rl_relative_gap(1), b% rl_relative_gap_old(1), &
+            b% rl_relative_gap(2), b% rl_relative_gap_old(2), &
+            b% r(1), b% r_old(1), &
+            b% r(2), b% r_old(2), &
+            b% rl(1), b% rl_old(1), &
+            b% rl(2), b% rl_old(2), &
+            b% m(1), b% m_old(1), &
+            b% m(2), b% m_old(2), &
+            b% dt, b% dt_old, &
+            b% env(1), b% env_old(1), &
+            b% env(2), b% env_old(2), &
+            b% eq_initial_bh_mass, &
+            b% period, b% period_old, &
+            b% max_timestep, b% max_timestep_old, &
+            b% change_factor, b% change_factor_old, &
+            b% min_binary_separation, &
+            b% using_jdot_mb(1), b% using_jdot_mb_old(1), &
+            b% using_jdot_mb(2), b% using_jdot_mb_old(2), &
+            b% d_i, b% d_i_old, b% a_i, b% a_i_old, &
+            b% point_mass_i, b% point_mass_i_old, &
+            b% ignore_rlof_flag, b% ignore_rlof_flag_old, &
+            b% model_twins_flag, b% model_twins_flag_old, &
+            b% dt_why_reason, b% dt_why_reason_old, &
+            b% have_star_1, b% have_star_2, &
+            b% CE_flag, b% CE_flag_old, &
+            b% CE_init, b% CE_init_old, &
+            b% CE_nz, b% CE_initial_radius, b% CE_initial_separation, b% CE_initial_Mdonor, &
+            b% CE_initial_Maccretor, b% CE_initial_age, b% CE_initial_model_number, &
+            b% CE_b_initial_age, b% CE_b_initial_model_number, &
+            b% CE_num1, b% CE_num1_old, &
+            b% CE_num2, b% CE_num2_old, &
+            b% CE_lambda1, b% CE_lambda1_old, &
+            b% CE_lambda2, b% CE_lambda2_old, &
+            b% CE_Ebind1, b% CE_Ebind1_old, &
+            b% CE_Ebind2, b% CE_Ebind2_old, &
+            b% ixtra(:), b% ixtra_old(:), &
+            b% xtra(:), b% xtra_old(:), &
+            b% lxtra(:), b% lxtra_old(:)
 
          if (b% CE_init) then
             write(iounit, iostat=ierr) &
@@ -193,49 +194,50 @@
             return
          end if
          read(iounit, iostat=ierr) &
-             b% binary_age, b% binary_age_old, &
-             b% model_number, b% model_number_old, &
-             b% mtransfer_rate, b% mtransfer_rate_old, &
-             b% angular_momentum_j, b% angular_momentum_j_old, & 
-             b% separation, b% separation_old, &
-             b% eccentricity, b% eccentricity_old, &
-             b% rl_relative_gap(1), b% rl_relative_gap_old(1), &
-             b% rl_relative_gap(2), b% rl_relative_gap_old(2), &
-             b% r(1), b% r_old(1), &
-             b% r(2), b% r_old(2), &
-             b% rl(1), b% rl_old(1), &
-             b% rl(2), b% rl_old(2), &
-             b% m(1), b% m_old(1), &
-             b% m(2), b% m_old(2), &
-             b% dt, b% dt_old, &
-             b% env, b% env_old, &
-             b% eq_initial_bh_mass, &
-             b% period, b% period_old, & 
-             b% max_timestep, b% max_timestep_old, &
-             b% change_factor, b% change_factor_old, &
-             b% min_binary_separation, &
-             b% using_jdot_mb(1), b% using_jdot_mb_old(1), &
-             b% using_jdot_mb(2), b% using_jdot_mb_old(2), &
-             b% d_i, b% d_i_old, b% a_i, b% a_i_old, &
-             b% point_mass_i, b% point_mass_i_old, &
-             b% ignore_rlof_flag, b% ignore_rlof_flag_old, &
-             b% model_twins_flag, b% model_twins_flag_old, &
-             b% dt_why_reason, b% dt_why_reason_old, &
-             b% have_star_1, b% have_star_2, &
-             b% CE_flag, b% CE_flag_old, &
-             b% CE_init, b% CE_init_old, &
-             b% CE_nz, b% CE_initial_radius, b% CE_initial_separation, b% CE_initial_Mdonor, &
-             b% CE_initial_Maccretor, b% CE_initial_age, b% CE_initial_model_number, &
-             b% CE_b_initial_age, b% CE_b_initial_model_number, &
-             b% CE_num1, b% CE_num1_old, &
-             b% CE_num2, b% CE_num2_old, &
-             b% CE_lambda1, b% CE_lambda1_old, &
-             b% CE_lambda2, b% CE_lambda2_old, &
-             b% CE_Ebind1, b% CE_Ebind1_old, &
-             b% CE_Ebind2, b% CE_Ebind2_old, &
-             b% ixtra(:), b% ixtra_old(:), &
-             b% xtra(:), b% xtra_old(:), &
-             b% lxtra(:), b% lxtra_old(:)
+            b% binary_age, b% binary_age_old, &
+            b% model_number, b% model_number_old, &
+            b% mtransfer_rate, b% mtransfer_rate_old, &
+            b% angular_momentum_j, b% angular_momentum_j_old, &
+            b% separation, b% separation_old, &
+            b% eccentricity, b% eccentricity_old, &
+            b% rl_relative_gap(1), b% rl_relative_gap_old(1), &
+            b% rl_relative_gap(2), b% rl_relative_gap_old(2), &
+            b% r(1), b% r_old(1), &
+            b% r(2), b% r_old(2), &
+            b% rl(1), b% rl_old(1), &
+            b% rl(2), b% rl_old(2), &
+            b% m(1), b% m_old(1), &
+            b% m(2), b% m_old(2), &
+            b% dt, b% dt_old, &
+            b% env(1), b% env_old(1), &
+            b% env(2), b% env_old(2), &
+            b% eq_initial_bh_mass, &
+            b% period, b% period_old, &
+            b% max_timestep, b% max_timestep_old, &
+            b% change_factor, b% change_factor_old, &
+            b% min_binary_separation, &
+            b% using_jdot_mb(1), b% using_jdot_mb_old(1), &
+            b% using_jdot_mb(2), b% using_jdot_mb_old(2), &
+            b% d_i, b% d_i_old, b% a_i, b% a_i_old, &
+            b% point_mass_i, b% point_mass_i_old, &
+            b% ignore_rlof_flag, b% ignore_rlof_flag_old, &
+            b% model_twins_flag, b% model_twins_flag_old, &
+            b% dt_why_reason, b% dt_why_reason_old, &
+            b% have_star_1, b% have_star_2, &
+            b% CE_flag, b% CE_flag_old, &
+            b% CE_init, b% CE_init_old, &
+            b% CE_nz, b% CE_initial_radius, b% CE_initial_separation, b% CE_initial_Mdonor, &
+            b% CE_initial_Maccretor, b% CE_initial_age, b% CE_initial_model_number, &
+            b% CE_b_initial_age, b% CE_b_initial_model_number, &
+            b% CE_num1, b% CE_num1_old, &
+            b% CE_num2, b% CE_num2_old, &
+            b% CE_lambda1, b% CE_lambda1_old, &
+            b% CE_lambda2, b% CE_lambda2_old, &
+            b% CE_Ebind1, b% CE_Ebind1_old, &
+            b% CE_Ebind2, b% CE_Ebind2_old, &
+            b% ixtra(:), b% ixtra_old(:), &
+            b% xtra(:), b% xtra_old(:), &
+            b% lxtra(:), b% lxtra_old(:)
 
          if (b% CE_flag .and. b% CE_init) then
             nz = b% CE_nz

--- a/binary/private/binary_timestep.f90
+++ b/binary/private/binary_timestep.f90
@@ -126,9 +126,14 @@
 
          if (b% max_timestep < 0) b% max_timestep = b% s_donor% dt
 
-         b% env = s% star_mass - s% he_core_mass 
-         if (b% env_old /= 0) then
-            env_change = b% env - b% env_old
+
+         b% env(b% d_i) = s% star_mass - s% he_core_mass
+         if (b% point_mass_i == 0) then
+            b% env(b% a_i) = b% s_accretor% star_mass - b% s_accretor% he_core_mass
+         end if
+
+         if (b% env_old(b% d_i) /= 0) then
+            env_change = b% env(b% d_i) - b% env_old(b% d_i)
          else
             env_change = 0
          end if
@@ -171,7 +176,7 @@
          end if
 
          if (b% fm > 0) then
-            rel_change = abs(env_change/max(b% env, b% fm_limit))
+            rel_change = abs(env_change/max(b% env(b% d_i), b% fm_limit))
             if (.not. b% ignore_hard_limits_this_step .and. &
                b% fm_hard > 0d0 .and. rel_change > b% fm_hard) then
                write(*,*) "retry because of fm_hard limit,", &

--- a/binary/public/binary_data.inc
+++ b/binary/public/binary_data.inc
@@ -19,7 +19,7 @@
              ! star masses
              m(2), m_old(2), &
              dt, dt_old, &
-             env, env_old, &
+             env(2), env_old(2), &
              period, period_old, & 
              max_timestep, max_timestep_old, &
              change_factor, change_factor_old, &


### PR DESCRIPTION
the binary timestep control b_fm might be unjustly tripped if the donor was switched.
If the donor is switched at the start of the step, b% env_old is not updated to reflect the envelope mass of the new donor.

made b% env an array so both stars can have their envelope stored