### PR TITLE
fix to after_step_loop so incoming result value is considered

### DIFF
--- a/star/job/run_star_support.f90
+++ b/star/job/run_star_support.f90
@@ -657,13 +657,13 @@
       end subroutine before_step_loop
 
 
-      subroutine after_step_loop(id, inlist_fname, &
-             dbg, result, ierr)
+      subroutine after_step_loop(id, inlist_fname, dbg, result, ierr)
          integer, intent(in) :: id
          type (star_info), pointer :: s         
          character (len=*) :: inlist_fname
          logical, intent(in) :: dbg
-         integer, intent(out) :: result, ierr
+         integer, intent(out) :: ierr
+         integer, intent(inout) :: result
          logical :: will_read_pgstar_inlist
 
          real(dp) :: tmp


### PR DESCRIPTION
When using r15140 with linux SDK 20.12.1 to run binary models, I unfortunately noticed no history or profiles of the stars were saved. I tracked the issue down to `run_star_support: after_step_loop`, where `star_finish_step` was not called since `result = -470533012` (or any other number that happened to be in that memory location) at that point. 
Newer compilers (such as the macOS SDK 22.6.2) seem to implicitly put `result = 0 (== keep_going)`, which avoids this issue, but still, if `result == terminate` upon invocation of `after_step_loop`, this value is not considered because of the `intent(out)`
simply changing the intent to `inout` avoids problems on any compiler, and lets `after_step_loop` take in the `result` value you give it.

Weird that this issue did not turn up earlier, SDK 20.12.1 was supposed to be a compatible SDK for r15140. Are there tests that logs/history and/or profiles are actually created/written?