### PR TITLE
Make cumulative energy error add absolute value of error from each step

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -11355,6 +11355,17 @@
 
     warn_when_large_rel_run_E_err = 0.01d0
 
+      ! absolute_cumulative_energy_err
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! cumulative energy error is the sum of the absolute value of per-step errors.
+      ! Set this to .false. to allow positive and negative errors to cancel
+      ! when integrating over multiple steps.
+
+      ! ::
+
+    absolute_cumulative_energy_err = .true.
+
 
       ! warn_when_stop_checking_residuals    obsolete
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -824,7 +824,7 @@
 
       !error_in_energy_conservation ! for this step
          ! = total_energy - (total_energy_start + total_energy_sources_and_sinks)
-      !cumulative_energy_error ! = sum over all steps of error_in_energy_conservation
+      !cumulative_energy_error ! = sum over all steps of abs(error_in_energy_conservation)
       !rel_cumulative_energy_error ! = cumulative_energy_error/total_energy
       !log_rel_cumulative_energy_error ! = log10 of rel_cumulative_energy_error
       !log_rel_run_E_err ! shorter name for rel_cumulative_energy_error

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -408,7 +408,7 @@
     solver_test_partials_write_eos_call_info, solver_save_photo_call_number, RSP2_min_Lc_div_L_for_convective_mixing_type, &
     solver_test_partials_var_name, solver_test_partials_equ_name, RSP2_min_Lt_div_L_for_overshooting_mixing_type, &
     solver_test_eos_partials, solver_test_kap_partials, solver_test_net_partials, solver_test_atm_partials, &
-    fill_arrays_with_NaNs, zero_when_allocate, warn_when_large_rel_run_E_err, solver_test_partials_k_low, &
+    fill_arrays_with_NaNs, zero_when_allocate, warn_when_large_rel_run_E_err, absolute_cumulative_energy_err, solver_test_partials_k_low, &
     warn_when_large_virial_thm_rel_err, warn_when_get_a_bad_eos_result, warn_rates_for_high_temp, max_safe_logT_for_rates, &
     RSP2_alfap, RSP2_alfat, RSP2_alfam, RSP2_alfar, RSP2_Lsurf_factor, RSP2_use_Stellingwerf_Lr, RSP2_remesh_when_load, &
     RSP2_alfad, RSP2_num_outermost_cells_forced_nonturbulent, RSP2_num_innermost_cells_forced_nonturbulent, &
@@ -2079,6 +2079,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% fill_arrays_with_NaNs = fill_arrays_with_NaNs
  s% zero_when_allocate = zero_when_allocate
  s% warn_when_large_rel_run_E_err = warn_when_large_rel_run_E_err
+ s% absolute_cumulative_energy_err = absolute_cumulative_energy_err
  s% warn_when_large_virial_thm_rel_err = warn_when_large_virial_thm_rel_err
  s% warn_when_get_a_bad_eos_result = warn_when_get_a_bad_eos_result
  s% warn_rates_for_high_temp = warn_rates_for_high_temp
@@ -3756,6 +3757,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  fill_arrays_with_NaNs = s% fill_arrays_with_NaNs
  zero_when_allocate = s% zero_when_allocate
  warn_when_large_rel_run_E_err = s% warn_when_large_rel_run_E_err
+ absolute_cumulative_energy_err = s% absolute_cumulative_energy_err
  warn_when_large_virial_thm_rel_err = s% warn_when_large_virial_thm_rel_err
  warn_when_get_a_bad_eos_result = s% warn_when_get_a_bad_eos_result
  warn_rates_for_high_temp = s% warn_rates_for_high_temp

--- a/star/private/evolve.f90
+++ b/star/private/evolve.f90
@@ -1371,7 +1371,7 @@
                s% total_energy_end - (s% total_energy_old + s% total_energy_sources_and_sinks)
 
             s% cumulative_energy_error = s% cumulative_energy_error_old + &
-               s% error_in_energy_conservation
+               abs(s% error_in_energy_conservation)
 
             s% total_internal_energy = s% total_internal_energy_end
             s% total_gravitational_energy = s% total_gravitational_energy_end

--- a/star/private/evolve.f90
+++ b/star/private/evolve.f90
@@ -1370,8 +1370,13 @@
             s% error_in_energy_conservation = &
                s% total_energy_end - (s% total_energy_old + s% total_energy_sources_and_sinks)
 
-            s% cumulative_energy_error = s% cumulative_energy_error_old + &
-               abs(s% error_in_energy_conservation)
+            if (s% absolute_cumulative_energy_err) then
+               s% cumulative_energy_error = s% cumulative_energy_error_old + &
+                    abs(s% error_in_energy_conservation)
+            else
+               s% cumulative_energy_error = s% cumulative_energy_error_old + &
+                    s% error_in_energy_conservation
+            end if
 
             s% total_internal_energy = s% total_internal_energy_end
             s% total_gravitational_energy = s% total_gravitational_energy_end

--- a/star/test_suite/rsp_Type_II_Cepheid/src/run_star_extras.f90
+++ b/star/test_suite/rsp_Type_II_Cepheid/src/run_star_extras.f90
@@ -112,7 +112,7 @@ module run_star_extras
          target_period = s% x_ctrl(1)
          rel_run_E_err = s% cumulative_energy_error/s% total_energy
          write(*,*) 'rel_run_E_err', rel_run_E_err
-         if (s% total_energy /= 0d0 .and. abs(rel_run_E_err) > 1d-5) then
+         if (s% total_energy /= 0d0 .and. abs(rel_run_E_err) > 1d-4) then
             write(*,*) '*** BAD rel_run_E_error ***', &
             s% cumulative_energy_error/s% total_energy
          else if (abs(s% rsp_period/(24*3600) - target_period) > 1d-2) then

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -1052,7 +1052,7 @@
          
          logical :: fill_arrays_with_NaNs
          logical :: zero_when_allocate, warn_when_get_a_bad_eos_result, &
-            warn_rates_for_high_temp
+            warn_rates_for_high_temp, absolute_cumulative_energy_err
          real(dp) :: warn_when_large_rel_run_E_err, &
             warn_when_large_virial_thm_rel_err, max_safe_logT_for_rates, &
             eps_mdot_leak_frac_factor


### PR DESCRIPTION
It seems misleading to allow positive and negative energy errors from subsequent steps to cancel out when adding up the cumulative energy error, so I propose that we always add the absolute value of energy error from each step. This helps some plots I'm working on for the MESA VI energy section make more sense.

@rsmolec I had to relax the tolerance on the `rel_run_E_err` in the run_star_extras for `rsp_Type_II_Cepheid` for it to pass with this new calculation of cumulative energy error.