### PR TITLE
Push net/ state into net_info

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -96,6 +96,9 @@ net
 The derived type net_info (conventional given the symbol ``n``) is no longer a pointer. If you declare a local copy of the variable, you should also ensure to do ``n% g => g`` to make sure that net_info knows
 about the ``net_general_info`` derived type. ``g`` can be had from a call to ``get_net_ptr(handle, g, ierr)``.
 
+The pointer array ``net_work`` and its size ``net_lwork`` have been removed from the net interface, thus these variables should be removed form any ``other_net_get`` and ``other_split_burn`` hooks.
+The following routines have also been removed as they are no longer needed ``net_work_size``, ``get_net_rate_ptrs``, ``net_1_zone_burn_work_size``, ``get_burn_work_array_pointers``, ``net_1_zone_burn_const_density_work_size``, and ``get_burn_const_density_work_array_pointers``
+
 
 Changes in r22.05.1
 ===================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -90,6 +90,12 @@ Test cases now infer their ``MESA_DIR`` variable entirely by the environment var
 
 The history output option ``tri_alfa`` (and other quantities that relate to the triple-alpha nuclear reaction) have been renamed to ``tri_alpha`` for better consistency with other ``_alpha`` reactions.
 
+net
+===
+
+The derived type net_info (conventional given the symbol ``n``) is no longer a pointer. If you declare a local copy of the variable, you should also ensure to do ``n% g => g`` to make sure that net_info knows
+about the ``net_general_info`` derived type. ``g`` can be had from a call to ``get_net_ptr(handle, g, ierr)``.
+
 
 Changes in r22.05.1
 ===================

--- a/net/private/burner_jakob.inc
+++ b/net/private/burner_jakob.inc
@@ -2,6 +2,6 @@
          use const_def, only: dp
          integer, intent(in) :: nvar
          real(dp) :: x,y(:)
-         real(dp), pointer :: dfdy(:,:)
+         real(dp) :: dfdy(:,:)
          integer, intent(out) :: ierr
       end subroutine jakob

--- a/net/private/net_approx21.f90
+++ b/net/private/net_approx21.f90
@@ -1618,7 +1618,7 @@
                i_burn_mg, i_burn_si, i_burn_s, i_burn_ar, i_burn_ca, i_burn_ti, i_burn_cr, &
                i_burn_fe, icc, ico, ioo, ipnhe4, iphoto, i_ni56_co56, i_co56_fe56, iother
             use net_def, only: Net_Info
-            type (Net_Info), pointer :: n
+            type (Net_Info) :: n
             real(dp), dimension(:), intent(in) :: y, mion, dydt, rate
             real(dp), intent(in) :: fII, &
                Qtotal_rpp, Qneu_rpp, Qr33, &

--- a/net/private/net_burn.f90
+++ b/net/private/net_burn.f90
@@ -176,8 +176,7 @@
       
          logical :: dbg
          
-         type (Net_Info), target :: net_info_target
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          
          real(dp), dimension(:), pointer :: &
             rate_raw, rate_raw_dT, rate_raw_dRho, &
@@ -198,7 +197,6 @@
          starting_y => starting_y_a
          ending_y => ending_y_a
          save_x => save_x_a
-         n => net_info_target
          
          have_set_rate_screened = .false.
          

--- a/net/private/net_burn.f90
+++ b/net/private/net_burn.f90
@@ -50,30 +50,14 @@
 
       contains
       
-      
-      integer function burn_1_zone_work_size(g) result(sz)
-         use net_initialize, only: work_size
-         use net_approx21, only: approx21_nrat
-         type (Net_General_Info), pointer :: g
-         integer :: net_lwork, num_reactions, species
-         num_reactions = g% num_reactions
-         if (g% doing_approx21) num_reactions = approx21_nrat
-         species = g% num_isos
-         net_lwork = work_size(g)
-         sz = net_lwork + 2*num_reactions + 2*species*species
-         ! dratdumdy1, dratdumdy2, dens_dfdy1, dmat1
-      end function burn_1_zone_work_size
-         
-
       subroutine get_pointers( &
-            g, burn_lwork, burn_work_array, species, num_reactions, &
+            g, species, num_reactions, &
             dratdumdy1, dratdumdy2, dens_dfdy, dmat, i, ierr)
          use net_approx21, only: approx21_nrat
          type (Net_General_Info), pointer :: g
-         real(dp), pointer :: burn_work_array(:)
-         integer, intent(in) :: burn_lwork, species, num_reactions
-         real(dp), pointer, dimension(:) :: dratdumdy1, dratdumdy2
-         real(dp), pointer, dimension(:,:) :: dens_dfdy, dmat
+         integer, intent(in) :: species, num_reactions
+         real(dp), allocatable, dimension(:) :: dratdumdy1, dratdumdy2
+         real(dp), allocatable, dimension(:,:) :: dens_dfdy, dmat
          integer, intent(inout) :: i
          integer, intent(out) :: ierr
          integer :: sz
@@ -82,12 +66,12 @@
                   
          sz = num_reactions
          if (g% doing_approx21) sz = approx21_nrat
-         dratdumdy1(1:sz) => burn_work_array(i+1:i+sz); i = i+sz
-         dratdumdy2(1:sz) => burn_work_array(i+1:i+sz); i = i+sz
+
+         allocate(dratdumdy1(1:sz))
+         allocate(dratdumdy2(1:sz))
          
-         sz = species*species
-         dens_dfdy(1:species,1:species) => burn_work_array(i+1:i+sz); i = i+sz
-         dmat(1:species,1:species) => burn_work_array(i+1:i+sz); i = i+sz
+         allocate(dens_dfdy(1:species,1:species))
+         allocate(dmat(1:species,1:species))
          
       end subroutine get_pointers
 
@@ -100,8 +84,6 @@
             screening_mode,  &
             stptry_in, max_steps, eps, odescal, &
             use_pivoting, trace, burn_dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, &
-            net_lwork, net_work_array, &
             ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
             nfcn, njac, nstep, naccpt, nrejct, ierr)
          use num_def
@@ -110,7 +92,7 @@
          use mtx_def
          use rates_def, only: rates_reaction_id_max, reaction_Name, reaction_categories
          use rates_lib, only: rates_reaction_id
-         use net_initialize, only: set_rate_ptrs, setup_net_info, work_size
+         use net_initialize, only: setup_net_info, work_size
          use chem_lib, only: basic_composition_info, get_Q
          use net_initialize, only: work_size
          use net_approx21, only: approx21_nrat
@@ -142,9 +124,6 @@
          interface
             include 'burner_finish_substep.inc'
          end interface
-         integer, intent(in) :: burn_lwork, net_lwork
-         real(dp), intent(inout), pointer :: burn_work_array(:)
-         real(dp), intent(inout), pointer :: net_work_array(:)
          real(dp), intent(inout) :: ending_x(:) ! (species)
          real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
          real(dp), intent(out) :: avg_eps_nuc, eps_neu_total
@@ -167,9 +146,9 @@
                   
          real(dp), dimension(species), target :: starting_y_a, ending_y_a, save_x_a
          real(dp), dimension(:), pointer :: starting_y, ending_y, save_x
-         real(dp), dimension(:), pointer :: dratdumdy1, dratdumdy2
+         real(dp), dimension(:), allocatable :: dratdumdy1, dratdumdy2
 
-         real(dp), dimension(:,:), pointer :: dens_dfdy, dmat
+         real(dp), dimension(:,:), allocatable :: dens_dfdy, dmat
 
          real(dp) :: xh, xhe, z, abar, zbar, z2bar, z53bar, ye, mass_correction, sumx
          real(dp) :: aion(species)
@@ -178,9 +157,6 @@
          
          type (Net_Info) :: n
          
-         real(dp), dimension(:), pointer :: &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            rate_screened, rate_screened_dT, rate_screened_dRho
          integer :: iwork, cid
          
          include 'formats'
@@ -250,24 +226,11 @@
          stpmin = min(t_end*1d-20,stptry*1d-6)
          stopp = t_end
          stpmax = max_steps
-         
-         if (dbg) write(*,2) 'call set_rate_ptrs', burn_lwork
-         call set_rate_ptrs(g, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            burn_lwork, burn_work_array, iwork, ierr)
-         if (ierr /= 0) then
-            if (dbg) write(*,*) 'failed in set_ptrs_in_work'
-            return
-         end if
-         
-         if (dbg) write(*,2) 'call setup_net_info', iwork
-         call setup_net_info( &
-            g, n, eps_nuc_categories,  &
-            screening_mode, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, burn_lwork, burn_work_array, &
-            iwork, ierr)
+
+         n% screening_mode = screening_mode
+                  
+         if (dbg) write(*,*) 'call setup_net_info'
+         call setup_net_info(g, n, ierr) 
          if (dbg) write(*,*) 'done setup_net_info'
          if (ierr /= 0) then
             if (dbg) write(*,*) 'failed in setup_net_info'
@@ -276,7 +239,7 @@
       
          if (dbg) write(*,*) 'call get_pointers'
          call get_pointers( &
-            g, burn_lwork, burn_work_array, species, num_reactions, &
+            g, species, num_reactions, &
             dratdumdy1, dratdumdy2, dens_dfdy, dmat, iwork, ierr)
          if (ierr /= 0) return
 
@@ -347,13 +310,11 @@
          subroutine burner_jakob(x,y,dfdy,species,ierr)
             integer, intent(in) :: species
             real(dp) :: x, y(:)
-            real(dp), pointer :: dfdy(:,:)
+            real(dp) :: dfdy(:,:)
             integer, intent(out) :: ierr
             real(dp), target :: f_arry(0)
             real(dp), pointer :: f(:)
             
-            real(dp), target :: dfdy21_a(species,species)
-            real(dp), pointer :: dfdy21(:,:)
             real(dp) :: Z_plus_N, df_t, df_m
             integer :: i, ci, j, cj
             logical :: okay
@@ -378,7 +339,7 @@
             use eos_lib, only: eosDT_get
          
             real(dp) :: time, y(:), f(:)
-            real(dp), pointer :: dfdy(:,:)
+            real(dp) :: dfdy(:,:)
             integer, intent(out) :: ierr
          
             real(dp) :: rho, lgRho, T, lgT, rate_limit, rat, dratdt, dratdd
@@ -489,7 +450,6 @@
                dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
                screening_mode, &
                eps_nuc_categories, eps_neu_total, &
-               net_lwork, net_work_array, &
                actual_Qs, actual_neuQs, from_weaklib, .false., ierr)
             
             if (size(f,dim=1) > 0) then

--- a/net/private/net_burn_const_density.f90
+++ b/net/private/net_burn_const_density.f90
@@ -165,8 +165,7 @@
       
          logical :: dbg
          
-         type (Net_Info), target :: net_info_target
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          
          real(dp), dimension(:), pointer :: &
             rate_raw, rate_raw_dT, rate_raw_dRho, &
@@ -196,7 +195,6 @@
          starting_y => starting_y_a
          ending_y => ending_y_a
          save_x => save_x_a
-         n => net_info_target
 
          d_eta_dlnRho = 0d0
          

--- a/net/private/net_burn_const_density.f90
+++ b/net/private/net_burn_const_density.f90
@@ -47,32 +47,14 @@
 
       contains
       
-      
-      integer function burn_const_density_1_zone_work_size(g) result(sz)
-         use net_initialize, only: work_size
-         use net_approx21, only: approx21_nrat
-         type (Net_General_Info), pointer :: g
-         integer :: net_lwork, num_reactions, species, nvar
-         include 'formats'
-         num_reactions = g% num_reactions
-         if (g% doing_approx21) num_reactions = approx21_nrat
-         species = g% num_isos
-         nvar = species + 1
-         net_lwork = work_size(g)
-         sz = net_lwork + 2*num_reactions + 2*nvar*nvar         
-         ! dratdumdy1, dratdumdy2, dens_dfdy1, dmat1
-      end function burn_const_density_1_zone_work_size
-         
-
       subroutine get_pointers( &
-            g, burn_lwork, burn_work_array, species, nvar, num_reactions, &
+            g, species, nvar, num_reactions, &
             dratdumdy1, dratdumdy2, dens_dfdy, dmat, i, ierr)
          use net_approx21, only: approx21_nrat
          type (Net_General_Info), pointer :: g
