### PR TITLE
Fix for conductive opacity edge cases

### DIFF
--- a/kap/private/condint.f90
+++ b/kap/private/condint.f90
@@ -194,57 +194,51 @@
          
          if (zlog <= logzs(1)) then ! use 1st
             call get1(1, logK, dlogK_dlogRho, dlogK_dlogT, ierr)
-            kap = exp10(logK)
-            return
-         end if
-         
-         if (zlog >= logzs(num_logzs)) then ! use last
+         else if (zlog >= logzs(num_logzs)) then ! use last
             call get1(num_logzs, logK, dlogK_dlogRho, dlogK_dlogT, ierr)
-            kap = exp10(logK)
-            return
-         end if
-         
-         iz1 = -1
-         do iz = 2, num_logzs
-            if (zlog >= logzs(iz-1) .and. zlog <= logzs(iz)) then
-               iz1 = iz-1; iz2 = iz; exit
-            end if
-         end do
-         if (iz1 < 0) then
-            write(*,2) 'num_logzs', num_logzs
-            do iz = 1, num_logzs
-               write(*,2) 'logzs(iz)', iz, logzs(iz)
+         else ! interpolate
+            iz1 = -1
+            do iz = 2, num_logzs
+               if (zlog >= logzs(iz-1) .and. zlog <= logzs(iz)) then
+                  iz1 = iz-1; iz2 = iz; exit
+               end if
             end do
