### PR TITLE
Allow trace_history to work with things like total_mass_c12

### DIFF
--- a/star/private/history_specs.f90
+++ b/star/private/history_specs.f90
@@ -620,7 +620,6 @@
                ! Rewrite string so its in the form string value (i.e total_mass c12)
                ! By finding the last _ and replacing with a space
                k = index(string,'_',.true.)
-               write(*,*) trim(string), k
                string(k:) = ' '
                buffer(k:k) = ' '
                i = len_trim(name)


### PR DESCRIPTION
When pgstar_flag is true both total_mass c12 and total_mass_c12 work
in trace_history. When pgstar_flag is false then only total_mass c12
works as we only search for the history column name (total_mass c12)
not the history output name (total_mass_c12). We can fix this by noticing
when we do this and replace the last _ with a space.

The do_get_history_id checks must now come earlier otherwise center_mu
will be confused with center_isotope.

Fixes #411