-         real(dp), pointer :: burn_work_array(:)
-         integer, intent(in) :: burn_lwork, species, nvar, num_reactions
-         real(dp), pointer, dimension(:) :: dratdumdy1, dratdumdy2
-         real(dp), pointer, dimension(:,:) :: dens_dfdy, dmat
+         integer, intent(in) :: species, nvar, num_reactions
+         real(dp), allocatable, dimension(:) :: dratdumdy1, dratdumdy2
+         real(dp), allocatable, dimension(:,:) :: dens_dfdy, dmat
          integer, intent(inout) :: i
          integer, intent(out) :: ierr
          integer :: sz
@@ -80,12 +62,12 @@
          ierr = 0
          sz = num_reactions
          if (g% doing_approx21) sz = approx21_nrat
-         dratdumdy1(1:sz) => burn_work_array(i+1:i+sz); i = i+sz
-         dratdumdy2(1:sz) => burn_work_array(i+1:i+sz); i = i+sz
+         allocate(dratdumdy1(1:sz))
+         allocate(dratdumdy2(1:sz))
          
          sz = nvar*nvar
-         dens_dfdy(1:nvar,1:nvar) => burn_work_array(i+1:i+sz); i = i+sz
-         dmat(1:nvar,1:nvar) => burn_work_array(i+1:i+sz); i = i+sz
+         allocate(dens_dfdy(1:nvar,1:nvar))
+         allocate(dmat(1:nvar,1:nvar))
          
       end subroutine get_pointers
 
@@ -98,7 +80,6 @@
             screening_mode, &
             stptry_in, max_steps, eps, odescal, &
             use_pivoting, trace, burn_dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, net_lwork, net_work_array, &
             ending_x, eps_nuc_categories, ending_log10T, avg_eps_nuc, eps_neu_total, &
             nfcn, njac, nstep, naccpt, nrejct, ierr)
          use num_def
@@ -107,7 +88,7 @@
          use mtx_def
          use rates_def, only: rates_reaction_id_max, reaction_Name
          use rates_lib, only: rates_reaction_id
-         use net_initialize, only: set_rate_ptrs, setup_net_info, work_size
+         use net_initialize, only: setup_net_info, work_size
          use chem_lib, only: basic_composition_info, get_Q
          use net_initialize, only: work_size
          use net_approx21, only: approx21_nrat
@@ -131,9 +112,6 @@
          interface
             include 'burner_finish_substep.inc'
          end interface
-         integer, intent(in) :: net_lwork, burn_lwork
-         real(dp), intent(inout), pointer :: burn_work_array(:) ! (burn_lwork)
-         real(dp), intent(inout), pointer :: net_work_array(:) ! (net_lwork)
          real(dp), intent(inout) :: ending_x(:) ! (species)
          real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
          real(dp), intent(out) :: ending_log10T, avg_eps_nuc, eps_neu_total
@@ -156,9 +134,9 @@
                   
          real(dp), dimension(nvar), target :: starting_y_a, ending_y_a, save_x_a
          real(dp), dimension(:), pointer :: starting_y, ending_y, save_x
-         real(dp), dimension(:), pointer :: dratdumdy1, dratdumdy2
+         real(dp), dimension(:), allocatable :: dratdumdy1, dratdumdy2
 
-         real(dp), dimension(:,:), pointer :: dens_dfdy, dmat
+         real(dp), allocatable, dimension(:,:) :: dens_dfdy, dmat
 
          real(dp) :: xh, xhe, z, abar, zbar, z2bar, z53bar, ye, mass_correction, sumx
          real(dp) :: aion(species)
@@ -250,24 +228,11 @@
          stpmin = min(t_end*1d-20,stptry*1d-6)
          stopp = t_end
          stpmax = max_steps
-         
-         if (dbg) write(*,2) 'call set_rate_ptrs', burn_lwork
-         call set_rate_ptrs(g, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            burn_lwork, burn_work_array, iwork, ierr)
-         if (ierr /= 0) then
-            if (dbg) write(*,*) 'failed in set_ptrs_in_work'
-            return
-         end if
-         
+
+         n% screening_mode = screening_mode
+                  
          if (dbg) write(*,2) 'call setup_net_info', iwork
-         call setup_net_info( &
-            g, n, eps_nuc_categories,  &
-            screening_mode, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, burn_lwork, burn_work_array, &
-            iwork, ierr)
+         call setup_net_info( g, n, ierr) 
          if (dbg) write(*,*) 'done setup_net_info'
          if (ierr /= 0) then
             if (dbg) write(*,*) 'failed in setup_net_info'
@@ -276,7 +241,7 @@
       
          if (dbg) write(*,*) 'call get_pointers'
          call get_pointers( &
-            g, burn_lwork, burn_work_array, species, nvar, num_reactions, &
+            g, species, nvar, num_reactions, &
             dratdumdy1, dratdumdy2, dens_dfdy, dmat, iwork, ierr)
          if (ierr /= 0) return
 
@@ -332,8 +297,7 @@
             real(dp) :: x, y(:), f(:)
             integer, intent(out) :: ierr
             integer, parameter :: ld_dfdx = 0
-            real(dp), target :: dfdx_arry(ld_dfdx,nvar)
-            real(dp), pointer :: dfdx(:,:)
+            real(dp) :: dfdx(ld_dfdx,nvar)
             real(dp) :: dxdt_sum, dxdt_sum_aprox21, &
                Z_plus_N, xsum, r, r1, r2
             integer :: i, ir, ci, j, k, ibad
@@ -346,7 +310,6 @@
             
             ierr = 0
             nfcn = nfcn + 1
-            dfdx => dfdx_arry
             call jakob_or_derivs(x,y,f,dfdx,ierr)
             if (ierr /= 0) return            
          
@@ -355,13 +318,11 @@
          subroutine burner_jakob(x,y,dfdy,nvar,ierr)
             integer, intent(in) :: nvar
             real(dp) :: x, y(:)
-            real(dp), pointer :: dfdy(:,:)
+            real(dp) :: dfdy(:,:)
             integer, intent(out) :: ierr
             real(dp), target :: f_arry(0)
             real(dp), pointer :: f(:)
             
-            real(dp), target :: dfdy21_a(nvar,nvar)
-            real(dp), pointer :: dfdy21(:,:)
             real(dp) :: Z_plus_N, df_t, df_m
             integer :: i, ci, j, cj
             logical :: okay
@@ -383,7 +344,7 @@
             use interp_1d_lib, only: interp_value
          
             real(dp) :: time, y(:), f(:)
-            real(dp), pointer :: dfdy(:,:)
+            real(dp) :: dfdy(:,:)
             integer, intent(out) :: ierr
          
             real(dp) :: T, lgT, rate_limit, rat, dratdt, dratdd
@@ -478,7 +439,6 @@
                dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
                screening_mode,  &
                eps_nuc_categories, eps_neu_total, &
-               net_lwork, net_work_array, &
                actual_Qs, actual_neuQs, from_weaklib, .false., ierr)
             if (ierr /= 0) then
                !write(*,*) 'failed in eval_net'

--- a/net/private/net_burn_const_p.f90
+++ b/net/private/net_burn_const_p.f90
@@ -102,7 +102,7 @@
          type (Net_Info) :: n
          type (Net_General_Info), pointer :: g
          integer :: ijac, nzmax, isparse, mljac, mujac, imas, mlmas, mumas, lrd, lid, &
-               lout, liwork, lwork, i, j, lrpar, lipar, idid, net_lwork, nvar
+               lout, liwork, lwork, i, j, lrpar, lipar, idid, nvar
          integer, pointer :: ipar(:), iwork(:), ipar_burn_const_P_decsol(:)
          real(dp), pointer :: rpar(:), work(:), v(:), rpar_burn_const_P_decsol(:)
          real(dp) :: t, lgT, lgRho, tend
@@ -155,13 +155,11 @@
          mumas = 0        
          
          lout = 0
-         
-         net_lwork = work_size(g)
-         
+                  
          call isolve_work_sizes(nvar, nzmax, imas, mljac, mujac, mlmas, mumas, liwork, lwork)
 
          lipar = burn_lipar
-         lrpar = burn_const_P_lrpar + net_lwork
+         lrpar = burn_const_P_lrpar 
          
          allocate(v(nvar), iwork(liwork), work(lwork), rpar(lrpar), ipar(lipar), &
                ipar_burn_const_P_decsol(lid), rpar_burn_const_P_decsol(lrd), stat=ierr)
@@ -176,7 +174,6 @@
          ipar(i_net_handle) = net_handle
          ipar(i_eos_handle) = eos_handle
          ipar(i_screening_mode) = screening_mode
-         ipar(i_net_lwork) = net_lwork
          ipar(i_sparse_format) = isparse
          if (clip) then
             ipar(i_clip) = 1
@@ -329,9 +326,8 @@
             real(dp) :: d_dxdt_dx(nvar-1, nvar-1)
             real(dp), target :: eps_nuc_categories(num_categories)
             logical :: rates_only, skip_jacobian
-            integer :: screening_mode, lwork, i, num_isos
+            integer :: screening_mode, i, num_isos
             integer(8) :: time0, time1, clock_rate
-            real(dp), pointer :: work(:) ! (lwork)
 
             real(dp) :: xh, Y, z, Cp, rate_limit
             real(dp) :: dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas
@@ -374,17 +370,6 @@
             num_reactions = g% num_reactions
 
             i = burn_const_P_lrpar
-            lwork = ipar(i_net_lwork)
-            work => rpar(i+1:i+lwork)
-         
-            i = i+lwork
-
-            if (i /= lrpar) then
-               write(*,2) 'burn_jacob i', i
-               write(*,2) 'lrpar', lrpar
-               ierr = -1
-               return
-            end if
          
             if (ipar(i_clip) /= 0) then
                do i=1,num_isos
@@ -482,7 +467,7 @@
                   dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx, &
                   screening_mode, &
                   eps_nuc_categories, eps_neu_total, &
-                  lwork, work, actual_Qs, actual_neuQs, from_weaklib, .false., ierr)
+                  actual_Qs, actual_neuQs, from_weaklib, .false., ierr)
 
             if (rpar(r_burn_const_P_time_net) >= 0) then
                call system_clock(time1,clock_rate)

--- a/net/private/net_burn_const_p.f90
+++ b/net/private/net_burn_const_p.f90
@@ -99,8 +99,7 @@
             ! else on return has input value plus time spent doing eos
          integer, intent(out) :: ierr
          
-         type (Net_Info), target :: netinfo_target
-         type (Net_Info), pointer :: netinfo
+         type (Net_Info) :: n
          type (Net_General_Info), pointer :: g
          integer :: ijac, nzmax, isparse, mljac, mujac, imas, mlmas, mumas, lrd, lid, &
                lout, liwork, lwork, i, j, lrpar, lipar, idid, net_lwork, nvar
@@ -109,9 +108,7 @@
          real(dp) :: t, lgT, lgRho, tend
          
          include 'formats'
-         
-         netinfo => netinfo_target
-         
+                  
          ending_x = 0
          ending_temp = 0
          ending_rho = 0
@@ -475,7 +472,7 @@
             skip_jacobian = .false.
 
             call eval_net( &
-                  netinfo, g, rates_only, skip_jacobian, &
+                  n, g, rates_only, skip_jacobian, &
                   num_isos, num_reactions, g% num_wk_reactions, &
                   x, T, logT, rho, logRho, &
                   abar, zbar, z2bar, ye, eta, d_eta_dlnT, d_eta_dlnRho, &

--- a/net/private/net_burn_support.f90
+++ b/net/private/net_burn_support.f90
@@ -68,7 +68,7 @@
 ! nbad     = number of bad steps taken, bad but retried and then succesful
 ! nstp     = total number of steps taken
 
-      real(dp), pointer :: dens_dfdy(:,:),dmat(:,:)
+      real(dp) :: dens_dfdy(:,:),dmat(:,:)
       integer, intent(out) :: ierr
       
       interface
@@ -223,7 +223,7 @@
       integer :: ierr
 
 
-      real(dp), pointer :: dens_dfdy(:,:),dmat(:,:)
+      real(dp) :: dens_dfdy(:,:),dmat(:,:)
       
       interface
          include 'burner_derivs.inc'
@@ -431,7 +431,7 @@
          y,dydx,nvar,xs,htot,nstep,yout,dens_dfdy,dmat, &
          derivs,ierr)
 !