-            write(*,1) 'zlog', zlog
-            write(*,*) 'confusion in do_electron_conduction'
-            call mesa_error(__FILE__,__LINE__)
-         end if
-         
-         call get1(iz1, logK1, dlogK1_dlogRho, dlogK1_dlogT, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'interp failed for iz1 in do_electron_conduction', iz1, logRho, logT
-            call mesa_error(__FILE__,__LINE__)
-         end if
-         
-         call get1(iz2, logK2, dlogK2_dlogRho, dlogK2_dlogT, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'interp failed for iz2 in do_electron_conduction', iz2, logRho, logT
-            call mesa_error(__FILE__,__LINE__)
-         end if
-         
-         ! linear interpolation in zlog
-         alfa = (zlog - logzs(iz1)) / (logzs(iz2) - logzs(iz1))
-         beta = 1d0-alfa
-         logK = alfa*logK2 + beta*logK1
-         if (clipped_logRho) then
-            dlogK_dlogRho = 0
-         else
-            dlogK_dlogRho = alfa*dlogK2_dlogRho + beta*dlogK1_dlogRho
-         end if
-         if (clipped_logT) then
-            dlogK_dlogT = 0
-         else
-            dlogK_dlogT = alfa*dlogK2_dlogT + beta*dlogK1_dlogT
+            if (iz1 < 0) then
+               write(*,2) 'num_logzs', num_logzs
+               do iz = 1, num_logzs
+                  write(*,2) 'logzs(iz)', iz, logzs(iz)
+               end do
+               write(*,1) 'zlog', zlog
+               write(*,*) 'confusion in do_electron_conduction'
+               call mesa_error(__FILE__,__LINE__)
+            end if
+            
+            call get1(iz1, logK1, dlogK1_dlogRho, dlogK1_dlogT, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'interp failed for iz1 in do_electron_conduction', iz1, logRho, logT
+               call mesa_error(__FILE__,__LINE__)
+            end if
+            
+            call get1(iz2, logK2, dlogK2_dlogRho, dlogK2_dlogT, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'interp failed for iz2 in do_electron_conduction', iz2, logRho, logT
+               call mesa_error(__FILE__,__LINE__)
+            end if
+            
+            ! linear interpolation in zlog
+            alfa = (zlog - logzs(iz1)) / (logzs(iz2) - logzs(iz1))
+            beta = 1d0-alfa
+            logK = alfa*logK2 + beta*logK1
+            if (clipped_logRho) then
+               dlogK_dlogRho = 0
+            else
+               dlogK_dlogRho = alfa*dlogK2_dlogRho + beta*dlogK1_dlogRho
+            end if
+            if (clipped_logT) then
+               dlogK_dlogT = 0
+            else
+               dlogK_dlogT = alfa*dlogK2_dlogT + beta*dlogK1_dlogT
+            end if
          end if
 
          ! chi = thermal conductivity, = 10**logK (cgs units)

--- a/kap/private/kap_eval.f90
+++ b/kap/private/kap_eval.f90
@@ -751,15 +751,16 @@
          if (dbg) write(*,1) 'log10(kap)', log10(kap)
          
          if (is_bad(kap)) then
-            ierr = -1; return
+            ierr = -1
             write(*,1) 'kap', kap
             call mesa_error(__FILE__,__LINE__,'Get_kap_Results')
+            return
          end if
 
          dlnkap_dlnRho = (kap/kap_rad) * dlnkap_rad_dlnRho + (kap/kap_ec) * dlnkap_ec_dlnRho
 
          if (is_bad(dlnkap_dlnRho)) then
-            ierr = -1; return
+            ierr = -1
             write(*,1) 'dlnkap_dlnRho', dlnkap_dlnRho
             write(*,1) 'kap', kap
             write(*,1) 'dkap_dlnRho', kap * dlnkap_dlnRho
@@ -768,12 +769,13 @@
             write(*,1) 'kap_rad', kap_rad
             write(*,1) 'kap_ec', kap_ec
             call mesa_error(__FILE__,__LINE__,'combine_rad_with_conduction')
+            return
          end if
          
          dlnkap_dlnT = (kap/kap_rad) * dlnkap_rad_dlnT + (kap/kap_ec) * dlnkap_ec_dlnT
          
          if (is_bad(dlnkap_dlnT)) then
-            ierr = -1; return
+            ierr = -1
             write(*,1) 'dlnkap_dlnT', dlnkap_dlnT
             write(*,1) 'kap', kap
             write(*,1) 'dkap_dlnT', kap * dlnkap_dlnT
@@ -782,6 +784,7 @@
             write(*,1) 'kap_rad', kap_rad
             write(*,1) 'kap_ec', kap_ec
             call mesa_error(__FILE__,__LINE__,'combine_rad_with_conduction')
+            return
          end if
 
          if (dbg) write(*,1) 'dlnkap_dlnRho', dlnkap_dlnRho

--- a/kap/private/kap_eval.f90
+++ b/kap/private/kap_eval.f90
@@ -751,16 +751,15 @@
          if (dbg) write(*,1) 'log10(kap)', log10(kap)
          
          if (is_bad(kap)) then
-            ierr = -1
+            ierr = -1; return
             write(*,1) 'kap', kap
             call mesa_error(__FILE__,__LINE__,'Get_kap_Results')
-            return
          end if
 
          dlnkap_dlnRho = (kap/kap_rad) * dlnkap_rad_dlnRho + (kap/kap_ec) * dlnkap_ec_dlnRho
 
          if (is_bad(dlnkap_dlnRho)) then
-            ierr = -1
+            ierr = -1; return
             write(*,1) 'dlnkap_dlnRho', dlnkap_dlnRho
             write(*,1) 'kap', kap
             write(*,1) 'dkap_dlnRho', kap * dlnkap_dlnRho
@@ -769,13 +768,12 @@
             write(*,1) 'kap_rad', kap_rad
             write(*,1) 'kap_ec', kap_ec
             call mesa_error(__FILE__,__LINE__,'combine_rad_with_conduction')
-            return
          end if
          
          dlnkap_dlnT = (kap/kap_rad) * dlnkap_rad_dlnT + (kap/kap_ec) * dlnkap_ec_dlnT
          
          if (is_bad(dlnkap_dlnT)) then
-            ierr = -1
+            ierr = -1; return
             write(*,1) 'dlnkap_dlnT', dlnkap_dlnT
             write(*,1) 'kap', kap
             write(*,1) 'dkap_dlnT', kap * dlnkap_dlnT
@@ -784,7 +782,6 @@
             write(*,1) 'kap_rad', kap_rad
             write(*,1) 'kap_ec', kap_ec
             call mesa_error(__FILE__,__LINE__,'combine_rad_with_conduction')
-            return
          end if
 
          if (dbg) write(*,1) 'dlnkap_dlnRho', dlnkap_dlnRho


### PR DESCRIPTION
Fixes a bug discovered by the students at MESA Summer School 2022.

331b515fe3e7d34be1453c81fac8b2f6ad07e95c introduced a bug by changing where the conversion from thermal conductivity to conductive opacity occurs. This change missed some `zlog` edge cases because they included `return` statements that caused the conversion at the end to be skipped. This manifested as `NaN` values for the `kap` derivatives because they never got set, and the returned opacity was also wrong (though not `NaN`). These `NaN`s in the derivatives propagated through to the overall opacity derivatives even when conductive opacities should be irrelevant.

The most relevant edge case where this occurs is for a pure hydrogen composition, though in principle it could also occur for a very high `zbar` (>60).
