### PR TITLE
Tweak `auto_diff` overview to point to index values for `auto_diff_real_star_order1`

### DIFF
--- a/docs/source/auto_diff/overview.rst
+++ b/docs/source/auto_diff/overview.rst
@@ -36,8 +36,13 @@ Similar types are included supporting higher-order and mixed-partial
 derivatives.  These derivatives are accessed via e.g. ``d2val1``
 (:math:`\partial^2 f/\partial x^2`), ``d1val1_d2val2`` (:math:`\partial^3 f/\partial x \partial y^2`).
 
-An additional special type ``auto_diff_real_star_order1`` provides support for first-order derivatives accessed using arrays.
-This type contains a value (``x%val``) and an array of first partial derivatives with respect to 27 independent variables  (``x%d1Array(1:27)``).
-This type is meant to make it easy to write equations and then, after the fact, change the basis of independent variables or re-index them.
-The number `27` is chosen to provide as many independent variables as the ``MESA/star`` solver uses,
-as this type is meant for use in writing the equations of stellar evolution.
+An additional special type ``auto_diff_real_star_order1`` provides support
+for first-order derivatives accessed using arrays.
+This type contains a value (``x%val``) and an array of first partial derivatives
+with respect to at least as many variables as the solver in ``MESA/star``.
+This type is meant to make it easy to write equations and then, after the fact,
+change the basis of independent variables or re-index them.
+The current indices are defined in ``star_data/public/star_data_def.inc``.
+E.g., if ``my_var`` is of type ``auto_diff_real_star_order1``,
+then ``my_var% d1Array(i_lnT_00)`` contains the derivative of ``my_var``
+with respect to ``lnT`` at the same mesh point.


### PR DESCRIPTION
Following [a question on MESA users](https://lists.mesastar.org/pipermail/mesa-users/2022-December/014183.html), I noticed that [the `auto_diff` overview](https://docs.mesastar.org/en/release-r22.11.1/auto_diff/overview.html) doesn't describe the indices of the `auto_diff_real_star_order1` type. This change is mainly to point to where users can find them, without adding them directly to the docs where they're at risk of falling out of sync.

I'm doing this as a PR so that anyone can comment on/commit further changes to the `auto_diff` help. I've used `auto_diff` relatively little myself so am open to those with more experience correcting/improving what I've written.

I had a quick look in the test suite for cases that made interesting use of the `auto_diff` type. `starspots` and `ppisn` do and, of those, I think only `ppisn` has a non-trivial use, in particular for setting the derivatives of the rotational distortion factors $f_P$ and $f_T$ with respect to $\omega/\omega_\mathrm{crit}$. But I also don't think it's enlightening for a new user so haven't linked to that.