-      real(dp), pointer :: dens_dfdy(:,:),dmat(:,:)
+      real(dp) :: dens_dfdy(:,:),dmat(:,:)
       
       interface
          include 'burner_derivs.inc'

--- a/net/private/net_derivs.f90
+++ b/net/private/net_derivs.f90
@@ -57,7 +57,6 @@
          logical, target :: deriv_flgs_data(num_reactions)
          logical, pointer :: deriv_flgs(:)
          type (Net_General_Info), pointer  :: g
-         real(dp), pointer :: y(:)
          real(dp) :: T9, T932, eps_nuc_cancel_factor, eps_factor, &
             old_eps_nuc_categories_val
          
@@ -68,7 +67,6 @@
          T9 = temp*1d-9
          T932 = T9*sqrt(T9)
          
-         y => n% y
          g => n% g
          
          if (.true. .or. logtemp <= g% logT_lo_eps_nuc_cancel) then
@@ -248,14 +246,14 @@
          
             select case(c1)
                case (1)
-                  ys_f = y(i1)
+                  ys_f = n% y(i1)
                   d_ysf_dy1 = 1d0
                case (2)
-                  ys_f = y(i1)*y(i1)/2d0
-                  d_ysf_dy1 = y(i1)
+                  ys_f = n% y(i1)*n% y(i1)/2d0
+                  d_ysf_dy1 = n% y(i1)
                case (3)
-                  ys_f = y(i1)*y(i1)*y(i1)/6d0
-                  d_ysf_dy1 = y(i1)*y(i1)/2d0
+                  ys_f = n% y(i1)*n% y(i1)*n% y(i1)/6d0
+                  d_ysf_dy1 = n% y(i1)*n% y(i1)/2d0
                case default
                   write(*,2) 'c1 bad for ' // trim(reaction_name(ir)), c1
                   call mesa_error(__FILE__,__LINE__,'get_general_1_to_1_derivs')
@@ -264,14 +262,14 @@
             
             select case(c2)
                case (1)
-                  ys_r = y(i2)
+                  ys_r = n% y(i2)
                   d_ysr_dy2 = 1d0
                case (2)
-                  ys_r = y(i2)*y(i2)/2d0
-                  d_ysr_dy2 = y(i2)
+                  ys_r = n% y(i2)*n% y(i2)/2d0
+                  d_ysr_dy2 = n% y(i2)
                case (3)
-                  ys_r = y(i2)*y(i2)*y(i2)/6d0
-                  d_ysr_dy2 = y(i2)*y(i2)/2d0
+                  ys_r = n% y(i2)*n% y(i2)*n% y(i2)/6d0
+                  d_ysr_dy2 = n% y(i2)*n% y(i2)/2d0
                case default
                   write(*,2) 'c2 bad for ' // trim(reaction_name(ir)), c2
                   call mesa_error(__FILE__,__LINE__,'get_general_1_to_1_derivs')
@@ -374,9 +372,9 @@
                return
             end if
             
-            y1 = y(i1)
-            y2 = y(i2)
-            y3 = y(i3)
+            y1 = n% y(i1)
+            y2 = n% y(i2)
+            y3 = n% y(i3)
          
             select case(c1)
                case (1)
@@ -590,10 +588,10 @@
                return
             end if
             
-            y1 = y(i1)
-            y2 = y(i2)
-            y3 = y(i3)
-            y4 = y(i4)
+            y1 = n% y(i1)
+            y2 = n% y(i2)
+            y3 = n% y(i3)
+            y4 = n% y(i4)
          
             select case(c1)
                case (1)
@@ -791,10 +789,10 @@
                return
             end if
             
-            y1 = y(i1)
-            y2 = y(i2)
-            y3 = y(i3)
-            y4 = y(i4)
+            y1 = n% y(i1)
+            y2 = n% y(i2)
+            y3 = n% y(i3)
+            y4 = n% y(i4)
          
             ys_f = y1*y2
             d_f = ys_f
@@ -922,9 +920,9 @@
                return
             end if
 
-            y1 = y(i1)
-            y2 = y(i2)
-            y3 = y(i3)
+            y1 = n% y(i1)
+            y2 = n% y(i2)
+            y3 = n% y(i3)
          
             ys_f = y1*y2
             d_f = ys_f
@@ -1048,7 +1046,6 @@
          real(dp) :: dout1, dout2, dout3, dout4, dout5
          type (Net_General_Info), pointer  :: g
          integer, pointer :: reaction_id(:)
-         real(dp), pointer :: y(:)
          integer :: i1, i2, i3, idr1, idr2, idr3, o1, o2, o3
          real(dp) :: r, dr1, dr2, dr3, rate, d_rate_dlnT, d_rate_dlnRho, Q, Qneu, rn14ec
 
@@ -1063,7 +1060,6 @@
          
          include 'formats'
          
-         y => n% y
          g => n% g
          reaction_id => g% reaction_id
 
@@ -1210,20 +1206,20 @@
             end if
             
             if (cin1 == 1) then
-               r = y(i1)
+               r = n% y(i1)
                idr1 = i1
                dr1 = 1
             else if (cin1 == 3 .and. in1 /= ih1) then ! 3 he4
                !write(*,'(/,a)') '1/6*r  reaction name <' // trim(reaction_Name(ir)) // '>'
-               r = (1d0/6d0)*y(i1)*y(i1)*y(i1)
+               r = (1d0/6d0)*n% y(i1)*n% y(i1)*n% y(i1)
                idr1 = i1
-               dr1 = 0.5d0*y(i1)*y(i1)
+               dr1 = 0.5d0*n% y(i1)*n% y(i1)
             else ! 2 body
                !write(*,'(/,a)') '1/2*r  reaction name <' // trim(reaction_Name(ir)) // '>'
                !write(*,'(i3,3x,99e20.10)') i, n% rate_raw(i), n% rate_screened(i)
-               r = 0.5d0*y(i1)*y(i1)
+               r = 0.5d0*n% y(i1)*n% y(i1)
                idr1 = i1
-               dr1 = y(i1)
+               dr1 = n% y(i1)
                !stop
             end if
             
@@ -1231,7 +1227,7 @@
                         
             if (reaction_ye_rho_exponents(2,ir) == 0) then
                ! treat as 1 body reaction
-               r = y(i1)
+               r = n% y(i1)
                idr1 = i1
                dr1 = 1
                idr2 = i2
@@ -1240,30 +1236,30 @@
                !call mesa_error(__FILE__,__LINE__,'net_derivs')
             else if ((cin1 == 1 .and. cin2 == 1) .or. reaction_ye_rho_exponents(2,ir) == 1) then
                ! reaction_ye_rho_exponents(2,ir) == 1 for electron captures; treat as 2 body reaction
-               r = y(i1)*y(i2)
-               dr1 = y(i1)
+               r = n% y(i1)*n% y(i2)
+               dr1 = n% y(i1)
                idr1 = i2
-               dr2 = y(i2)
+               dr2 = n% y(i2)
                idr2 = i1
             else if (cin1 == 2 .and. cin2 == 1) then 
-               r = 0.5d0*y(i1)*y(i1)*y(i2)
-               dr1 = 0.5d0*y(i1)*y(i1)
+               r = 0.5d0*n% y(i1)*n% y(i1)*n% y(i2)
+               dr1 = 0.5d0*n% y(i1)*n% y(i1)
                idr1 = i2
-               dr2 = y(i1)*y(i2)
+               dr2 = n% y(i1)*n% y(i2)
                idr2 = i1
             else if (cin1 == 1 .and. cin2 == 2) then 
                ! e.g., rhe4p, r_neut_he4_he4_to_be9, r_neut_h1_h1_to_h1_h2
-               r = y(i1)*0.5d0*y(i2)*y(i2)
-               dr1 = y(i1)*y(i2)
+               r = n% y(i1)*0.5d0*n% y(i2)*n% y(i2)
+               dr1 = n% y(i1)*n% y(i2)
                idr1 = i2
-               dr2 = 0.5d0*y(i2)*y(i2)
+               dr2 = 0.5d0*n% y(i2)*n% y(i2)
                idr2 = i1
             else if (cin1 == 2 .and. cin2 == 2) then 
                ! e.g., r_neut_neut_he4_he4_to_h3_li7, r_h1_h1_he4_he4_to_he3_be7
-               r = 0.5d0*y(i1)*y(i1)*0.5d0*y(i2)*y(i2)
-               dr1 = 0.5d0*y(i1)*y(i1)*y(i2)
+               r = 0.5d0*n% y(i1)*n% y(i1)*0.5d0*n% y(i2)*n% y(i2)
+               dr1 = 0.5d0*n% y(i1)*n% y(i1)*n% y(i2)
                idr1 = i2
-               dr2 = y(i1)*0.5d0*y(i2)*y(i2)
+               dr2 = n% y(i1)*0.5d0*n% y(i2)*n% y(i2)
                idr2 = i1
             else
                write(*,*) 'get1_derivs: ' // trim(reaction_Name(ir)) // ' invalid coefficient'
@@ -1323,7 +1319,7 @@
                      trim(chem_isos% name(g% chem_id(i1))) // ' => ' // &
                      trim(chem_isos% name(g% chem_id(o1))) // ' + ' // &
                      trim(chem_isos% name(g% chem_id(o2))), &
-                     n% rate_screened(i), r, dr1, y(i1)
+                     n% rate_screened(i), r, dr1, n% y(i1)
                   stop
                end if
 
@@ -1349,22 +1345,22 @@
                if (dbg) write(*,*) 'do_two_one dout1', dout1, trim(chem_isos% name(g% chem_id(o1)))
                
                if (.false. .and. reaction_Name(ir) == 'r_neut_he4_he4_to_be9' .and. r > 0 .and. &
-                     abs(y(i1) - 7.7763751756339478D-05) < 1d-20) then
+                     abs(n% y(i1) - 7.7763751756339478D-05) < 1d-20) then
                   write(*,'(i3,3x,a,2x,99e20.10)') i, &
                      'do_two_one ' // trim(reaction_Name(ir)) // ' ' // &
                      trim(chem_isos% name(g% chem_id(i1))) // ' + ' // &
                      trim(chem_isos% name(g% chem_id(i2))) // ' => ' // &
                      trim(chem_isos% name(g% chem_id(o1))), &
-                     r, dr1, dr2, y(i1), y(i2)
+                     r, dr1, dr2, n% y(i1), n% y(i2)
                   !stop
                end if
                
                if (.false. .and. reaction_Name(ir) == 'r_he4_si28_to_o16_o16') then
-                  write(*,2) 'y(i1)', i1, y(i1)
-                  write(*,2) 'y(i2)', i2, y(i2)
+                  write(*,2) 'n% y(i1)', i1, n% y(i1)
+                  write(*,2) 'n% y(i2)', i2, n% y(i2)
                   write(*,1) 'r', r
                   write(*,1) 'rate screened', n% rate_screened(i)
-                  write(*,1) 'r*y1*y2', y(i1)*y(i2)*n% rate_screened(i)
+                  write(*,1) 'r*y1*y2', n% y(i1)*n% y(i2)*n% rate_screened(i)
                   !stop
                end if
 
@@ -1641,7 +1637,6 @@
          real(dp) :: dout1, dout2, dout3, dout4, dout5
          type (Net_General_Info), pointer  :: g
          integer, pointer :: reaction_id(:)
