### PR TITLE
Refactor basic enrichment law (Y=0.24+2Z) for initial models with `initial_y = -1`

### DIFF
--- a/atm/private/atm_t_tau_relations.f90
+++ b/atm/private/atm_t_tau_relations.f90
@@ -398,7 +398,7 @@ contains
 
     real(dp) :: x
 
-    ! Evaluate q'(τ) for Ball (2021, RNAAS ...)
+    ! Evaluate q'(τ) for Ball (2021, RNAAS 5, 7)
     ! using fit to solar simulation by
     ! Trampedach et al. (2014, MNRAS 442, 805–820)
 

--- a/star/private/create_initial_model.f90
+++ b/star/private/create_initial_model.f90
@@ -128,7 +128,6 @@
 
          initial_z = s% initial_z
          initial_y = s% initial_y
-         if (initial_y < 0) initial_y = max(0d0, min(1d0, 0.24d0 + 2d0*initial_z))
          initial_h1 = max(0d0, min(1d0, 1d0 - (initial_z + initial_y)))
          initial_h2 = 0d0
          xsol_he3 = chem_Xsol('he3')

--- a/star/private/init.f90
+++ b/star/private/init.f90
@@ -867,6 +867,9 @@
 
          initial_mass = s% initial_mass
          initial_z = s% initial_z
+
+         if (s% initial_y < 0) s% initial_y = max(0d0, min(1d0, 0.24d0 + 2*initial_z))
+
          s% dt = 0
          s% termination_code = -1
 

--- a/star/private/pgstar_production.f90
+++ b/star/private/pgstar_production.f90
@@ -189,12 +189,11 @@
             allocate(abun(1:s%species),init_comp(1:s%species))
             abun=0.d0
 
-            !Get initial composotion
+            !Get initial composition
 
             !Stolen from star/private/create_initial_model
             initial_z = s% initial_z
             initial_y = s% initial_y
-            if (initial_y < 0) initial_y = max(0d0, min(1d0, 0.24d0 + 2*initial_z))
             initial_h1 = max(0d0, min(1d0, 1d0 - (initial_z + initial_y)))
             initial_h2 = chem_Xsol('h2')
             xsol_he3 = chem_Xsol('he3')

--- a/star/private/pre_ms_model.f90
+++ b/star/private/pre_ms_model.f90
@@ -97,7 +97,6 @@
          ierr = 0
          initial_z = s% initial_z
          initial_y = s% initial_y
-         if (initial_y < 0) initial_y = max(0d0, min(1d0, 0.24d0 + 2*initial_z))
          s% M_center = 0
          s% L_center = 0
          s% R_center = 0


### PR DESCRIPTION
When an initial model is constructed with `initial_y < 0`, a basic enrichment law `Y=0.24 + 2Z` is invoked:
https://github.com/MESAHub/mesa/blob/68644ccd15db719d33c62ad03754135cbbdd2920/star/defaults/controls.defaults#L59-L73
The enrichment law doesn't carry through to the FGONG or OSC pulsation formats, which @AntoNoll flagged in #465. On investigating, this enrichment law was being invoked in at least three places. This PR refactors all of this by changing the value of the control `s% initial_y` itself to use the enrichment law, so that subsequent routines only see that (positive) value.

`s% initial_y` is only re-assigned just before an initial model is constructed. I don't often start from existing models or photos. I'm not sure if this might cause unexpected behaviour but I assume that if you aren't creating an initial model, you never go down the modified code path. The test suite is [all passing](https://testhub.mesastar.org/fix_pulse_X0/commits/1af7515) with the `[ci optional]` flag.