### PR TITLE
fix compiling with `USE_CRMATH = NO`

### DIFF
--- a/math/public/math_lib_intrinsic.f90
+++ b/math/public/math_lib_intrinsic.f90
@@ -31,6 +31,7 @@ module math_lib
 
   use math_io
   use math_pown
+  use math_def
 
   use IEEE_ARITHMETIC
 


### PR DESCRIPTION
When compiling release `r22.05.1` or the current `main` with `USE_CRMATH = NO`, I'm getting this error.

```
COMPILE_CMD ../public/math_def.f90
COMPILE_CMD ../public/math_lib_intrinsic.f90
precompute_zs.inc:8:10:

Error: Unclassifiable statement at (1)
precompute_zs.inc:5:33:

Error: Symbol 'max_precomp_ints' at (1) has no IMPLICIT type
```

I think the reason is that `math_lib_intrinsic.f90` does not have a `use math_def` statement. The alternative file `math_lib_crmath.f90` does load this module.

This PR fixes compilation with `USE_CRMATH = NO`.