-         real(dp), pointer :: y(:)
          integer :: i1, i2, i3, idr1, idr2, idr3, o1, o2, o3
          real(dp) :: r, dr1, dr2, dr3, rate, d_rate_dlnT, d_rate_dlnRho, Q, Qneu, rn14ec
 
@@ -1656,7 +1651,6 @@
          
          include 'formats'
          
-         y => n% y
          g => n% g
          reaction_id => g% reaction_id
 
@@ -1700,9 +1694,9 @@
             case(irn14ag_lite) ! n14 + 1.5 alpha => ne20
                n14 = itab(in14)
                ne20 = itab(ine20)
-               r = y(n14) * y(he4)
-               dr1 = y(n14)
-               dr2 = y(he4)
+               r = n% y(n14) * n% y(he4)
+               dr1 = n% y(n14)
+               dr2 = n% y(he4)
 
 
                i_in(1) = n14; i_in(2) = he4; i_in(3) = 0
@@ -1737,7 +1731,7 @@
             he4 = itab(ihe4)
             c12 = itab(ic12)
             UE = abar/zbar
-            YHe4 = y(he4)
+            YHe4 = n% y(he4)
             XHe4 = 4d0*YHe4
             if (YHe4 < 1d-50) then
                n% rate_screened(i) = 0

--- a/net/private/net_derivs.f90
+++ b/net/private/net_derivs.f90
@@ -41,7 +41,7 @@
             n, dydt, eps_nuc_MeV, eta, ye, logtemp, temp, den, abar, zbar, &
             num_reactions, rate_factors, &
             symbolic, just_dydt, ierr)
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          real(qp), pointer, intent(inout) :: dydt(:,:)
          real(qp), intent(out) :: eps_nuc_MeV(:)
          integer, intent(in) :: num_reactions
@@ -1022,7 +1022,7 @@
             num_reactions, rate_factors, rtab, itab, &
             deriv_flgs, symbolic, just_dydt, ierr)
          use rates_lib, only: eval_n14_electron_capture_rate
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          integer, intent(in) :: i, num_reactions
          real(qp), pointer, intent(inout) :: dydt(:,:)
          real(qp), intent(out) :: eps_nuc_MeV(num_rvs)
@@ -1615,7 +1615,7 @@
             num_reactions, rate_factors, rtab, itab, &
             deriv_flgs, symbolic, just_dydt, ierr)
          use rates_lib, only: eval_n14_electron_capture_rate
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          integer, intent(in) :: i, num_reactions
          real(qp), pointer, intent(inout) :: dydt(:,:)
          real(qp), intent(out) :: eps_nuc_MeV(num_rvs)

--- a/net/private/net_derivs_support.f90
+++ b/net/private/net_derivs_support.f90
@@ -75,7 +75,7 @@
            idr, dr, &
            deriv_flgs, symbolic, just_dydt)
 
-        type (Net_Info), pointer :: n
+        type (Net_Info) :: n
         real(qp), pointer :: dydt(:,:) ! (num_rvs, num_isos)
         real(qp), intent(out) :: eps_nuc_MeV(num_rvs)
         integer, intent(in) :: i ! the reaction number
@@ -110,7 +110,7 @@
 
         ! this function handles reactions with 1-3 inputs going to 1-3 outputs
 
-        type (Net_Info), pointer :: n
+        type (Net_Info) :: n
         real(qp), pointer :: dydt(:,:) ! (num_rvs, num_isos)
         real(qp), intent(out) :: eps_nuc_MeV(num_rvs)
         integer, intent(in) :: i ! the reaction number
@@ -265,7 +265,7 @@
 
       subroutine do_lhs_iso( &
             n, dydt, i, c, i1, rvs, i2, dr2, i3, dr3, i4, dr4, symbolic, just_dydt)
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          real(qp), pointer :: dydt(:,:) ! (num_rvs, num_isos)
          integer, intent(in) :: i, i1, i2, i3, i4
          real(dp), intent(in) :: c, rvs(:), dr2, dr3, dr4
@@ -354,7 +354,7 @@
 
       subroutine do_rhs_iso( &
             n, dydt, i, c, i1, rvs, i2, dr2, i3, dr3, i4, dr4, symbolic, just_dydt)
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          real(qp), pointer :: dydt(:,:) ! (num_rvs, num_isos)
          integer, intent(in) :: i, i1, i2, i3, i4
          real(dp), intent(in) :: c, rvs(:), dr2, dr3, dr4
@@ -439,7 +439,7 @@
 
 
       subroutine check_balance(n, i, lhs, rhs) ! check conservation of nucleons
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          real(qp), pointer :: dydt(:,:) ! (num_rvs, num_isos)
          integer, intent(in) :: i
          real(dp), intent(in) :: lhs, rhs

--- a/net/private/net_eval.f90
+++ b/net/private/net_eval.f90
@@ -59,7 +59,7 @@
             net_test_partials_val, net_test_partials_dval_dx, &
             net_test_partials_i, net_test_partials_iother
 
-         type (Net_Info), pointer:: n
+         type (Net_Info) :: n
          type (Net_General_Info), pointer :: g
          logical, intent(in) :: rates_only, just_dxdt
          integer, intent(in) :: num_isos

--- a/net/private/net_initialize.f90
+++ b/net/private/net_initialize.f90
@@ -156,7 +156,7 @@
             i, ierr)
          use chem_def
          type (Net_General_Info), pointer  :: g
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          integer, intent(in) :: lwork
          real(dp), intent(inout), target :: eps_nuc_categories(:) ! (num_categories)
          integer, intent(in) :: screening_mode
@@ -245,9 +245,7 @@
          character (len=*), intent(in) :: cache_suffix
          integer, intent(out) :: ierr
          
-         type (Net_Info), target :: netinfo 
-            ! just used during initialization and then discarded
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          integer :: ios, status, lwork, num_reactions, &
             num_isos, num_wk_reactions, i, iwork
          real(dp), dimension(:), pointer :: eps_nuc_categories
@@ -267,9 +265,8 @@
          call get_net_ptr(handle, g, ierr)
          if (ierr /= 0) return
 
-         netinfo % g => g
-         n => netinfo
-         
+         n% g => g
+
          n% reaction_Qs => std_reaction_Qs
          n% reaction_neuQs => std_reaction_neuQs
                   

--- a/net/private/net_screen.f90
+++ b/net/private/net_screen.f90
@@ -39,7 +39,7 @@
 
 
       subroutine make_screening_tables(n, ierr)
-         type (Net_Info), pointer :: n
+         type (Net_Info) :: n
          integer, intent(out) :: ierr
          real(dp) :: y(num_chem_isos)
          y = 0

--- a/net/public/burner_finish_substep.inc
+++ b/net/public/burner_finish_substep.inc
@@ -1,5 +1,6 @@
       subroutine burner_finish_substep(nstp, time, y, ierr)
+         use const_def, only: dp
          integer,intent(in) :: nstp
-         double precision, intent(in) :: time, y(:)
+         real(dp), intent(in) :: time, y(:)
          integer, intent(out) :: ierr
       end subroutine burner_finish_substep

--- a/net/public/net_def.f90
+++ b/net/public/net_def.f90
@@ -239,7 +239,7 @@
          import dp, qp, Net_Info
          implicit none
 
-         type(Net_Info), pointer :: n
+         type(Net_Info) :: n
          real(qp), pointer, intent(inout) :: dydt(:,:)
          real(qp), intent(out) :: eps_nuc_MeV(:)
          integer, intent(in) :: num_reactions

--- a/net/public/net_def.f90
+++ b/net/public/net_def.f90
@@ -508,8 +508,16 @@
       end subroutine get_net_ptr
 
 
-      integer function get_net_timing_total(g)
+      integer function get_net_timing_total(handle, ierr)
+         integer, intent(in) :: handle
          type (Net_General_Info), pointer :: g
+         integer, intent(inout) :: ierr 
+         ierr = 0
+         call get_net_ptr(handle, g, ierr)
+         if (ierr /= 0) then
+            write(*,*) 'invalid handle for net_set_logTcut'
+            return
+         end if
          get_net_timing_total = 0
          if (.not. g% doing_timing) return
          get_net_timing_total = &
@@ -521,8 +529,17 @@
       end function get_net_timing_total
 
 
-      subroutine zero_net_timing(g)
+      subroutine zero_net_timing(handle,ierr)
+         integer, intent(in) :: handle
          type (Net_General_Info), pointer :: g
+         integer, intent(inout) :: ierr 
+         ierr = 0
+         call get_net_ptr(handle, g, ierr)
+         if (ierr /= 0) then
+            write(*,*) 'invalid handle for net_set_logTcut'
+            return
+         end if
+
          g% clock_net_eval = 0
          g% clock_net_weak_rates = 0
          g% clock_net_rate_tables = 0 

--- a/net/public/net_def.f90
+++ b/net/public/net_def.f90
@@ -182,10 +182,10 @@
          real(dp), pointer :: reaction_Qs(:) ! if null, use standard values         
          real(dp), pointer :: reaction_neuQs(:) ! if null, use standard values
 
-         real(dp), pointer :: eps_nuc_categories(:) ! (num_categories)
+         real(dp), allocatable :: eps_nuc_categories(:) ! (num_categories)
          ! eps_nuc subtotals for each reaction category
          
-         real(dp), pointer, dimension(:) :: &
+         real(dp), allocatable, dimension(:) :: &
             rate_screened, rate_screened_dT, rate_screened_dRho ! (num_rates)
          ! the units here depend on the number of reactants.
          ! in all cases, the rate_screened times as many molar fractions as there are reactants
@@ -198,19 +198,19 @@
          ! similarly, a 3 body reaction will have rate_screened
          ! with units of [gram^2/(mole^2-sec)].
 
-         real(dp), pointer, dimension(:) :: &
+         real(dp), allocatable, dimension(:) :: &
             rate_raw, rate_raw_dT, rate_raw_dRho ! (num_rates)
          ! raw rates are unscreened (but include density factors)
                   
          ! pointers into work array ----------------------------------
 
          ! molar fractions and their rates of change
-         real(dp), pointer :: y(:) ! units [moles/gram]     (num_isos)
-         real(dp), pointer :: d_dydt_dy(:,:) ! units [1/second] (num_isos, num_isos)
-         real(dp), pointer :: d_eps_nuc_dy(:) ! (num_isos)
+         real(dp), allocatable :: y(:) ! units [moles/gram]     (num_isos)
+         real(dp), allocatable :: d_dydt_dy(:,:) ! units [1/second] (num_isos, num_isos)
+         real(dp), allocatable :: d_eps_nuc_dy(:) ! (num_isos)
          
          ! weaklib results
-         real(dp), dimension(:), pointer :: &
+         real(dp), dimension(:), allocatable :: &
             lambda, dlambda_dlnT, dlambda_dlnRho, &
             Q, dQ_dlnT, dQ_dlnRho, &
             Qneu, dQneu_dlnT, dQneu_dlnRho
@@ -271,14 +271,15 @@
       integer, parameter :: i_burn_caller_id = 1
       integer, parameter :: i_net_handle = 2
       integer, parameter :: i_screening_mode = 3
-      integer, parameter :: i_net_lwork = 4
-      integer, parameter :: i_eos_handle = 5
-      integer, parameter :: i_sparse_format = 6
-      integer, parameter :: i_clip = 7
-      integer, parameter :: i_ntimes = 8
+      integer, parameter :: i_eos_handle = 4
+      integer, parameter :: i_sparse_format = 5
+      integer, parameter :: i_clip = 6
+      integer, parameter :: i_ntimes = 7
       
       integer, parameter :: burn_lipar = i_ntimes
 
+      ! Note: We need  burn_lrpar /= burn_const_P_lrpar so that we can determine whether we are doing a normal burn or 
+      ! one at const_P. This is needed in burn_solout in mod_one_zone_burn
       integer, parameter :: r_burn_temp = 1
       integer, parameter :: r_burn_lgT = 2
       integer, parameter :: r_burn_rho = 3

--- a/net/public/net_lib.f90
+++ b/net/public/net_lib.f90
@@ -389,22 +389,6 @@
          net_num_reactions = g% num_reactions
       end function net_num_reactions
       
