### PR TITLE
Change in check_jdot_mb_conditions and binary_controls

### DIFF
--- a/binary/defaults/binary_controls.defaults
+++ b/binary/defaults/binary_controls.defaults
@@ -957,7 +957,7 @@
 
     jdot_mb_min_qconv_env = 1d-6
     jdot_mb_max_qconv_env = 0.99d0
-    jdot_mb_max_qrad_core = 1d-2
+    jdot_mb_max_qconv_core = 1d-2
     jdot_mb_qlim_for_check_rad_core = 1d-3
     jdot_mb_qlim_for_check_conv_env = 0.999d0
 

--- a/binary/defaults/binary_controls.defaults
+++ b/binary/defaults/binary_controls.defaults
@@ -943,14 +943,14 @@
 
 ! Conditions for magnetic braking to operate. Magnetic braking is
 ! turned off if any of these do not apply.
-! The mass fraction of the convective envelope has to be > jdot_mb_min_qconv_env
-! The mass fraction of the convective envelope has to be < jdot_mb_max_qconv_env
-! The mass fraction of the radiative core has to be < jdot_mb_max_qconv_core
+! The mass fraction of the convective envelope has to be > jdot_mb_min_qconv_env.
+! The mass fraction of the convective envelope has to be < jdot_mb_max_qconv_env.
+! The mass fraction of the convective core has to be < jdot_mb_max_qconv_core.
 ! Here by mass fraction we refer to the mass of the respective zone divided by the
 ! total mass of the star. To compute the mass in the envelope we add all convective
 ! layers down to jdot_mb_qlim_for_check_conv_env, and keep adding layers downwards
 ! until we reach a non-convective zone. This is because the very outermost cell is
-! likely radiative. A simular thing is done for the core with jdot_mb_qlim_for_check_rad_core.
+! likely radiative. A similar thing is done for the core with jdot_mb_qlim_for_check_rad_core.
 ! For full details check binary_jdot.f90.
 
 ! ::

--- a/binary/defaults/binary_controls.defaults
+++ b/binary/defaults/binary_controls.defaults
@@ -934,7 +934,7 @@
 ! ~~~~~~~~~~~~~~~~~~~~~
 ! jdot_mb_max_qconv_env
 ! ~~~~~~~~~~~~~~~~~~~~~
-! jdot_mb_max_qrad_core
+! jdot_mb_max_qconv_core
 ! ~~~~~~~~~~~~~~~~~~~~~
 ! jdot_mb_qlim_for_check_rad_core
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -945,7 +945,7 @@
 ! turned off if any of these do not apply.
 ! The mass fraction of the convective envelope has to be > jdot_mb_min_qconv_env
 ! The mass fraction of the convective envelope has to be < jdot_mb_max_qconv_env
-! The mass fraction of the radiative core has to be < jdot_mb_max_qrad_core
+! The mass fraction of the radiative core has to be < jdot_mb_max_qconv_core
 ! Here by mass fraction we refer to the mass of the respective zone divided by the
 ! total mass of the star. To compute the mass in the envelope we add all convective
 ! layers down to jdot_mb_qlim_for_check_conv_env, and keep adding layers downwards

--- a/binary/private/binary_ctrls_io.f90
+++ b/binary/private/binary_ctrls_io.f90
@@ -151,7 +151,7 @@
          keep_mb_on, &
          jdot_mb_min_qconv_env, &
          jdot_mb_max_qconv_env, &
-         jdot_mb_max_qrad_core, &
+         jdot_mb_max_qconv_core, &
          jdot_mb_qlim_for_check_rad_core, &
          jdot_mb_qlim_for_check_conv_env, &
          jdot_mb_scale_for_low_qconv_env, &
@@ -501,7 +501,7 @@
          b% keep_mb_on = keep_mb_on
          b% jdot_mb_min_qconv_env = jdot_mb_min_qconv_env
          b% jdot_mb_max_qconv_env = jdot_mb_max_qconv_env
-         b% jdot_mb_max_qrad_core = jdot_mb_max_qrad_core
+         b% jdot_mb_max_qconv_core = jdot_mb_max_qconv_core
          b% jdot_mb_qlim_for_check_rad_core = jdot_mb_qlim_for_check_rad_core
          b% jdot_mb_qlim_for_check_conv_env = jdot_mb_qlim_for_check_conv_env
          b% jdot_mb_scale_for_low_qconv_env = jdot_mb_scale_for_low_qconv_env
@@ -691,7 +691,7 @@
          keep_mb_on = b% keep_mb_on
          jdot_mb_min_qconv_env = b% jdot_mb_min_qconv_env
          jdot_mb_max_qconv_env = b% jdot_mb_max_qconv_env
-         jdot_mb_max_qrad_core = b% jdot_mb_max_qrad_core
+         jdot_mb_max_qconv_core = b% jdot_mb_max_qconv_core
          jdot_mb_qlim_for_check_rad_core = b% jdot_mb_qlim_for_check_rad_core
          jdot_mb_qlim_for_check_conv_env = b% jdot_mb_qlim_for_check_conv_env
          jdot_mb_scale_for_low_qconv_env = b% jdot_mb_scale_for_low_qconv_env

--- a/binary/private/binary_jdot.f90
+++ b/binary/private/binary_jdot.f90
@@ -211,18 +211,18 @@
          logical, intent(out) :: apply_jdot_mb
          real(dp), intent(out) :: qconv_env
          
-         real(dp) :: qrad_core
+         real(dp) :: qconv_core
          integer :: i, k, id
 
          include 'formats'
 
          ! calculate how much of inner region is convective
-         qrad_core = 0d0
+         qconv_core = 0d0
          do k = s% nz, 1, -1
             if (s% q(k) > b% jdot_mb_qlim_for_check_rad_core .and. & 
-               (qrad_core == 0d0 .or. s% mixing_type(k) /= convective_mixing)) exit
+               (qconv_core == 0d0 .or. s% mixing_type(k) /= convective_mixing)) exit
             if (s% mixing_type(k) == convective_mixing) &
-               qrad_core = qrad_core + s% dq(k)
+               qconv_core = qconv_core + s% dq(k)
          end do
 
          ! calculate how much of the envelope
@@ -245,7 +245,7 @@
             return
          end if
 
-         if (qrad_core > b% jdot_mb_max_qrad_core) then
+         if (qconv_core > b% jdot_mb_max_qconv_core) then
             apply_jdot_mb = .false.
             return
          end if

--- a/binary/public/binary_controls.inc
+++ b/binary/public/binary_controls.inc
@@ -96,7 +96,7 @@
       logical :: include_accretor_mb
       real(dp) :: magnetic_braking_gamma
       logical :: keep_mb_on
-      real(dp) :: jdot_mb_min_qconv_env, jdot_mb_max_qconv_env, jdot_mb_max_qrad_core, &
+      real(dp) :: jdot_mb_min_qconv_env, jdot_mb_max_qconv_env, jdot_mb_max_qconv_core, &
          jdot_mb_qlim_for_check_rad_core, jdot_mb_qlim_for_check_conv_env
       logical :: jdot_mb_scale_for_low_qconv_env
       real(dp) :: jdot_mb_mass_frac_for_scale


### PR DESCRIPTION
qrad_core and jdot_mb_max_qrad_core are misleading variable names since check_jdot_mb_conditions (binary/private/binary_jdot.f90) is actually checking that the convective core is not too large (ie that there actually is a radiative core). The documentation is also updated to reflect what the check_jdot_mb_conditions subroutine is actually doing.