-      ! this routine supplies the required size for the work array needed by net_get.
-      integer function net_work_size(handle, ierr)
-         use net_def, only: Net_General_Info, get_net_ptr
-         use net_initialize, only: work_size
-         integer, intent(in) :: handle
-         integer, intent(out) :: ierr
-         type (Net_General_Info), pointer :: g
-         net_work_size = 0
-         call get_net_ptr(handle, g, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'invalid handle for net_work_size -- did you call alloc_net_handle?'
-            return
-         end if
-         net_work_size = work_size(g)
-      end function net_work_size
-      
       subroutine get_chem_id_table(handle, num_isos, chem_id, ierr)
          use net_def, only: Net_General_Info, get_net_ptr
          integer, intent(in) :: handle, num_isos ! num_isos must be number of isos in current net
@@ -580,7 +564,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode,  &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, ierr)
+            ierr)
          use chem_def, only: num_categories
          use net_eval, only: eval_net
          use net_def, only: Net_General_Info, Net_Info, get_net_ptr
@@ -640,10 +624,7 @@
          real(dp), intent(out) :: eps_neu_total ! ergs/g/s neutrinos from weak reactions
 
          integer, intent(in) :: screening_mode 
-            
-         integer, intent(in) :: lwork ! size of work >= result from calling net_work_size
-         real(dp), pointer :: work(:) ! (lwork)
-         
+                     
          integer, intent(out) :: ierr ! 0 means okay
                   
          integer(8) :: time0, time1
@@ -679,7 +660,7 @@
                dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
                screening_mode,  &
                eps_nuc_categories, eps_neu_total, &
-               lwork, work, actual_Qs, actual_neuQs, from_weaklib, symbolic, &
+               actual_Qs, actual_neuQs, from_weaklib, symbolic, &
                ierr)
          if (g% doing_timing) then
             call system_clock(time1)
@@ -687,35 +668,7 @@
          end if
 
       end subroutine net_get
-      
-      subroutine get_net_rate_ptrs(handle, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, lwork, work, &
-            ierr)
-         use net_def, only: Net_General_Info, get_net_ptr
-         use net_initialize, only: set_rate_ptrs
-         integer, intent(in) :: handle
-         real(dp), pointer, dimension(:) :: &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho
-         integer, intent(in) :: lwork
-         real(dp), pointer :: work(:)
-         integer, intent(out) :: ierr
-         integer :: i
-         type (Net_General_Info), pointer  :: g
-         ierr = 0
-         call get_net_ptr(handle, g, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'invalid handle for get_net_rate_ptrs -- did you call alloc_net_handle?'
-            return
-         end if
-         call set_rate_ptrs(g, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, lwork, work, &
-            i, ierr)
-      end subroutine get_net_rate_ptrs
-      
-      
+            
       subroutine net_get_rates_only( &
             handle, n, num_isos, num_reactions,  &
             x, temp, log10temp, rho, log10rho,  &
@@ -723,7 +676,7 @@
             rate_factors, weak_rate_factor, &
             reaction_Qs, reaction_neuQs, &
             screening_mode,  &
-            lwork, work, ierr)
+            ierr)
          use chem_def, only: num_categories
          use net_eval, only: eval_net
          use net_def, only: Net_General_Info, Net_Info, get_net_ptr
@@ -765,10 +718,7 @@
          ! rate_raw and rate_screened are described in the declaration of the Net_Info derived type
 
          integer, intent(in) :: screening_mode
-            
-         integer, intent(in) :: lwork ! size of work >= result from calling net_work_size
-         real(dp), pointer :: work(:) ! (lwork)
-         
+                     
          integer, intent(out) :: ierr ! 0 means okay
                   
          integer(8) :: time0, time1
@@ -821,7 +771,7 @@
                dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
                screening_mode,  &
                eps_nuc_categories, eps_neu_total, &
-               lwork, work, actual_Qs, actual_neuQs, from_weaklib, symbolic, &
+               actual_Qs, actual_neuQs, from_weaklib, symbolic, &
                ierr)
          if (g% doing_timing) then
             call system_clock(time1)
@@ -844,7 +794,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode,  &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, ierr)
+            ierr)
          use chem_def, only: num_categories
          use net_eval, only: eval_net
          use net_def, only: Net_General_Info, Net_Info, get_net_ptr
@@ -901,10 +851,7 @@
          ! rate_raw and rate_screened are described in the declaration of the Net_Info derived type
 
          integer, intent(in) :: screening_mode ! Selects which screening mode to use, see rates_def for definition 
-            
-         integer, intent(in) :: lwork ! size of work >= result from calling net_work_size
-         real(dp), pointer :: work(:) ! (lwork)
-         
+                     
          integer, intent(out) :: ierr
             ! ierr = 0 means AOK
             ! ierr = -1 means mass fractions don't add to something very close to 1.0
@@ -942,7 +889,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode,  &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, actual_Qs, actual_neuQs, from_weaklib, symbolic, &
+            actual_Qs, actual_neuQs, from_weaklib, symbolic, &
             ierr)
          
       end subroutine net_get_symbolic_d_dxdt_dx
@@ -957,7 +904,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode,  &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, actual_Qs, actual_neuQs, from_weaklib, &
+            actual_Qs, actual_neuQs, from_weaklib, &
             ierr)
          use chem_def, only: num_categories
          use net_eval, only: eval_net
@@ -991,8 +938,6 @@
          real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
          real(dp), intent(out) :: eps_neu_total ! ergs/g/s neutrinos from weak reactions
          integer, intent(in) :: screening_mode
-         integer, intent(in) :: lwork ! size of work >= result from calling net_work_size
-         real(dp), pointer :: work(:) ! (lwork)
          real(dp), pointer, dimension(:) :: actual_Qs, actual_neuQs ! ignore if null  (num_reactions)
          logical, pointer :: from_weaklib(:) ! ignore if null
          integer, intent(out) :: ierr
@@ -1025,7 +970,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode,  &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, actual_Qs, actual_neuQs, from_weaklib, symbolic, &
+            actual_Qs, actual_neuQs, from_weaklib, symbolic, &
             ierr)
          if (g% doing_timing) then
             call system_clock(time1)
@@ -1033,22 +978,6 @@
          end if
          
       end subroutine net_get_with_Qs
-
-      integer function net_1_zone_burn_work_size(handle,ierr) result(sz)
-         use net_burn, only: burn_1_zone_work_size
-         use net_def, only: Net_General_Info, get_net_ptr
-         integer, intent(in) :: handle
-         integer, intent(out) :: ierr
-         type (Net_General_Info), pointer :: g
-         ierr = 0
-         call get_net_ptr(handle, g, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'invalid handle for net_1_zone_burn_work_size -- did you call alloc_net_handle?'
-            sz = 0
-            return
-         end if
-         sz = burn_1_zone_work_size(g)
-      end function net_1_zone_burn_work_size
 
       ! a 1-zone integrator for nets -- for given temperature and density as functions of time
       subroutine net_1_zone_burn( &
@@ -1059,8 +988,6 @@
             screening_mode, &
             stptry, max_steps, eps, odescal, &
             use_pivoting, trace, dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, &
-            net_lwork, net_work_array, &
             ! results
             ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
             nfcn, njac, nstep, naccpt, nrejct, ierr)
@@ -1093,9 +1020,6 @@
          interface
             include 'burner_finish_substep.inc'
          end interface
-         integer, intent(in) :: net_lwork, burn_lwork
-         real(dp), intent(inout), pointer :: burn_work_array(:) ! (burn_lwork)
-         real(dp), intent(inout), pointer :: net_work_array(:) ! (net_lwork)
          real(dp), intent(inout) :: ending_x(:) ! (num_isos)
          real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
          real(dp), intent(out) :: avg_eps_nuc, eps_neu_total
@@ -1113,49 +1037,12 @@
             reaction_Qs, reaction_neuQs, screening_mode, &
             stptry, max_steps, eps, odescal, &
             use_pivoting, trace, dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, &
-            net_lwork, net_work_array, &
             ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
             nfcn, njac, nstep, naccpt, nrejct, ierr)
          
       end subroutine net_1_zone_burn
+
       
-      subroutine get_burn_work_array_pointers(handle, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            burn_lwork, burn_work_array, ierr)
-         integer, intent(in) :: handle
-         real(dp), pointer :: burn_work_array(:)
-         integer, intent(in) :: burn_lwork
-         real(dp), pointer, dimension(:) :: &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            rate_screened, rate_screened_dT, rate_screened_dRho
-         integer, intent(out) :: ierr
-         call get_net_rate_ptrs(handle, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, burn_lwork, burn_work_array, &
-            ierr)
-      end subroutine get_burn_work_array_pointers
-
-
-
-      integer function net_1_zone_burn_const_density_work_size(handle,ierr) result(sz)
-         use net_burn_const_density, only: burn_const_density_1_zone_work_size
-         use net_def, only: Net_General_Info, get_net_ptr
-         integer, intent(in) :: handle
-         integer, intent(out) :: ierr
-         type (Net_General_Info), pointer :: g
-         ierr = 0
-         call get_net_ptr(handle, g, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'invalid handle for net_1_zone_burn_const_density_work_size'
-            sz = 0
-            return
-         end if
-         sz = burn_const_density_1_zone_work_size(g)
-      end function net_1_zone_burn_const_density_work_size
-
-
       ! a 1-zone integrator for nets -- for given density
       ! evolve lnT according to dlnT/dt = eps_nuc/(Cv*T)
       subroutine net_1_zone_burn_const_density( &
@@ -1166,7 +1053,6 @@
             screening_mode,  &
             stptry, max_steps, eps, odescal, &
             use_pivoting, trace, dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, net_lwork, net_work_array, &
             ! results
             ending_x, eps_nuc_categories, ending_log10T, &
             avg_eps_nuc, ending_eps_neu_total, &
@@ -1194,9 +1080,6 @@
          interface
             include 'burner_finish_substep.inc'
          end interface
-         integer, intent(in) :: net_lwork, burn_lwork
-         real(dp), intent(inout), pointer :: burn_work_array(:) ! (burn_lwork)
-         real(dp), intent(inout), pointer :: net_work_array(:) ! (net_lwork)
          real(dp), intent(inout) :: ending_x(:) ! (num_isos)
          real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
          real(dp), intent(out) :: ending_log10T, avg_eps_nuc, ending_eps_neu_total
@@ -1215,29 +1098,10 @@
             screening_mode,  &
             stptry, max_steps, eps, odescal, &
             use_pivoting, trace, dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, net_lwork, net_work_array, &
             ending_x, eps_nuc_categories, ending_log10T, avg_eps_nuc, ending_eps_neu_total, &
             nfcn, njac, nstep, naccpt, nrejct, ierr)
          
       end subroutine net_1_zone_burn_const_density
-      
-      subroutine get_burn_const_density_work_array_pointers(handle, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            burn_lwork, burn_work_array, ierr)
-         integer, intent(in) :: handle
-         real(dp), pointer :: burn_work_array(:)
-         integer, intent(in) :: burn_lwork
-         real(dp), pointer, dimension(:) :: &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            rate_screened, rate_screened_dT, rate_screened_dRho
-         integer, intent(out) :: ierr
-         call get_net_rate_ptrs(handle, &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho, burn_lwork, burn_work_array, &
-            ierr)
-      end subroutine get_burn_const_density_work_array_pointers
-
       
       ! evolve T according to dT/dt = eps_nuc/Cp while using given P.
       !  then find new Rho and Cp to match P and new T.

--- a/net/public/net_lib.f90
+++ b/net/public/net_lib.f90
@@ -592,7 +592,7 @@
       
          integer, intent(in) :: handle
          logical, intent(in) :: just_dxdt
-         type (Net_Info), pointer:: n
+         type (Net_Info) :: n
          integer, intent(in) :: num_isos
          integer, intent(in) :: num_reactions
          real(dp), intent(in)  :: x(:) ! (num_isos)
@@ -733,7 +733,7 @@
          ! same for Rho and logRho
       
          integer, intent(in) :: handle
-         type (Net_Info), pointer:: n
+         type (Net_Info) :: n
          integer, intent(in) :: num_isos
          integer, intent(in) :: num_reactions
          real(dp), intent(in)  :: x(:) ! (num_isos)
@@ -851,7 +851,7 @@
          use rates_def, only: num_rvs
       
          integer, intent(in) :: handle
-         type (Net_Info), pointer :: n
+         type (Net_Info)  :: n
          integer, intent(in) :: num_isos
          integer, intent(in) :: num_reactions
          real(dp), intent(in)  :: x(:) ! (num_isos)
@@ -965,7 +965,7 @@
          use rates_def, only: num_rvs
          integer, intent(in) :: handle
          logical, intent(in) :: just_dxdt
-         type (Net_Info), pointer:: n
+         type (Net_Info) :: n
          integer, intent(in) :: num_isos
          integer, intent(in) :: num_reactions
          real(dp), intent(in)  :: x(:) ! (num_isos)

--- a/net/test/src/mod_one_zone_burn.f90
+++ b/net/test/src/mod_one_zone_burn.f90
@@ -219,8 +219,7 @@
          integer, parameter :: nwork = pm_work_size
          real(dp), pointer :: pm_work(:)
          
-         type (Net_Info), target :: netinfo_target
-         type (Net_Info), pointer :: netinfo
+         type (Net_Info) :: n
          type (Net_General_Info), pointer :: g
          
          include 'formats'
@@ -229,7 +228,6 @@
          told = 0
          
          net_file = net_file_in
-         netinfo => netinfo_target
 
          call test_net_setup(net_file)
 
@@ -1086,6 +1084,7 @@
             real(dp), pointer :: work(:), actual_Qs(:), actual_neuQs(:)
             logical, pointer :: from_weaklib(:)
             type (Net_General_Info), pointer  :: g
+            type(net_info) :: netinfo
             logical :: skip_jacobian
 
             include 'formats'
@@ -1170,6 +1169,13 @@
             eta = res(i_eta)
             d_eta_dlnT = 0d0
             d_eta_dlnRho = 0d0
+
+            call get_net_ptr(handle, g, ierr)
+            if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
+         
+
+            netinfo% g => g
+
          
             call net_get_with_Qs( &
                   handle, skip_jacobian, netinfo, species, num_reactions, &
@@ -1190,9 +1196,6 @@
                call mesa_error(__FILE__,__LINE__)
             end if
 
-            call get_net_ptr(handle, g, ierr)
-            if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-         
             dt = time - told
 
             ! set burn_ergs according to change from initial abundances

--- a/net/test/src/mod_one_zone_burn.f90
+++ b/net/test/src/mod_one_zone_burn.f90
@@ -180,9 +180,7 @@
          real(dp) :: logRho, logT, Rho, T, xsum, &
            eps_nuc, d_eps_nuc_dRho, d_eps_nuc_dT
          real(dp), target :: eps_nuc_categories(num_categories)
-         real(dp), dimension(:), pointer :: &
-            rate_raw, rate_raw_dT, rate_raw_dRho, &
-            rate_screened, rate_screened_dT, rate_screened_dRho
+
          integer :: i, j, ierr, iounit, decsol_choice, solver_choice, num_times
 
          real(dp), dimension(:), pointer :: times, dxdt_source_term
@@ -198,8 +196,6 @@
          real(dp), pointer :: atol(:) ! absolute error tolerance (species)
          integer :: itol ! switch for rtol and atol
          
-         real(dp), pointer :: burn_work_array(:), net_work_array(:)
-         
          real(dp), pointer :: ending_x(:) ! (species)
          integer :: nfcn    ! number of function evaluations
          integer :: njac    ! number of jacobian evaluations
@@ -208,7 +204,7 @@
          integer :: nrejct  ! number of rejected steps
          integer :: max_order_used
          
-         integer :: iout, caller_id, cid, ir, burn_lwork, net_lwork
+         integer :: iout, caller_id, cid, ir
          integer(8) :: time0, time1, clock_rate
 
          real(dp) :: ending_temp, ending_rho, ending_lnS, initial_rho, initial_lnS, dt
@@ -523,15 +519,7 @@
          time_doing_eos = -1
             
          if (burn_at_constant_density) then
-            
-            burn_lwork = net_1_zone_burn_const_density_work_size(handle,ierr)
-            if (ierr /= 0) return
-            net_lwork = net_work_size(handle,ierr)
-            if (ierr /= 0) return
-            allocate(net_work_array(net_lwork), burn_work_array(burn_lwork))
-            
-            call set_nan(burn_work_array) ! TESTING
-            
+                        
             starting_log10T = burn_logT
             logT = burn_logT
             logRho = burn_logRho
@@ -545,7 +533,6 @@
                screening_mode,  &
                stptry, max_steps, eps, odescal, &
                use_pivoting, trace, burn_dbg, burn_finish_substep, &
-               burn_lwork, burn_work_array, net_lwork, net_work_array, &
                ending_x, eps_nuc_categories, ending_log10T, &
                avg_eps_nuc, ending_eps_neu_total, &
                nfcn, njac, nstep, naccpt, nrejct, ierr)
@@ -559,7 +546,6 @@
                write(*,1) 'avg_eps_nuc', avg_eps_nuc
                write(*,1) 'ending_eps_neu_total', ending_eps_neu_total
             end if
-            deallocate(burn_work_array)
 
          else if (burn_at_constant_P) then
             if (num_times_for_burn <= 0) then
@@ -612,14 +598,6 @@
                if (ierr /= 0) call mesa_error(__FILE__,__LINE__,'failed in interp for etas')
             end if
             
-            burn_lwork = net_1_zone_burn_work_size(handle,ierr)
-            if (ierr /= 0) return
-            net_lwork = net_work_size(handle,ierr)
-            if (ierr /= 0) return
-            allocate(net_work_array(net_lwork), burn_work_array(burn_lwork))
-            
-            call set_nan(burn_work_array) ! TESTING
-            
             call net_1_zone_burn( &
                net_handle, eos_handle, species, num_reactions, 0d0, burn_tend, xin, &
                num_times, times, log10Ts_f1, log10Rhos_f1, etas_f1, dxdt_source_term, &
@@ -628,14 +606,10 @@
                screening_mode,  & 
                stptry, max_steps, eps, odescal, &
                use_pivoting, trace, burn_dbg, burn_finish_substep, &
-               burn_lwork, burn_work_array, & 
-               net_lwork, net_work_array, & 
                ending_x, eps_nuc_categories, &
                avg_eps_nuc, eps_neu_total, &
                nfcn, njac, nstep, naccpt, nrejct, ierr)
-               
-            deallocate(net_work_array, burn_work_array)
-            
+                           
          end if
          call system_clock(time1,clock_rate)
          dt = dble(time1 - time0) / clock_rate
@@ -1037,14 +1011,24 @@
             integer, intent(inout), target :: iwork_y(*)
             integer, intent(inout), pointer :: ipar(:) ! (lipar)
             real(dp), intent(inout), pointer :: rpar(:) ! (lrpar)
+            real(dp) :: lgt,lgrho
             integer :: i, cid
             interface
                include 'num_interp_y.dek'
             end interface
             integer, intent(out) :: irtrn ! < 0 causes solver to return to calling program.
+
+            if(size(rpar)==burn_lrpar) then
+               lgt = rpar(r_burn_prev_lgT)
+               lgrho = rpar(r_burn_prev_lgRho)
+            else if (size(rpar)==burn_const_P_lrpar)then
+               lgt = log10(rpar(r_burn_const_P_temperature))
+               lgrho = log10(rpar(r_burn_const_P_rho))
+            end if
+
             
             call burn_solout1( &
-               step, told, time, rpar(r_burn_prev_lgT), rpar(r_burn_prev_lgRho), n, x, irtrn)
+               step, told, time, lgt, lgrho, n, x, irtrn)
          end subroutine burn_solout
 
 
@@ -1062,9 +1046,6 @@
             real(dp) :: logT, logRho, lgPgas, Pgas, Prad, lgP, avg_eps_nuc
             real(dp) :: eps_neu_total, eps_nuc, d_eps_nuc_dRho, d_eps_nuc_dT, &
               eps_nuc_categories(num_categories)
-            real(dp), dimension(:), pointer :: &
-               rate_raw, rate_raw_dT, rate_raw_dRho, &
-               rate_screened, rate_screened_dT, rate_screened_dRho
 
             real(dp) :: dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas
             real(dp) :: dlnRho_dlnT_const_P, d_epsnuc_dlnT_const_P, d_Cv_dlnT
@@ -1079,9 +1060,9 @@
                   dt, energy, entropy, burn_ergs, &
                   xh, xhe, Z, mass_correction
          
-            integer :: i, j, lwork, adjustment_iso, cid, ierr, max_j
+            integer :: i, j, adjustment_iso, cid, ierr, max_j
             real(dp), dimension(species) :: dabar_dx, dzbar_dx, eps_nuc_dx, dmc_dx
-            real(dp), pointer :: work(:), actual_Qs(:), actual_neuQs(:)
+            real(dp), pointer :: actual_Qs(:), actual_neuQs(:)
             logical, pointer :: from_weaklib(:)
             type (Net_General_Info), pointer  :: g
             type(net_info) :: netinfo
@@ -1109,10 +1090,8 @@
             end if
 
             ierr = 0
-            lwork = net_work_size(handle, ierr) 
-            if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
          
-            allocate(work(lwork), &
+            allocate( &
                   actual_Qs(num_reactions), actual_neuQs(num_reactions), &
                   from_weaklib(num_reactions), &
                   stat=ierr)
@@ -1187,7 +1166,7 @@
                   dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx, &
                   screening_mode, &
                   eps_nuc_categories, eps_neu_total, &
-                  lwork, work, actual_Qs, actual_neuQs, from_weaklib, ierr)
+                  actual_Qs, actual_neuQs, from_weaklib, ierr)
             if (ierr /= 0) then
                write(*,'(A)')
                write(*,1) 'logT', logT
@@ -1226,15 +1205,6 @@
          
             if (time >= data_output_min_t) then
          
-               call get_net_rate_ptrs(g% handle, &
-                  rate_screened, rate_screened_dT, rate_screened_dRho, &
-                  rate_raw, rate_raw_dT, rate_raw_dRho, lwork, work, &
-                  ierr)
-               if (ierr /= 0) then
-                  write(*,*) 'failed in get_net_rate_ptrs'
-                  call mesa_error(__FILE__,__LINE__)
-               end if
-
                write(io_out,'(i7,99(1pe26.16,1x))',advance='no') &
                   step, &
                   sign(1d0,avg_eps_nuc)*log10(max(1d0,abs(avg_eps_nuc))), &
@@ -1284,8 +1254,8 @@
                do i=1,num_reactions_to_track
                   j = index_for_reaction_to_track(i)
                   if (j == 0) cycle
-                  write(io_out,'(1pe26.16,1x)',advance='no') rate_raw(j)
-                  write(io_out,'(1pe26.16,1x)',advance='no') rate_screened(j)
+                  write(io_out,'(1pe26.16,1x)',advance='no') netinfo% rate_raw(j)
+                  write(io_out,'(1pe26.16,1x)',advance='no') netinfo% rate_screened(j)
                end do
                write(io_out,*) 
                do j=1, species
@@ -1316,7 +1286,7 @@
             end if
          
          
-            deallocate(work, actual_Qs, actual_neuQs, from_weaklib)
+            deallocate(actual_Qs, actual_neuQs, from_weaklib)
 
          end subroutine burn_solout1
 

--- a/net/test/src/mod_test_net.f90
+++ b/net/test/src/mod_test_net.f90
@@ -40,9 +40,7 @@
          integer :: ierr
          
          qt = quiet
-      
-         n => net_info_target
-         
+               
          call load_libs
       
          test_logT = 7.833d0

--- a/net/test/src/sample_net.f90
+++ b/net/test/src/sample_net.f90
@@ -182,8 +182,7 @@
          real(dp), target :: work_ary(lwork), rate_factors_ary(num_reactions)
          real(dp), pointer, dimension(:) :: work, rate_factors
          logical :: skip_jacobian
-         type (Net_Info), target :: netinfo_target
-         type (Net_Info), pointer :: netinfo
+         type (Net_Info) :: n
          character (len=80) :: string
          
          include "formats"
@@ -200,7 +199,6 @@
          ierr = 0
          work => work_ary
          rate_factors => rate_factors_ary
-         netinfo => netinfo_target
 
          eta = 0
          rate_factors(:) = 1
@@ -249,7 +247,7 @@
 ! this is the instantaneous eps_nuc only
 
          call net_get( &
-            handle, skip_jacobian, netinfo, species, num_reactions, &
+            handle, skip_jacobian, n, species, num_reactions, &
             xa, T, logT, Rho, logRho, & 
             abar, zbar, z2bar, ye, eta, d_eta_dlnT, d_eta_dlnRho, &
             rate_factors, weak_rate_factor, & 

--- a/net/test/src/sample_net.f90
+++ b/net/test/src/sample_net.f90
@@ -41,7 +41,7 @@
          use chem_def, only: num_categories
          
          integer :: ierr, handle, species, &
-            num_reactions, lwork
+            num_reactions
          integer, pointer :: chem_id(:), net_iso(:)
          character (len=100) :: net_file
          character (len=64) :: mesa_dir
@@ -65,14 +65,14 @@
 ! set up the network         
          call setup_net( &
             net_file, handle, &
-            species, chem_id, net_iso, num_reactions, lwork, ierr)
+            species, chem_id, net_iso, num_reactions, ierr)
          if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
 
 
 ! call the burner         
          call do1_net_eval( &
             handle, species, num_reactions, &
-            chem_id, net_iso, lwork, ierr)
+            chem_id, net_iso,  ierr)
          if (ierr /= 0) call mesa_error(__FILE__,__LINE__)         
          
       end subroutine test
@@ -112,13 +112,13 @@
       
       subroutine setup_net( &
             net_file, handle, &
-            species, chem_id, net_iso, num_reactions, lwork, ierr)
+            species, chem_id, net_iso, num_reactions, ierr)
          use net_lib
          use rates_def, only: rates_reaction_id_max
          
          character (len=*), intent(in) :: net_file
          integer, pointer :: chem_id(:), net_iso(:) ! set, but not allocated
-         integer, intent(out) :: handle, species, num_reactions, lwork, ierr
+         integer, intent(out) :: handle, species, num_reactions, ierr
          
          ierr = 0
          handle = alloc_net_handle(ierr)
@@ -148,15 +148,12 @@
          
          num_reactions = net_num_reactions(handle, ierr)
          if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-
-         lwork = net_work_size(handle, ierr)
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
          
       end subroutine setup_net
       
       
       subroutine do1_net_eval( &
-            handle, species, num_reactions, chem_id, net_iso, lwork, ierr)
+            handle, species, num_reactions, chem_id, net_iso, ierr)
             
          use rates_def
          use chem_def
@@ -166,7 +163,7 @@
       
 ! declare the pass   
          integer, intent(in) :: handle, species, num_reactions, &
-            chem_id(:), net_iso(:), lwork
+            chem_id(:), net_iso(:)
          integer, intent(out) :: ierr
          
 
@@ -179,8 +176,8 @@
             eps_nuc_categories(num_categories), eps_neu_total, &
             dxdt(species), d_dxdt_dRho(species), d_dxdt_dT(species), &
             d_dxdt_dx(species,species)
-         real(dp), target :: work_ary(lwork), rate_factors_ary(num_reactions)
-         real(dp), pointer, dimension(:) :: work, rate_factors
+         real(dp), target :: rate_factors_ary(num_reactions)
+         real(dp), pointer, dimension(:) :: rate_factors
          logical :: skip_jacobian
          type (Net_Info) :: n
          character (len=80) :: string
@@ -197,7 +194,6 @@
 
 ! set some pointers and options
          ierr = 0
-         work => work_ary
          rate_factors => rate_factors_ary
 
          eta = 0
@@ -256,7 +252,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx, & 
             screening_mode, &     
             eps_nuc_categories, eps_neu_total, & 
-            lwork, work, ierr)
+            ierr)
          if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
          
 

--- a/net/test/src/test_net_do_one.f90
+++ b/net/test/src/test_net_do_one.f90
@@ -46,8 +46,7 @@
       real(dp), dimension(:), pointer ::  &
          xin, xin_copy, d_eps_nuc_dx, dxdt, d_dxdt_dRho, d_dxdt_dT
       real(dp), pointer :: d_dxdt_dx(:,:)  
-      type (Net_Info), target :: net_info_target
-      type (Net_Info), pointer :: n
+      type (Net_Info) :: n
       
 
       contains

--- a/rates/private/eval_ecapture.f90
+++ b/rates/private/eval_ecapture.f90
@@ -53,7 +53,7 @@ contains
     integer, intent(in) :: n, ids(:)
     type(Coulomb_Info), intent(in) :: cc
     real(dp), intent(in) :: T9, YeRho, etak, d_etak_dlnT, d_etak_dlnRho
-    real(dp), dimension(:), intent(inout), pointer :: &
+    real(dp), dimension(:), intent(inout) :: &
          lambda, dlambda_dlnT, dlambda_dlnRho, &
          Q, dQ_dlnT, dQ_dlnRho, &
          Qneu, dQneu_dlnT, dQneu_dlnRho

--- a/rates/private/eval_weak.f90
+++ b/rates/private/eval_weak.f90
@@ -48,7 +48,7 @@
          use utils_lib, only: is_bad
          integer, intent(in) :: n, ids(:), reaction_ids(:)
          real(dp), intent(in) :: T9, YeRho, eta, d_eta_dlnT, d_eta_dlnRho
-         real(dp), dimension(:), intent(inout), pointer :: &
+         real(dp), dimension(:), intent(inout) :: &
             lambda, dlambda_dlnT, dlambda_dlnRho, &
             Q, dQ_dlnT, dQ_dlnRho, &
             Qneu, dQneu_dlnT, dQneu_dlnRho
@@ -142,7 +142,7 @@
          use utils_lib, only: is_bad, integer_dict_lookup
          integer, intent(in) :: n, ids(:)
          real(dp), intent(in) :: T9_in, YeRho_in, eta, d_eta_dlnT, d_eta_dlnRho
-         real(dp), dimension(:), intent(inout), pointer :: &
+         real(dp), dimension(:), intent(inout) :: &
             lambda, dlambda_dlnT, dlambda_dlnRho, &
             Q, dQ_dlnT, dQ_dlnRho, &
             Qneu, dQneu_dlnT, dQneu_dlnRho

--- a/rates/public/rates_lib.f90
+++ b/rates/public/rates_lib.f90
@@ -694,7 +694,7 @@
          ! Q is total, so Q-Qneu is the actual thermal energy.
          ! note: lambdas include Ye Rho factors for electron captures.
          ! so treat the rates as if just beta decays
-         real(dp), dimension(:), pointer, intent(inout) :: &
+         real(dp), dimension(:), intent(inout) :: &
                 lambda, dlambda_dlnT, dlambda_dlnRho, &
                 Q, dQ_dlnT, dQ_dlnRho, &
                 Qneu, dQneu_dlnT, dQneu_dlnRho
@@ -751,7 +751,7 @@
          ! Q is total, so Q-Qneu is the actual thermal energy.
          ! note: lambdas include Ye Rho factors for electron captures.
          ! so treat the rates as if just beta decays
-         real(dp), dimension(:), pointer :: &
+         real(dp), dimension(:) :: &
             lambda, dlambda_dlnT, dlambda_dlnRho, &
             Q, dQ_dlnT, dQ_dlnRho, &
             Qneu, dQneu_dlnT, dQneu_dlnRho

--- a/star/other/other_net_derivs.f90
+++ b/star/other/other_net_derivs.f90
@@ -49,7 +49,7 @@
       
       implicit none
 
-      type(Net_Info), pointer :: n
+      type(Net_Info) :: n
       real(qp), pointer, intent(inout) :: dydt(:,:)
       real(qp), intent(out) :: eps_nuc_MeV(:)
       integer, intent(in) :: num_reactions

--- a/star/other/other_net_get.f90
+++ b/star/other/other_net_get.f90
@@ -55,7 +55,7 @@
          integer, intent(in) :: k ! cell number or 0 if not for a particular cell         
          integer, intent(in) :: net_handle
          logical, intent(in) :: just_dxdt
-         type (Net_Info), pointer:: n
+         type (Net_Info) :: n
          integer, intent(in) :: num_isos
          integer, intent(in) :: num_reactions
          real(dp), intent(in)  :: x(:) ! (num_isos)

--- a/star/other/other_net_get.f90
+++ b/star/other/other_net_get.f90
@@ -48,7 +48,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode, &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, ierr)      
+            ierr)      
          use net_lib, only: net_get
          use net_def, only: Net_Info
          integer, intent(in) :: id ! id for star         
@@ -81,8 +81,6 @@
          real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
          real(dp), intent(out) :: eps_neu_total ! ergs/g/s neutrinos from weak reactions
          integer, intent(in) :: screening_mode
-         integer, intent(in) :: lwork ! size of work >= result from calling net_work_size
-         real(dp), pointer :: work(:) ! (lwork)
          integer, intent(out) :: ierr ! 0 means okay
          call net_get( &
             net_handle, just_dxdt, n, num_isos, num_reactions,  &
@@ -94,7 +92,7 @@
             dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
             screening_mode, &
             eps_nuc_categories, eps_neu_total, &
-            lwork, work, ierr)
+            ierr)
       end subroutine null_other_net_get
 
 

--- a/star/other/other_split_burn.f90
+++ b/star/other/other_split_burn.f90
@@ -46,8 +46,6 @@
          screening_mode, &
          stptry, max_steps, eps, odescal, &
          use_pivoting, trace, dbg,  burner_finish_substep, &
-         burn_lwork, burn_work_array, &
-         net_lwork, net_work_array, &
          ! results
          ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
          nfcn, njac, nstep, naccpt, nrejct, ierr)
@@ -79,9 +77,6 @@
          interface
             include 'burner_finish_substep.inc'
          end interface
-         integer, intent(in) :: net_lwork, burn_lwork
-         real(dp), intent(inout), pointer :: burn_work_array(:) ! (burn_lwork)
-         real(dp), intent(inout), pointer :: net_work_array(:) ! (net_lwork)
 
          ! These should be set for the output
          real(dp), intent(inout) :: ending_x(:) ! (num_isos)

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -1208,8 +1208,7 @@
          !   rate_raw, rate_raw_dT, rate_raw_dRho
          !integer :: ir
          !real(dp) :: log10_rho, log10_T, d_eps_nuc_dRho, d_eps_nuc_dT
-         !type (Net_Info), target :: net_info_target
-         !type (Net_Info), pointer :: netinfo
+         !type (Net_Info) :: n
          
          integer :: k, i, min_k, k2
          real(dp) :: Ledd, L_rad, phi_Joss, power_photo, tmp, r, m_div_h, w_div_w_Kep, &
@@ -1241,8 +1240,6 @@
          !       end if
          !    end if
          !    
-         !    net_work => net_work_ary
-         !    netinfo => net_info_target
          ! 
          !    log10_rho = s% lnd(k)/ln10
          !    log10_T = s% lnT(k)/ln10
@@ -1250,7 +1247,7 @@
          !    net_lwork = net_work_size(s% net_handle, ierr)
          !    
          !    call net_get( &
-         !       s% net_handle, .false., netinfo, species, s% num_reactions, s% xa(1:species,k), &
+         !       s% net_handle, .false., n, species, s% num_reactions, s% xa(1:species,k), &
          !       s% T(k), log10_T, s% rho(k), log10_Rho, &
          !       s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
          !       s% eta(k), s% d_eos_dlnd(i_eta,k), s% d_eos_dlnT(i_eta,k), &

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -1181,7 +1181,7 @@
          use gravity_darkening
          
          !use net_def, only: Net_Info
-         !use net_lib, only: net_work_size, get_reaction_id_table_ptr, get_net_rate_ptrs
+         !use net_lib, only: net_work_size, get_reaction_id_table_ptr
          use rates_def, only: T_Factors!, reaction_name, std_reaction_Qs, std_reaction_neuQs
          use rates_lib, only: get_raw_rate, eval_tfactors!, rates_reaction_id, screening_option
          !use eos_def, only : i_eta
@@ -1200,9 +1200,6 @@
          type (T_Factors), target :: tf2
          !real(dp), pointer :: work(:)
          !integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
-         !integer :: net_lwork
-         !real(dp), target :: net_work_ary(net_lwork)
-         !real(dp), pointer :: net_work(:)
          !real(dp), pointer, dimension(:) :: &
          !   rate_screened, rate_screened_dT, rate_screened_dRho, &
          !   rate_raw, rate_raw_dT, rate_raw_dRho
@@ -1244,7 +1241,6 @@
          !    log10_rho = s% lnd(k)/ln10
          !    log10_T = s% lnT(k)/ln10
          !    
-         !    net_lwork = net_work_size(s% net_handle, ierr)
          !    
          !    call net_get( &
          !       s% net_handle, .false., n, species, s% num_reactions, s% xa(1:species,k), &
@@ -1257,20 +1253,12 @@
          !       s% dxdt_nuc(:,k), s% d_dxdt_nuc_dRho(:,k), s% d_dxdt_nuc_dT(:,k), s% d_dxdt_nuc_dx(:,:,k), &
          !       s% screening_mode_value, &
          !       s% eps_nuc_categories(:,k), &
-         !       s% eps_nuc_neu_total(k), net_lwork, net_work, ierr)
+         !       s% eps_nuc_neu_total(k), ierr)
          !    if (ierr /= 0) then
          !       write(*,*) 'failed in net_get'
          !       stop 1
          !    end if
          !
-         !    call get_net_rate_ptrs(s% net_handle, &
-         !       rate_screened, rate_screened_dT, rate_screened_dRho, &
-         !       rate_raw, rate_raw_dT, rate_raw_dRho, net_lwork, net_work, &
-         !       ierr)
-         !    if (ierr /= 0) then
-         !       write(*,*) 'failed in get_net_rate_ptrs'
-         !       stop 1
-         !    end if
          !    ir = rates_reaction_id(reaction_name(i))
          !end if
          

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -62,7 +62,6 @@ contains
 
     use kap_support, only: prepare_kap
     use star_utils, only: start_time, update_time
-    use net_lib, only: net_work_size
     use net, only: do_net
     use chem_def, only: icno, ipp, chem_isos
     use rates_def, only: i_rate

--- a/star/private/net.f90
+++ b/star/private/net.f90
@@ -141,7 +141,7 @@
             star_debugging_rates_flag, rates_test_partials_val, rates_test_partials_dval_dx
          use net_def, only: Net_Info, net_test_partials, &
             net_test_partials_val, net_test_partials_dval_dx, net_test_partials_i, &
-            net_test_partials_iother
+            net_test_partials_iother, get_net_ptr
          use net_lib, only: net_get
          use star_utils, only: lookup_nameofvar
          use chem_def, only: chem_isos, category_name, i_ni56_co56, i_co56_fe56, &
@@ -158,8 +158,7 @@
             d_eps_nuc_dRho, d_eps_nuc_dT, cat_factor, tau_gamma, eps_cat_sum
          real(dp), target :: net_work_ary(net_lwork)
          real(dp), pointer :: net_work(:)
-         type (Net_Info), target :: net_info_target
-         type (Net_Info), pointer :: netinfo
+         type (Net_Info) :: n
          character (len=100) :: message
          real(dp), pointer :: reaction_neuQs(:)
          logical :: clipped_T
@@ -177,10 +176,9 @@
          end if
 
          net_work => net_work_ary
-         netinfo => net_info_target
 
-         netinfo% star_id = s% id
-         netinfo% zone = k
+         n% star_id = s% id
+         n% zone = k
          
          s% eps_nuc(k) = 0d0
          s% d_epsnuc_dlnd(k) = 0d0
@@ -247,7 +245,7 @@
          if (s% use_other_net_get) then
             call s% other_net_get( &
                s% id, k, &
-               s% net_handle, .false., netinfo, species, num_reactions, s% xa(1:species,k), &
+               s% net_handle, .false., n, species, num_reactions, s% xa(1:species,k), &
                T, log10_T, s% rho(k), log10_Rho, &
                s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
                s% eta(k), s% d_eos_dlnT(i_eta,k), s% d_eos_dlnd(i_eta,k), &
@@ -259,7 +257,7 @@
                s% eps_nuc_neu_total(k), net_lwork, net_work, ierr)
          else
             call net_get( &
-               s% net_handle, .false., netinfo, species, num_reactions, s% xa(1:species,k), &
+               s% net_handle, .false., n, species, num_reactions, s% xa(1:species,k), &
                T, log10_T, s% rho(k), log10_Rho, &
                s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
                s% eta(k), s% d_eos_dlnT(i_eta,k), s% d_eos_dlnd(i_eta,k), &

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -262,7 +262,7 @@
          use rsp_def, only: rsp_WORK, rsp_WORKQ, rsp_WORKT, rsp_WORKC
          
          !use net_def, only: Net_Info
-         !use net_lib, only: net_work_size, get_reaction_id_table_ptr, get_net_rate_ptrs
+         !use net_lib, only: net_work_size, get_reaction_id_table_ptr
          use rates_def, only: T_Factors!, reaction_name, std_reaction_Qs, std_reaction_neuQs
          use rates_lib, only: get_raw_rate, eval_tfactors!, rates_reaction_id, screening_option
          !use eos_def, only : i_eta
@@ -277,9 +277,6 @@
          type (T_Factors), pointer :: tf
          type (T_Factors), target :: tf2
          !integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
-         !integer :: net_lwork
-         !real(dp), target :: net_work_ary
-         !real(dp), pointer :: net_work(:)
          !real(dp), pointer, dimension(:) :: &
          !   rate_screened, rate_screened_dT, rate_screened_dRho, &
          !   rate_raw, rate_raw_dT, rate_raw_dRho
@@ -333,7 +330,6 @@
          !    log10_rho = s% lnd(k)/ln10
          !    log10_T = s% lnT(k)/ln10
          !    
-         !    net_lwork = net_work_size(s% net_handle, ierr)
          !    
          !    call net_get( &
          !       s% net_handle, .false., n, species, s% num_reactions, s% xa(1:species,k), &
@@ -346,20 +342,12 @@
          !       s% dxdt_nuc(:,k), s% d_dxdt_nuc_dRho(:,k), s% d_dxdt_nuc_dT(:,k), s% d_dxdt_nuc_dx(:,:,k), &
          !       s% screening_mode_value, &
          !       s% eps_nuc_categories(:,k), &
-         !       s% eps_nuc_neu_total(k), net_lwork, net_work, ierr)
+         !       s% eps_nuc_neu_total(k),  ierr)
          !    if (ierr /= 0) then
          !       write(*,*) 'failed in net_get'
          !       stop 1
          !    end if
          !
-         !    call get_net_rate_ptrs(s% net_handle, &
-         !       rate_screened, rate_screened_dT, rate_screened_dRho, &
-         !       rate_raw, rate_raw_dT, rate_raw_dRho, net_lwork, net_work, &
-         !       ierr)
-         !    if (ierr /= 0) then
-         !       write(*,*) 'failed in get_net_rate_ptrs'
-         !       stop 1
-         !    end if
          !    ir = rates_reaction_id(reaction_name(i))
          !end if
 

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -285,8 +285,7 @@
          !   rate_raw, rate_raw_dT, rate_raw_dRho
          !integer :: ir
          !real(dp) :: log10_rho, log10_T, d_eps_nuc_dRho, d_eps_nuc_dT
-         !type (Net_Info), target :: net_info_target
-         !type (Net_Info), pointer :: netinfo
+         !type (Net_Info) :: n
 
          real(dp) :: cno, z, x, frac, eps, eps_alt, L_rad, L_edd, Pbar_00, Pbar_p1, &
             P_face, rho_face, dr, v, r00, rp1, v00, vp1, A00, Ap1, Amid, &
@@ -330,8 +329,6 @@
          !       end if
          !    end if
          !    
-         !    net_work => net_work_ary
-         !    netinfo => net_info_target
          ! 
          !    log10_rho = s% lnd(k)/ln10
          !    log10_T = s% lnT(k)/ln10
@@ -339,7 +336,7 @@
          !    net_lwork = net_work_size(s% net_handle, ierr)
          !    
          !    call net_get( &
-         !       s% net_handle, .false., netinfo, species, s% num_reactions, s% xa(1:species,k), &
+         !       s% net_handle, .false., n, species, s% num_reactions, s% xa(1:species,k), &
          !       s% T(k), log10_T, s% rho(k), log10_Rho, &
          !       s% abar(k), s% zbar(k), s% z2bar(k), s% ye(k), &
          !       s% eta(k), s% d_eos_dlnd(i_eta,k), s% d_eos_dlnT(i_eta,k), &

--- a/star_data/public/star_data_def.inc
+++ b/star_data/public/star_data_def.inc
@@ -713,7 +713,7 @@
             integer, intent(in) :: k ! cell number or 0 if not for a particular cell         
             integer, intent(in) :: net_handle
             logical, intent(in) :: just_dxdt
-            type (Net_Info), pointer:: n
+            type (Net_Info) :: n
             integer, intent(in) :: num_isos
             integer, intent(in) :: num_reactions
             real(dp), intent(in)  :: x(:) ! (num_isos)

--- a/star_data/public/star_data_def.inc
+++ b/star_data/public/star_data_def.inc
@@ -706,7 +706,7 @@
                dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
                screening_mode,  &
                eps_nuc_categories, eps_neu_total, &
-               lwork, work, ierr)      
+               ierr)      
             use const_def, only: dp
             use net_def, only: Net_Info
             integer, intent(in) :: id ! id for star         
@@ -739,8 +739,6 @@
             real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
             real(dp), intent(out) :: eps_neu_total ! ergs/g/s neutrinos from weak reactions
             integer, intent(in) :: screening_mode
-            integer, intent(in) :: lwork ! size of work >= result from calling net_work_size
-            real(dp), pointer :: work(:) ! (lwork)
             integer, intent(out) :: ierr ! 0 means okay
          end subroutine other_net_get_interface
 
@@ -753,8 +751,6 @@
             screening_mode, &
             stptry, max_steps, eps, odescal, &
             use_pivoting, trace, dbg, burner_finish_substep, &
-            burn_lwork, burn_work_array, &
-            net_lwork, net_work_array, &
             ! results
             ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
             nfcn, njac, nstep, naccpt, nrejct, ierr)
@@ -785,9 +781,6 @@
             interface
                include 'burner_finish_substep.inc'
             end interface
-            integer, intent(in) :: net_lwork, burn_lwork
-            real(dp), intent(inout), pointer :: burn_work_array(:) ! (burn_lwork)
-            real(dp), intent(inout), pointer :: net_work_array(:) ! (net_lwork)
    
             ! These should be set for the output
             real(dp), intent(inout) :: ending_x(:) ! (num_isos)


### PR DESCRIPTION
Simplify much of the net memory management by moving net_info components into allocatables instead of pointers, as well
as making net_info not  a pointer either.

I plan to push more of the net state into net_info so then it becomes easier to pass around the net (For instance making functions
take both the temp and n, but n contains the temp anyway so one of these is redundant).

This has also fixed a hard to find bug in burn_const_P which was using (probably) random values for T,Rho as we where
accessing the wrong part of an rpar array (which never errored as we had a large work array stuck to the end of rpar which
masks the wrong access).

Hopefully  by the end of this we can just call net_get(..., rates_only=.true.) and get back the rates for that zone, without having to re-implement half of eval_net