### PR TITLE
Inlist arrays

### DIFF
--- a/astero/defaults/astero_pgstar.defaults
+++ b/astero/defaults/astero_pgstar.defaults
@@ -83,40 +83,12 @@
    ! Include other inlists
    ! ---------------------
 
-   ! read_extra_astero_pgstar_inlist1
+   ! read_extra_astero_pgstar_inlist
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_pgstar_inlist1_name
+   ! extra_astero_pgstar_inlist_name
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_pgstar_inlist2
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_pgstar_inlist2_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_pgstar_inlist3
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_pgstar_inlist3_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_pgstar_inlist4
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_pgstar_inlist4_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_pgstar_inlist5
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_pgstar_inlist5_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! If ``read_extra_astero_pgstar_inlistN`` is ``.true.``, then read the namelist
-   ! in file ``extra_astero_pgstar_inlistN_name``.  ::
+   ! If ``read_extra_astero_pgstar_inlist(i)`` is ``.true.``, then read the namelist
+   ! in file ``extra_astero_pgstar_inlist_name(i)``.  ::
 
-      read_extra_astero_pgstar_inlist1 = .false.
-      extra_astero_pgstar_inlist1_name = 'undefined'
-
-      read_extra_astero_pgstar_inlist2 = .false.
-      extra_astero_pgstar_inlist2_name = 'undefined'
-
-      read_extra_astero_pgstar_inlist3 = .false.
-      extra_astero_pgstar_inlist3_name = 'undefined'
-
-      read_extra_astero_pgstar_inlist4 = .false.
-      extra_astero_pgstar_inlist4_name = 'undefined'
-
-      read_extra_astero_pgstar_inlist5 = .false.
-      extra_astero_pgstar_inlist5_name = 'undefined'
+      read_extra_astero_pgstar_inlist(:) = .false.
+      extra_astero_pgstar_inlist_name(:) = 'undefined'

--- a/astero/defaults/astero_search.defaults
+++ b/astero/defaults/astero_search.defaults
@@ -1247,9 +1247,9 @@
    ! ---------------------
 
    ! read_extra_astero_search_inlist(1..5)
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ! extra_astero_search_inlist_name(1..5)
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ! If ``read_extra_astero_search_inlist(i)`` is ``.true.``, then read the namelist
    ! in file ``extra_astero_search_inlist_name(i)``.  ::
 

--- a/astero/defaults/astero_search.defaults
+++ b/astero/defaults/astero_search.defaults
@@ -1246,40 +1246,13 @@
    ! Include other inlists
    ! ---------------------
 
-   ! read_extra_astero_search_inlist1
+   ! read_extra_astero_search_inlist(1..5)
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_search_inlist1_name
+   ! extra_astero_search_inlist_name(1..5)
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_search_inlist2
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_search_inlist2_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_search_inlist3
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_search_inlist3_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_search_inlist4
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_search_inlist4_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! read_extra_astero_search_inlist5
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! extra_astero_search_inlist5_name
-   ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   ! If ``read_extra_astero_search_inlistN`` is ``.true.``, then read the namelist
-   ! in file ``extra_astero_search_inlistN_name``.  ::
+   ! If ``read_extra_astero_search_inlist(i)`` is ``.true.``, then read the namelist
+   ! in file ``extra_astero_search_inlist_name(i)``.  ::
 
-      read_extra_astero_search_inlist1 = .false.
-      extra_astero_search_inlist1_name = 'undefined'
+      read_extra_astero_search_inlist(:) = .false.
+      extra_astero_search_inlist_name(:) = 'undefined'
 
-      read_extra_astero_search_inlist2 = .false.
-      extra_astero_search_inlist2_name = 'undefined'
-
-      read_extra_astero_search_inlist3 = .false.
-      extra_astero_search_inlist3_name = 'undefined'
-
-      read_extra_astero_search_inlist4 = .false.
-      extra_astero_search_inlist4_name = 'undefined'
-
-      read_extra_astero_search_inlist5 = .false.
-      extra_astero_search_inlist5_name = 'undefined'

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -273,23 +273,9 @@
          ! frequency range for adipls is set from observed frequencies times these            
       integer :: & ! misc adipls parameters
          adipls_irotkr, adipls_nprtkr, adipls_igm1kr, adipls_npgmkr
-
       
-      logical :: read_extra_astero_search_inlist1
-      character (len=256) :: extra_astero_search_inlist1_name 
-      
-      logical :: read_extra_astero_search_inlist2
-      character (len=256) :: extra_astero_search_inlist2_name 
-      
-      logical :: read_extra_astero_search_inlist3
-      character (len=256) :: extra_astero_search_inlist3_name 
-      
-      logical :: read_extra_astero_search_inlist4
-      character (len=256) :: extra_astero_search_inlist4_name 
-      
-      logical :: read_extra_astero_search_inlist5
-      character (len=256) :: extra_astero_search_inlist5_name 
-
+      logical, dimension(max_extra_inlists) :: read_extra_astero_search_inlist
+      character (len=strlen), dimension(max_extra_inlists) :: extra_astero_search_inlist_name
 
       namelist /astero_search_controls/ &
          normalize_chi2_spectro, &
@@ -422,16 +408,8 @@
          iscan_factor, &
          adipls_irotkr, adipls_nprtkr, adipls_igm1kr, adipls_npgmkr, &
          nu_lower_factor, nu_upper_factor, &
-         read_extra_astero_search_inlist1, &
-         extra_astero_search_inlist1_name, &
-         read_extra_astero_search_inlist2, &
-         extra_astero_search_inlist2_name, &
-         read_extra_astero_search_inlist3, &
-         extra_astero_search_inlist3_name, &
-         read_extra_astero_search_inlist4, &
-         extra_astero_search_inlist4_name, &
-         read_extra_astero_search_inlist5, &
-         extra_astero_search_inlist5_name
+         read_extra_astero_search_inlist, &
+         extra_astero_search_inlist_name
             
       
       ! pgstar plots
@@ -466,20 +444,8 @@
          show_ratios_annotation2, &
          show_ratios_annotation3      
       
-      logical :: read_extra_astero_pgstar_inlist1
-      character (len=256) :: extra_astero_pgstar_inlist1_name 
-      
-      logical :: read_extra_astero_pgstar_inlist2
-      character (len=256) :: extra_astero_pgstar_inlist2_name 
-      
-      logical :: read_extra_astero_pgstar_inlist3
-      character (len=256) :: extra_astero_pgstar_inlist3_name 
-      
-      logical :: read_extra_astero_pgstar_inlist4
-      character (len=256) :: extra_astero_pgstar_inlist4_name 
-      
-      logical :: read_extra_astero_pgstar_inlist5
-      character (len=256) :: extra_astero_pgstar_inlist5_name 
+      logical, dimension(max_extra_inlists) :: read_extra_astero_pgstar_inlist
+      character (len=strlen), dimension(max_extra_inlists) :: extra_astero_pgstar_inlist_name
          
       namelist /astero_pgstar_controls/ &
          echelle_win_flag, echelle_file_flag, &
@@ -505,11 +471,7 @@
          show_ratios_annotation1, &
          show_ratios_annotation2, &
          show_ratios_annotation3, &
-         read_extra_astero_pgstar_inlist1, extra_astero_pgstar_inlist1_name, &
-         read_extra_astero_pgstar_inlist2, extra_astero_pgstar_inlist2_name, &
-         read_extra_astero_pgstar_inlist3, extra_astero_pgstar_inlist3_name, &
-         read_extra_astero_pgstar_inlist4, extra_astero_pgstar_inlist4_name, &
-         read_extra_astero_pgstar_inlist5, extra_astero_pgstar_inlist5_name
+         read_extra_astero_pgstar_inlist, extra_astero_pgstar_inlist_name
 
 
 
@@ -896,9 +858,10 @@
          integer, intent(in) :: level  
          integer, intent(out) :: ierr
          
-         logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-         character (len=256) :: message, extra1, extra2, extra3, extra4, extra5
-         integer :: unit
+         logical, dimension(max_extra_inlists) :: read_extra
+         character (len=strlen) :: message
+         character (len=strlen), dimension(max_extra_inlists) :: extra
+         integer :: unit, i
          
          if (level >= 10) then
             write(*,*) 'ERROR: too many levels of nested extra star_job inlist files'
@@ -933,61 +896,18 @@
          if (ierr /= 0) return
          
          ! recursive calls to read other inlists
-         
-         read_extra1 = read_extra_astero_search_inlist1
-         read_extra_astero_search_inlist1 = .false.
-         extra1 = extra_astero_search_inlist1_name
-         extra_astero_search_inlist1_name = 'undefined'
-         
-         read_extra2 = read_extra_astero_search_inlist2
-         read_extra_astero_search_inlist2 = .false.
-         extra2 = extra_astero_search_inlist2_name
-         extra_astero_search_inlist2_name = 'undefined'
-         
-         read_extra3 = read_extra_astero_search_inlist3
-         read_extra_astero_search_inlist3 = .false.
-         extra3 = extra_astero_search_inlist3_name
-         extra_astero_search_inlist3_name = 'undefined'
-         
-         read_extra4 = read_extra_astero_search_inlist4
-         read_extra_astero_search_inlist4 = .false.
-         extra4 = extra_astero_search_inlist4_name
-         extra_astero_search_inlist4_name = 'undefined'
-         
-         read_extra5 = read_extra_astero_search_inlist5
-         read_extra_astero_search_inlist5 = .false.
-         extra5 = extra_astero_search_inlist5_name
-         extra_astero_search_inlist5_name = 'undefined'
-         
-         if (read_extra1) then
-            !write(*,*) 'read extra astero_search inlist1 from ' // trim(extra1)
-            call read1_astero_search_inlist(extra1, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra2) then
-            !write(*,*) 'read extra astero_search inlist2 from ' // trim(extra2)
-            call read1_astero_search_inlist(extra2, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra3) then
-            !write(*,*) 'read extra astero_search inlist3 from ' // trim(extra3)
-            call read1_astero_search_inlist(extra3, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra4) then
-            !write(*,*) 'read extra astero_search inlist4 from ' // trim(extra4)
-            call read1_astero_search_inlist(extra4, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra5) then
-            write(*,*) 'read extra astero_search inlist5 from ' // trim(extra5)
-            call read1_astero_search_inlist(extra5, level+1, ierr)
-            if (ierr /= 0) return
-         end if
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_astero_search_inlist(i)
+            read_extra_astero_search_inlist(i) = .false.
+            extra(i) = extra_astero_search_inlist_name(i)
+            extra_astero_search_inlist_name(i) = 'undefined'
+            
+            if (read_extra(i)) then
+               call read1_astero_search_inlist(extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
+        
          
       end subroutine read1_astero_search_inlist
 
@@ -1042,9 +962,10 @@
          integer, intent(in) :: level  
          integer, intent(out) :: ierr
          
-         logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-         character (len=256) :: message, extra1, extra2, extra3, extra4, extra5
-         integer :: unit
+         logical, dimension(max_extra_inlists) :: read_extra
+         character (len=strlen) :: message
+         character (len=strlen), dimension(max_extra_inlists) :: extra
+         integer :: unit, i
          
          if (level >= 10) then
             write(*,*) 'ERROR: too many levels of nested extra star_job inlist files'
@@ -1077,62 +998,18 @@
          call free_iounit(unit)
          if (ierr /= 0) return
          
-         ! recursive calls to read other inlists
-         
-         read_extra1 = read_extra_astero_pgstar_inlist1
-         read_extra_astero_pgstar_inlist1 = .false.
-         extra1 = extra_astero_pgstar_inlist1_name
-         extra_astero_pgstar_inlist1_name = 'undefined'
-         
-         read_extra2 = read_extra_astero_pgstar_inlist2
-         read_extra_astero_pgstar_inlist2 = .false.
-         extra2 = extra_astero_pgstar_inlist2_name
-         extra_astero_pgstar_inlist2_name = 'undefined'
-         
-         read_extra3 = read_extra_astero_pgstar_inlist3
-         read_extra_astero_pgstar_inlist3 = .false.
-         extra3 = extra_astero_pgstar_inlist3_name
-         extra_astero_pgstar_inlist3_name = 'undefined'
-         
-         read_extra4 = read_extra_astero_pgstar_inlist4
-         read_extra_astero_pgstar_inlist4 = .false.
-         extra4 = extra_astero_pgstar_inlist4_name
-         extra_astero_pgstar_inlist4_name = 'undefined'
-         
-         read_extra5 = read_extra_astero_pgstar_inlist5
-         read_extra_astero_pgstar_inlist5 = .false.
-         extra5 = extra_astero_pgstar_inlist5_name
-         extra_astero_pgstar_inlist5_name = 'undefined'
-         
-         if (read_extra1) then
-            !write(*,*) 'read extra astero_pgstar inlist1 from ' // trim(extra1)
-            call read1_astero_pgstar_inlist(extra1, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra2) then
-            !write(*,*) 'read extra astero_pgstar inlist2 from ' // trim(extra2)
-            call read1_astero_pgstar_inlist(extra2, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra3) then
-            !write(*,*) 'read extra astero_pgstar inlist3 from ' // trim(extra3)
-            call read1_astero_pgstar_inlist(extra3, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra4) then
-            !write(*,*) 'read extra astero_pgstar inlist4 from ' // trim(extra4)
-            call read1_astero_pgstar_inlist(extra4, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra5) then
-            write(*,*) 'read extra astero_pgstar inlist5 from ' // trim(extra5)
-            call read1_astero_pgstar_inlist(extra5, level+1, ierr)
-            if (ierr /= 0) return
-         end if
+                  ! recursive calls to read other inlists
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_astero_pgstar_inlist(i)
+            read_extra_astero_pgstar_inlist(i) = .false.
+            extra(i) = extra_astero_pgstar_inlist_name(i)
+            extra_astero_pgstar_inlist_name(i) = 'undefined'
+            
+            if (read_extra(i)) then
+               call read1_astero_pgstar_inlist(extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
          
       end subroutine read1_astero_pgstar_inlist
 

--- a/astero/test_suite/astero_adipls/inlist
+++ b/astero/test_suite/astero_adipls/inlist
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_astero_adipls'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_astero_adipls'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_astero_adipls'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_astero_adipls'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_astero_adipls'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_astero_adipls'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_astero_adipls'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_astero_adipls'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_astero_adipls'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_astero_adipls'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/astero_adipls/inlist_astero_adipls_header
+++ b/astero/test_suite/astero_adipls/inlist_astero_adipls_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_astero_adipls'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_astero_adipls'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_astero_adipls'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_astero_adipls'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_astero_adipls'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_astero_adipls'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_astero_adipls'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_astero_adipls'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_astero_adipls'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_astero_adipls'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/astero_adipls/inlist_zams_header
+++ b/astero/test_suite/astero_adipls/inlist_zams_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/astero_gyre/inlist_astero_gyre_header
+++ b/astero/test_suite/astero_gyre/inlist_astero_gyre_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_astero_gyre'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_astero_gyre'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_astero_gyre'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_astero_gyre'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_astero_gyre'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_astero_gyre'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_astero_gyre'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_astero_gyre'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_astero_gyre'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_astero_gyre'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/example_astero/inlist
+++ b/astero/test_suite/example_astero/inlist
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_example_astero'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_example_astero'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_example_astero'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_example_astero'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_example_astero'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_example_astero'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_example_astero'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_example_astero'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_example_astero'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_example_astero'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/example_astero/inlist_astero_search_controls
+++ b/astero/test_suite/example_astero/inlist_astero_search_controls
@@ -408,29 +408,6 @@
          nu_upper_factor = 1.2
 
 
-   ! include other inlists
-   
-         read_extra_astero_search_inlist1 = .false.
-         extra_astero_search_inlist1_name = 'undefined'
-            ! if read_extra_astero_search_inlist1 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist2 = .false.
-         extra_astero_search_inlist2_name = 'undefined'
-            ! if read_extra_astero_search_inlist2 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist3 = .false.
-         extra_astero_search_inlist3_name = 'undefined'
-            ! if read_extra_astero_search_inlist3 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist4 = .false.
-         extra_astero_search_inlist4_name = 'undefined'
-            ! if read_extra_astero_search_inlist4 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist5 = .false.
-         extra_astero_search_inlist5_name = 'undefined'
-            ! if read_extra_astero_search_inlist5 is true, then read this namelist file
-
-
 / ! end astero_search_controls
 
 

--- a/astero/test_suite/example_astero/inlist_example_astero_header
+++ b/astero/test_suite/example_astero/inlist_example_astero_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_example_astero'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_example_astero'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_example_astero'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_example_astero'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_example_astero'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_example_astero'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_example_astero'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_example_astero'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_example_astero'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_example_astero'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/fast_from_file/inlist_astero_search_controls
+++ b/astero/test_suite/fast_from_file/inlist_astero_search_controls
@@ -363,29 +363,6 @@
          nu_upper_factor = 1.2
 
 
-   ! include other inlists
-   
-         read_extra_astero_search_inlist1 = .false.
-         extra_astero_search_inlist1_name = 'undefined'
-            ! if read_extra_astero_search_inlist1 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist2 = .false.
-         extra_astero_search_inlist2_name = 'undefined'
-            ! if read_extra_astero_search_inlist2 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist3 = .false.
-         extra_astero_search_inlist3_name = 'undefined'
-            ! if read_extra_astero_search_inlist3 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist4 = .false.
-         extra_astero_search_inlist4_name = 'undefined'
-            ! if read_extra_astero_search_inlist4 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist5 = .false.
-         extra_astero_search_inlist5_name = 'undefined'
-            ! if read_extra_astero_search_inlist5 is true, then read this namelist file
-
-
 / ! end astero_search_controls
 
 

--- a/astero/test_suite/fast_from_file/inlist_fast_from_file_header
+++ b/astero/test_suite/fast_from_file/inlist_fast_from_file_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_fast_from_file'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_fast_from_file'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_fast_from_file'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_fast_from_file'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_fast_from_file'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_fast_from_file'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_fast_from_file'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_fast_from_file'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_fast_from_file'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_fast_from_file'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/fast_newuoa/inlist_astero_search_controls
+++ b/astero/test_suite/fast_newuoa/inlist_astero_search_controls
@@ -290,29 +290,6 @@
          nu_upper_factor = 1.2
 
 
-   ! include other inlists
-   
-         read_extra_astero_search_inlist1 = .false.
-         extra_astero_search_inlist1_name = 'undefined'
-            ! if read_extra_astero_search_inlist1 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist2 = .false.
-         extra_astero_search_inlist2_name = 'undefined'
-            ! if read_extra_astero_search_inlist2 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist3 = .false.
-         extra_astero_search_inlist3_name = 'undefined'
-            ! if read_extra_astero_search_inlist3 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist4 = .false.
-         extra_astero_search_inlist4_name = 'undefined'
-            ! if read_extra_astero_search_inlist4 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist5 = .false.
-         extra_astero_search_inlist5_name = 'undefined'
-            ! if read_extra_astero_search_inlist5 is true, then read this namelist file
-
-
 / ! end astero_search_controls
 
 

--- a/astero/test_suite/fast_newuoa/inlist_fast_newuoa_header
+++ b/astero/test_suite/fast_newuoa/inlist_fast_newuoa_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_fast_newuoa'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_fast_newuoa'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_fast_newuoa'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_fast_newuoa'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_fast_newuoa'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_fast_newuoa'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_fast_newuoa'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_fast_newuoa'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_fast_newuoa'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_fast_newuoa'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/fast_scan_grid/inlist_astero_search_controls
+++ b/astero/test_suite/fast_scan_grid/inlist_astero_search_controls
@@ -311,29 +311,6 @@
          nu_upper_factor = 1.2
 
 
-   ! include other inlists
-   
-         read_extra_astero_search_inlist1 = .false.
-         extra_astero_search_inlist1_name = 'undefined'
-            ! if read_extra_astero_search_inlist1 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist2 = .false.
-         extra_astero_search_inlist2_name = 'undefined'
-            ! if read_extra_astero_search_inlist2 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist3 = .false.
-         extra_astero_search_inlist3_name = 'undefined'
-            ! if read_extra_astero_search_inlist3 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist4 = .false.
-         extra_astero_search_inlist4_name = 'undefined'
-            ! if read_extra_astero_search_inlist4 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist5 = .false.
-         extra_astero_search_inlist5_name = 'undefined'
-            ! if read_extra_astero_search_inlist5 is true, then read this namelist file
-
-
 / ! end astero_search_controls
 
 

--- a/astero/test_suite/fast_scan_grid/inlist_fast_scan_grid_header
+++ b/astero/test_suite/fast_scan_grid/inlist_fast_scan_grid_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_fast_scan_grid'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_fast_scan_grid'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_fast_scan_grid'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_fast_scan_grid'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_fast_scan_grid'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_fast_scan_grid'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_fast_scan_grid'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_fast_scan_grid'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_fast_scan_grid'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_fast_scan_grid'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/fast_simplex/inlist_astero_search_controls
+++ b/astero/test_suite/fast_simplex/inlist_astero_search_controls
@@ -314,28 +314,6 @@
          nu_lower_factor = 0.8
          nu_upper_factor = 1.2
 
-   ! include other inlists
-   
-         read_extra_astero_search_inlist1 = .false.
-         extra_astero_search_inlist1_name = 'undefined'
-            ! if read_extra_astero_search_inlist1 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist2 = .false.
-         extra_astero_search_inlist2_name = 'undefined'
-            ! if read_extra_astero_search_inlist2 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist3 = .false.
-         extra_astero_search_inlist3_name = 'undefined'
-            ! if read_extra_astero_search_inlist3 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist4 = .false.
-         extra_astero_search_inlist4_name = 'undefined'
-            ! if read_extra_astero_search_inlist4 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist5 = .false.
-         extra_astero_search_inlist5_name = 'undefined'
-            ! if read_extra_astero_search_inlist5 is true, then read this namelist file
-
 
 / ! end astero_search_controls
 

--- a/astero/test_suite/fast_simplex/inlist_fast_simplex_header
+++ b/astero/test_suite/fast_simplex/inlist_fast_simplex_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_fast_simplex'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_fast_simplex'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_fast_simplex'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_fast_simplex'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_fast_simplex'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_fast_simplex'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_fast_simplex'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_fast_simplex'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_fast_simplex'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_fast_simplex'
 
 / ! end of pgstar namelist

--- a/astero/test_suite/surface_effects/inlist_astero_search_controls
+++ b/astero/test_suite/surface_effects/inlist_astero_search_controls
@@ -357,29 +357,6 @@
          nu_upper_factor = 1.2
 
 
-   ! include other inlists
-   
-         read_extra_astero_search_inlist1 = .false.
-         extra_astero_search_inlist1_name = 'undefined'
-            ! if read_extra_astero_search_inlist1 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist2 = .false.
-         extra_astero_search_inlist2_name = 'undefined'
-            ! if read_extra_astero_search_inlist2 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist3 = .false.
-         extra_astero_search_inlist3_name = 'undefined'
-            ! if read_extra_astero_search_inlist3 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist4 = .false.
-         extra_astero_search_inlist4_name = 'undefined'
-            ! if read_extra_astero_search_inlist4 is true, then read this namelist file
-   
-         read_extra_astero_search_inlist5 = .false.
-         extra_astero_search_inlist5_name = 'undefined'
-            ! if read_extra_astero_search_inlist5 is true, then read this namelist file
-
-
 / ! end astero_search_controls
 
 

--- a/astero/test_suite/surface_effects/inlist_surface_effects_header
+++ b/astero/test_suite/surface_effects/inlist_surface_effects_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_surface_effects'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_surface_effects'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_surface_effects'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_surface_effects'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_surface_effects'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_surface_effects'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_surface_effects'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_surface_effects'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_surface_effects'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_surface_effects'
 
 / ! end of pgstar namelist

--- a/astero/work/inlist
+++ b/astero/work/inlist
@@ -6,39 +6,39 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_project'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_project'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_project'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_project'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_project'
 
 / ! end of kap namelist
 
 
 &controls
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_project'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1)= 'inlist_project'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/binary/defaults/binary_job.defaults
+++ b/binary/defaults/binary_job.defaults
@@ -52,11 +52,11 @@ inlist_names(1) = 'inlist1'
 inlist_names(2) = 'inlist2'
 
 
-! read_extra_binary_job_inlist{1..5}
+! read_extra_binary_job_inlist(1..5)
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-! extra_binary_job_inlist{1..5}_name
+! extra_binary_job_inlist_name(1..5)
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ! You can split your ``binary_job`` inlist into pieces using the following controls.
@@ -66,16 +66,8 @@ inlist_names(2) = 'inlist2'
 
 ! ::
 
-read_extra_binary_job_inlist1 = .false.
-extra_binary_job_inlist1_name = 'undefined'
-read_extra_binary_job_inlist2 = .false.
-extra_binary_job_inlist2_name = 'undefined'
-read_extra_binary_job_inlist3 = .false.
-extra_binary_job_inlist3_name = 'undefined'
-read_extra_binary_job_inlist4 = .false.
-extra_binary_job_inlist4_name = 'undefined'
-read_extra_binary_job_inlist5 = .false.
-extra_binary_job_inlist5_name = 'undefined'
+read_extra_binary_job_inlist(:) = .false.
+extra_binary_job_inlist_name(:) = 'undefined'
 
 ! starting model
 ! ==============

--- a/binary/defaults/pgbinary.defaults
+++ b/binary/defaults/pgbinary.defaults
@@ -2967,35 +2967,7 @@ annotation3_text = ''
 
 ! ::
 
-read_extra_pgbinary_inlist1 = .false.
-extra_pgbinary_inlist1_name = 'undefined'
+read_extra_pgbinary_inlist(:) = .false.
+extra_pgbinary_inlist_name(:) = 'undefined'
 
-! if ``read_extra_pgbinary_inlist1`` is true, then read &pgbinary from this namelist file
-
-! ::
-
-read_extra_pgbinary_inlist2 = .false.
-extra_pgbinary_inlist2_name = 'undefined'
-
-! if ``read_extra_pgbinary_inlist2`` is true, then read &pgbinary from this namelist file
-
-! ::
-
-read_extra_pgbinary_inlist3 = .false.
-extra_pgbinary_inlist3_name = 'undefined'
-
-! if ``read_extra_pgbinary_inlist3`` is true, then read &pgbinary from this namelist file
-
-! ::
-
-read_extra_pgbinary_inlist4 = .false.
-extra_pgbinary_inlist4_name = 'undefined'
-
-! if ``read_extra_pgbinary_inlist4`` is true, then read &pgbinary from this namelist file
-
-! ::
-
-read_extra_pgbinary_inlist5 = .false.
-extra_pgbinary_inlist5_name = 'undefined'
-
-! if ``read_extra_pgbinary_inlist5`` is true, then read &pgbinary from this namelist file
+! if ``read_extra_pgbinary_inlist(i)`` is true, then read &pgbinary from this namelist file

--- a/binary/private/binary_ctrls_io.f90
+++ b/binary/private/binary_ctrls_io.f90
@@ -32,20 +32,8 @@
       
       include "binary_controls.inc"      
       
-      logical :: read_extra_binary_controls_inlist1
-      character (len=256) :: extra_binary_controls_inlist1_name 
-   
-      logical :: read_extra_binary_controls_inlist2
-      character (len=256) :: extra_binary_controls_inlist2_name 
-   
-      logical :: read_extra_binary_controls_inlist3
-      character (len=256) :: extra_binary_controls_inlist3_name 
-   
-      logical :: read_extra_binary_controls_inlist4
-      character (len=256) :: extra_binary_controls_inlist4_name 
-   
-      logical :: read_extra_binary_controls_inlist5
-      character (len=256) :: extra_binary_controls_inlist5_name 
+      logical, dimension(max_extra_inlists) :: read_extra_binary_controls_inlist
+      character (len=strlen), dimension(max_extra_inlists) :: extra_binary_controls_inlist_name
       
       namelist /binary_controls/ &
          ! specifications for starting model
@@ -235,11 +223,7 @@
          use_other_CE_binary_finish_step, &
 
          ! extra files
-         read_extra_binary_controls_inlist1, extra_binary_controls_inlist1_name, &
-         read_extra_binary_controls_inlist2, extra_binary_controls_inlist2_name, &
-         read_extra_binary_controls_inlist3, extra_binary_controls_inlist3_name, &
-         read_extra_binary_controls_inlist4, extra_binary_controls_inlist4_name, &
-         read_extra_binary_controls_inlist5, extra_binary_controls_inlist5_name
+         read_extra_binary_controls_inlist, extra_binary_controls_inlist_name
 
       contains
       
@@ -283,11 +267,12 @@
          use utils_lib
          character(*), intent(in) :: filename
          type (binary_info), pointer :: b
-         integer, intent(in) :: level  
+         integer, intent(in) :: level
          integer, intent(out) :: ierr
-         logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-         character (len=256) :: message, extra1, extra2, extra3, extra4, extra5
-         integer :: unit 
+         logical, dimension(max_extra_inlists) :: read_extra
+         character (len=strlen) :: message
+         character (len=strlen), dimension(max_extra_inlists) :: extra
+         integer :: unit, i
          
          ierr = 0        
          
@@ -325,61 +310,17 @@
          call store_binary_controls(b, ierr)
          
          ! recursive calls to read other inlists
-         
-         read_extra1 = read_extra_binary_controls_inlist1
-         read_extra_binary_controls_inlist1 = .false.
-         extra1 = extra_binary_controls_inlist1_name
-         extra_binary_controls_inlist1_name = 'undefined'
-         
-         read_extra2 = read_extra_binary_controls_inlist2
-         read_extra_binary_controls_inlist2 = .false.
-         extra2 = extra_binary_controls_inlist2_name
-         extra_binary_controls_inlist2_name = 'undefined'
-         
-         read_extra3 = read_extra_binary_controls_inlist3
-         read_extra_binary_controls_inlist3 = .false.
-         extra3 = extra_binary_controls_inlist3_name
-         extra_binary_controls_inlist3_name = 'undefined'
-         
-         read_extra4 = read_extra_binary_controls_inlist4
-         read_extra_binary_controls_inlist4 = .false.
-         extra4 = extra_binary_controls_inlist4_name
-         extra_binary_controls_inlist4_name = 'undefined'
-         
-         read_extra5 = read_extra_binary_controls_inlist5
-         read_extra_binary_controls_inlist5 = .false.
-         extra5 = extra_binary_controls_inlist5_name
-         extra_binary_controls_inlist5_name = 'undefined'
-         
-         if (read_extra1) then
-            write(*,*) 'read ' // trim(extra1)
-            call read_binary_controls_file(b, extra1, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra2) then
-            write(*,*) 'read ' // trim(extra2)
-            call read_binary_controls_file(b, extra2, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra3) then
-            write(*,*) 'read ' // trim(extra3)
-            call read_binary_controls_file(b, extra3, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra4) then
-            write(*,*) 'read ' // trim(extra4)
-            call read_binary_controls_file(b, extra4, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-         
-         if (read_extra5) then
-            write(*,*) 'read ' // trim(extra5)
-            call read_binary_controls_file(b, extra5, level+1, ierr)
-            if (ierr /= 0) return
-         end if
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_binary_controls_inlist(i)
+            read_extra_binary_controls_inlist(i) = .false.
+            extra(i) = extra_binary_controls_inlist_name(i)
+            extra_binary_controls_inlist_name(i) = 'undefined'
+            
+            if (read_extra(i)) then
+               call read_binary_controls_file(b, extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
          
       end subroutine read_binary_controls_file
 

--- a/binary/private/binary_job_controls.inc
+++ b/binary/private/binary_job_controls.inc
@@ -6,16 +6,8 @@
       character (len=1000) :: binary_history_columns_file
       logical :: warn_binary_extra
       character (len=256), dimension(2) :: inlist_names
-      logical :: read_extra_binary_job_inlist1
-      character (len=256) :: extra_binary_job_inlist1_name 
-      logical :: read_extra_binary_job_inlist2
-      character (len=256) :: extra_binary_job_inlist2_name 
-      logical :: read_extra_binary_job_inlist3
-      character (len=256) :: extra_binary_job_inlist3_name 
-      logical :: read_extra_binary_job_inlist4
-      character (len=256) :: extra_binary_job_inlist4_name 
-      logical :: read_extra_binary_job_inlist5
-      character (len=256) :: extra_binary_job_inlist5_name 
+      logical, dimension(max_extra_inlists) :: read_extra_binary_job_inlist
+      character (len=strlen), dimension(max_extra_inlists) :: extra_binary_job_inlist_name
 
       logical :: evolve_both_stars
       logical :: relax_primary_to_th_eq

--- a/binary/private/binary_job_ctrls_io.f90
+++ b/binary/private/binary_job_ctrls_io.f90
@@ -38,11 +38,7 @@
          warn_binary_extra, &
          inlist_names, &
       ! extra files (Maybe overkill with so few inlist parameters)
-         read_extra_binary_job_inlist1, extra_binary_job_inlist1_name, &
-         read_extra_binary_job_inlist2, extra_binary_job_inlist2_name, &
-         read_extra_binary_job_inlist3, extra_binary_job_inlist3_name, &
-         read_extra_binary_job_inlist4, extra_binary_job_inlist4_name, &
-         read_extra_binary_job_inlist5, extra_binary_job_inlist5_name, &
+         read_extra_binary_job_inlist, extra_binary_job_inlist_name, &
          evolve_both_stars, &
          relax_primary_to_th_eq, &
          log_Lnuc_div_L_for_relax_primary_to_th_eq, &
@@ -97,9 +93,10 @@
          type (binary_info), pointer :: b
          integer, intent(in) :: level
          integer, intent(out) :: ierr
-         logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-         character (len=strlen) :: message, extra1, extra2, extra3, extra4, extra5
-         integer :: unit
+         logical, dimension(max_extra_inlists) :: read_extra
+         character (len=strlen) :: message
+         character (len=strlen), dimension(max_extra_inlists) :: extra
+         integer :: unit, i
 
          ierr = 0
 
@@ -137,57 +134,18 @@
          call store_binary_job_controls(b, ierr)
 
          ! recursive calls to read other inlists
-
-         read_extra1 = read_extra_binary_job_inlist1
-         read_extra_binary_job_inlist1 = .false.
-         extra1 = extra_binary_job_inlist1_name
-         extra_binary_job_inlist1_name = 'undefined'
-
-         read_extra2 = read_extra_binary_job_inlist2
-         read_extra_binary_job_inlist2 = .false.
-         extra2 = extra_binary_job_inlist2_name
-         extra_binary_job_inlist2_name = 'undefined'
-
-         read_extra3 = read_extra_binary_job_inlist3
-         read_extra_binary_job_inlist3 = .false.
-         extra3 = extra_binary_job_inlist3_name
-         extra_binary_job_inlist3_name = 'undefined'
-
-         read_extra4 = read_extra_binary_job_inlist4
-         read_extra_binary_job_inlist4 = .false.
-         extra4 = extra_binary_job_inlist4_name
-         extra_binary_job_inlist4_name = 'undefined'
-
-         read_extra5 = read_extra_binary_job_inlist5
-         read_extra_binary_job_inlist5 = .false.
-         extra5 = extra_binary_job_inlist5_name
-         extra_binary_job_inlist5_name = 'undefined'
-
-         if (read_extra1) then
-            call read_binary_job_file(b, extra1, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra2) then
-            call read_binary_job_file(b, extra2, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra3) then
-            call read_binary_job_file(b, extra3, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra4) then
-            call read_binary_job_file(b, extra4, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra5) then
-            call read_binary_job_file(b, extra5, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_binary_job_inlist(i)
+            read_extra_binary_job_inlist(i) = .false.
+            extra(i) = extra_binary_job_inlist_name(i)
+            extra_binary_job_inlist_name(i) = 'undefined'
+            
+            if (read_extra(i)) then
+               call read_binary_job_file(b, extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
+         
       end subroutine read_binary_job_file
 
 

--- a/binary/private/pgbinary_ctrls_io.f90
+++ b/binary/private/pgbinary_ctrls_io.f90
@@ -1364,20 +1364,8 @@ module pgbinary_ctrls_io
       annotation3_coord, &
       annotation3_fjust, &
 
-      read_extra_pgbinary_inlist1, &
-      extra_pgbinary_inlist1_name, &
-
-      read_extra_pgbinary_inlist2, &
-      extra_pgbinary_inlist2_name, &
-
-      read_extra_pgbinary_inlist3, &
-      extra_pgbinary_inlist3_name, &
-
-      read_extra_pgbinary_inlist4, &
-      extra_pgbinary_inlist4_name, &
-
-      read_extra_pgbinary_inlist5, &
-      extra_pgbinary_inlist5_name
+      read_extra_pgbinary_inlist, &
+      extra_pgbinary_inlist_name
 
 
 contains
@@ -1404,9 +1392,10 @@ contains
       type (binary_info), pointer :: b
       integer, intent(in) :: level
       integer, intent(out) :: ierr
-      logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-      character (len = strlen) :: message, extra1, extra2, extra3, extra4, extra5
-      integer :: unit
+      logical, dimension(max_extra_inlists) :: read_extra
+      character (len=strlen) :: message
+      character (len=strlen), dimension(max_extra_inlists) :: extra
+      integer :: unit, i
 
       ierr = 0
 
@@ -1440,57 +1429,18 @@ contains
 
       call store_pgbinary_controls(b, ierr)
 
-      ! recursive calls to read other inlists
-
-      read_extra1 = read_extra_pgbinary_inlist1
-      read_extra_pgbinary_inlist1 = .false.
-      extra1 = extra_pgbinary_inlist1_name
-      extra_pgbinary_inlist1_name = 'undefined'
-
-      read_extra2 = read_extra_pgbinary_inlist2
-      read_extra_pgbinary_inlist2 = .false.
-      extra2 = extra_pgbinary_inlist2_name
-      extra_pgbinary_inlist2_name = 'undefined'
-
-      read_extra3 = read_extra_pgbinary_inlist3
-      read_extra_pgbinary_inlist3 = .false.
-      extra3 = extra_pgbinary_inlist3_name
-      extra_pgbinary_inlist3_name = 'undefined'
-
-      read_extra4 = read_extra_pgbinary_inlist4
-      read_extra_pgbinary_inlist4 = .false.
-      extra4 = extra_pgbinary_inlist4_name
-      extra_pgbinary_inlist4_name = 'undefined'
-
-      read_extra5 = read_extra_pgbinary_inlist5
-      read_extra_pgbinary_inlist5 = .false.
-      extra5 = extra_pgbinary_inlist5_name
-      extra_pgbinary_inlist5_name = 'undefined'
-
-      if (read_extra1) then
-         call read_pgbinary_file(b, extra1, level + 1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra2) then
-         call read_pgbinary_file(b, extra2, level + 1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra3) then
-         call read_pgbinary_file(b, extra3, level + 1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra4) then
-         call read_pgbinary_file(b, extra4, level + 1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra5) then
-         call read_pgbinary_file(b, extra5, level + 1, ierr)
-         if (ierr /= 0) return
-      end if
+ ! recursive calls to read other inlists
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_pgbinary_inlist(i)
+            read_extra_pgbinary_inlist(i) = .false.
+            extra(i) = extra_pgbinary_inlist_name(i)
+            extra_pgbinary_inlist_name(i) = 'undefined'
+            
+            if (read_extra(i)) then
+               call read_pgbinary_file(b, extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
 
    end subroutine read_pgbinary_file
 
@@ -2888,20 +2838,8 @@ contains
       pg% annotation3_coord = annotation3_coord
       pg% annotation3_fjust = annotation3_fjust
 
-      pg% read_extra_pgbinary_inlist1 = read_extra_pgbinary_inlist1
-      pg% extra_pgbinary_inlist1_name = extra_pgbinary_inlist1_name
-
-      pg% read_extra_pgbinary_inlist2 = read_extra_pgbinary_inlist2
-      pg% extra_pgbinary_inlist2_name = extra_pgbinary_inlist2_name
-
-      pg% read_extra_pgbinary_inlist3 = read_extra_pgbinary_inlist3
-      pg% extra_pgbinary_inlist3_name = extra_pgbinary_inlist3_name
-
-      pg% read_extra_pgbinary_inlist4 = read_extra_pgbinary_inlist4
-      pg% extra_pgbinary_inlist4_name = extra_pgbinary_inlist4_name
-
-      pg% read_extra_pgbinary_inlist5 = read_extra_pgbinary_inlist5
-      pg% extra_pgbinary_inlist5_name = extra_pgbinary_inlist5_name
+      pg% read_extra_pgbinary_inlist = read_extra_pgbinary_inlist
+      pg% extra_pgbinary_inlist_name = extra_pgbinary_inlist_name
 
    end subroutine store_pgbinary_controls
 

--- a/binary/public/pgbinary_controls.inc
+++ b/binary/public/pgbinary_controls.inc
@@ -952,20 +952,8 @@ character (len = 356) :: annotation3_text
 character :: annotation3_side
 real :: annotation3_disp, annotation3_coord, annotation3_fjust
 
-logical :: read_extra_pgbinary_inlist1
-character (len = strlen) :: extra_pgbinary_inlist1_name
-
-logical :: read_extra_pgbinary_inlist2
-character (len = strlen) :: extra_pgbinary_inlist2_name
-
-logical :: read_extra_pgbinary_inlist3
-character (len = strlen) :: extra_pgbinary_inlist3_name
-
-logical :: read_extra_pgbinary_inlist4
-character (len = strlen) :: extra_pgbinary_inlist4_name
-
-logical :: read_extra_pgbinary_inlist5
-character (len = strlen) :: extra_pgbinary_inlist5_name
+logical, dimension(max_extra_inlists) :: read_extra_pgbinary_inlist
+character (len=strlen), dimension(max_extra_inlists) :: extra_pgbinary_inlist_name
 
 logical :: History_Panels1_use_decorator, &
       History_Panels2_use_decorator, &

--- a/binary/test_suite/double_bh/inlist
+++ b/binary/test_suite/double_bh/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/double_bh/inlist1
+++ b/binary/test_suite/double_bh/inlist1
@@ -138,7 +138,7 @@
 
 
 &pgstar
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1)= 'inlist_pgstar'
       
 / ! end of pgstar namelist

--- a/binary/test_suite/double_bh/inlist2
+++ b/binary/test_suite/double_bh/inlist2
@@ -141,8 +141,8 @@
 
 
 &pgstar
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1)= 'inlist_pgstar'
       
 / ! end of pgstar namelist
 

--- a/binary/test_suite/double_bh/inlist_project
+++ b/binary/test_suite/double_bh/inlist_project
@@ -24,8 +24,8 @@
 
    ! initial conditions specified in extra inlist
    ! the initial masses and period are given there
-   read_extra_binary_controls_inlist1 = .true.
-   extra_binary_controls_inlist1_name = "inlist_extra"
+   read_extra_binary_controls_inlist(1) = .true.
+   extra_binary_controls_inlist_name(1) = "inlist_extra"
 
    terminal_interval = 10
 

--- a/binary/test_suite/evolve_both_stars/inlist
+++ b/binary/test_suite/evolve_both_stars/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_pgbinary'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_pgbinary'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/evolve_both_stars/inlist1
+++ b/binary/test_suite/evolve_both_stars/inlist1
@@ -41,7 +41,7 @@
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/binary/test_suite/evolve_both_stars/inlist2
+++ b/binary/test_suite/evolve_both_stars/inlist2
@@ -40,7 +40,7 @@
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/binary/test_suite/jdot_gr_check/inlist
+++ b/binary/test_suite/jdot_gr_check/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/jdot_ls_check/inlist
+++ b/binary/test_suite/jdot_ls_check/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/jdot_ml_check/inlist
+++ b/binary/test_suite/jdot_ml_check/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/star_plus_point_mass/inlist
+++ b/binary/test_suite/star_plus_point_mass/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/star_plus_point_mass_explicit_mdot/inlist
+++ b/binary/test_suite/star_plus_point_mass_explicit_mdot/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/wind_fed_bhhmxb/inlist
+++ b/binary/test_suite/wind_fed_bhhmxb/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/binary/work/inlist
+++ b/binary/work/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,8 +10,8 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -19,7 +19,7 @@
 
 &pgbinary
 
-      read_extra_pgbinary_inlist1 = .true.
-      extra_pgbinary_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
 / ! end of pgbinary namelist

--- a/const/public/const_def.f90
+++ b/const/public/const_def.f90
@@ -39,6 +39,8 @@
 
 
       integer, parameter :: strlen = 256 ! for character (len=strlen)
+      
+      integer, parameter :: max_extra_inlists = 5  ! number of inlists an inlist can depend on
 
 
 !

--- a/data/star_data/zams_models/create_z2m2_y28/inlist
+++ b/data/star_data/zams_models/create_z2m2_y28/inlist
@@ -1,7 +1,7 @@
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_create_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_create_zams'
 
 / ! end of kap namelist
 
@@ -9,15 +9,15 @@
 
       mesa_dir = '../../../..'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_create_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_create_zams'
 
 / ! end of star_job namelist
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_create_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_create_zams'
 
 / ! end of controls namelist
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -40,7 +40,10 @@ style, you can use the following ``sed`` terminal command: ::
     sed -E '/inlist[1-5]/s/([1-5])([_a-z]*) =/\2\(\1\) =/' -i inlist_name
 
 where ``inlist_name`` is the inlist (or inlists) that you'd like to update.
-``sed`` is a standard tool that is included with most Linux distributions.
+This will *replace* the file ``inlist_name``.  Omit the ``-i`` flag if you'd
+like to see the changes without modifying the file.
+
+``sed`` is a standard tool that is included with macOS and most Linux distributions.
 
 
 Changes in r22.11.1

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,44 @@ Changes in main
 Backwards-incompatible changes
 ------------------------------
 
+Extra inlist controls are now arrays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Almost all MESA inlists have the option of reading other inlists,
+which is a feature canonically used in the main ``inlist`` file.
+e.g. the ``inlist`` in the standard ``star/work`` directory has ::
+
+    read_extra_controls_inlist1 = .true.
+    extra_controls_inlist1_name = 'inlist_project'
+
+where the inlist number could range from 1 to 5.
+
+These and all similar controls have been replaced with arrays like ::
+
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1) = 'inlist_project'
+
+That is, the number should be moved to the end of the control name
+and placed in round brackets.
+
+This allows a lot of duplicate code to be refactored but will break
+almost all existing MESA inlists.  To update an old inlist to this new
+style, you can use the following ``sed`` terminal command: ::
+
+    sed -E '/inlist[1-5]/s/([1-5])([_a-z]*) =/\2\(\1\) =/' -i inlist_name
+
+where ``inlist_name`` is the inlist (or inlists) that you'd like to update.
+``sed`` is a standard tool that is included with most Linux distributions.
+
+
+Changes in r22.11.1
+===================
+
+.. _Backwards-incompatible changes r22.11.1:
+
+Backwards-incompatible changes
+------------------------------
+
 .. note::
 
    A large amount of internal clean up has occurred since the last release.  This lists some of the most important changes, but the list is not exhaustive.

--- a/docs/source/using_mesa/best_practices.rst
+++ b/docs/source/using_mesa/best_practices.rst
@@ -184,12 +184,12 @@ Second, modify ``inlist_semiconvection_header``
 
   change
 
-      !read_extra_pgstar_inlist1 = .true.
-      !extra_pgstar_inlist1_name = 'inlist_semiconvection'
+      !read_extra_pgstar_inlist(1) = .true.
+      !extra_pgstar_inlist_name(1)= 'inlist_semiconvection'
 
   to
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_semiconvection'  
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_semiconvection'
 
    and save the file changes.
 

--- a/docs/source/using_mesa/running.rst
+++ b/docs/source/using_mesa/running.rst
@@ -292,7 +292,7 @@ If you want to try this out, save the preceding text as a file named
 ``inlist_load`` in your work directory. Make sure your file ends with 
 a blank new line. Then edit your main inlist
 file so that it will use ``inlist_load`` instead of ``inlist_project``
-everywhere within inlist (i.e., extra_star_job_inlist1_name and
+everywhere within inlist (i.e., extra_star_job_inlist_name(1) and
 extra_controls_inlist1_name).
 
 Then as usual, do

--- a/eos/defaults/eos.defaults
+++ b/eos/defaults/eos.defaults
@@ -328,61 +328,13 @@
    ! It works recursively, so the extras can read extras too.
 
 
-         ! read_extra_eos_inlist1
+         ! read_extra_eos_inlist(1..5)
          ! ~~~~~~~~~~~~~~~~~~~~~~
-         ! extra_eos_inlist1_name
+         ! extra_eos_inlist_name(1..5)
          ! ~~~~~~~~~~~~~~~~~~~~~~
 
-         ! If ``read_extra_eos_inlist1`` is true, then read &eos from the file ``extra_eos_inlist1_name``.
+         ! If ``read_extra_eos_inlist(i)`` is true, then read &eos from the file ``extra_eos_inlist_name(i)``.
          ! ::
 
-      read_extra_eos_inlist1 = .false.
-      extra_eos_inlist1_name = 'undefined'
-
-
-         ! read_extra_eos_inlist2
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-         ! extra_eos_inlist2_name
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-
-         ! If ``read_extra_eos_inlist2`` is true, then read &eos from the file ``extra_eos_inlist2_name``.
-         ! ::
-
-      read_extra_eos_inlist2 = .false.
-      extra_eos_inlist2_name = 'undefined'
-
-
-         ! read_extra_eos_inlist3
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-         ! extra_eos_inlist3_name
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-
-         ! If ``read_extra_eos_inlist3`` is true, then read &eos from the file ``extra_eos_inlist3_name``.
-         ! ::
-
-      read_extra_eos_inlist3 = .false.
-      extra_eos_inlist3_name = 'undefined'
-
-
-         ! read_extra_eos_inlist4
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-         ! extra_eos_inlist4_name
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-
-         ! If ``read_extra_eos_inlist4`` is true, then read &eos from the file ``extra_eos_inlist4_name``.
-         ! ::
-
-      read_extra_eos_inlist4 = .false.
-      extra_eos_inlist4_name = 'undefined'
-
-
-         ! read_extra_eos_inlist5
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-         ! extra_eos_inlist5_name
-         ! ~~~~~~~~~~~~~~~~~~~~~~
-
-         ! If ``read_extra_eos_inlist5`` is true, then read &eos from the file ``extra_eos_inlist5_name``.
-         ! ::
-
-      read_extra_eos_inlist5 = .false.
-      extra_eos_inlist5_name = 'undefined'
+      read_extra_eos_inlist(:) = .false.
+      extra_eos_inlist_name(:) = 'undefined'

--- a/eos/defaults/eos.defaults
+++ b/eos/defaults/eos.defaults
@@ -329,9 +329,9 @@
 
 
          ! read_extra_eos_inlist(1..5)
-         ! ~~~~~~~~~~~~~~~~~~~~~~
+         ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
          ! extra_eos_inlist_name(1..5)
-         ! ~~~~~~~~~~~~~~~~~~~~~~
+         ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
          ! If ``read_extra_eos_inlist(i)`` is true, then read &eos from the file ``extra_eos_inlist_name(i)``.
          ! ::

--- a/eos/private/eos_ctrls_io.f90
+++ b/eos/private/eos_ctrls_io.f90
@@ -133,20 +133,8 @@
    real(dp) :: X_lo, X_hi
    real(dp) :: Z_lo, Z_hi
 
-   logical :: read_extra_eos_inlist1
-   character (len=128) :: extra_eos_inlist1_name
-
-   logical :: read_extra_eos_inlist2
-   character (len=128) :: extra_eos_inlist2_name
-
-   logical :: read_extra_eos_inlist3
-   character (len=128) :: extra_eos_inlist3_name
-
-   logical :: read_extra_eos_inlist4
-   character (len=128) :: extra_eos_inlist4_name
-
-   logical :: read_extra_eos_inlist5
-   character (len=128) :: extra_eos_inlist5_name
+   logical, dimension(max_extra_inlists) :: read_extra_eos_inlist
+   character (len=strlen), dimension(max_extra_inlists) :: extra_eos_inlist_name
 
 
    namelist /eos/ &
@@ -262,11 +250,7 @@
       X_lo, X_hi, &
       Z_lo, Z_hi, &
       
-      read_extra_eos_inlist1, extra_eos_inlist1_name, &
-      read_extra_eos_inlist2, extra_eos_inlist2_name, &
-      read_extra_eos_inlist3, extra_eos_inlist3_name, &
-      read_extra_eos_inlist4, extra_eos_inlist4_name, &
-      read_extra_eos_inlist5, extra_eos_inlist5_name
+      read_extra_eos_inlist, extra_eos_inlist_name
 
 
    contains
@@ -299,9 +283,10 @@
       type (EoS_General_Info), pointer :: rq
       integer, intent(in) :: level
       integer, intent(out) :: ierr
-      logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-      character (len=128) :: message, extra1, extra2, extra3, extra4, extra5
-      integer :: unit
+      logical, dimension(max_extra_inlists) :: read_extra
+      character (len=strlen) :: message
+      character (len=strlen), dimension(max_extra_inlists) :: extra
+      integer :: unit, i
 
       ierr = 0
       if (level >= 10) then
@@ -350,56 +335,18 @@
       if (len_trim(filename) == 0) return
 
       ! recursive calls to read other inlists
+      do i=1, max_extra_inlists
+         read_extra(i) = read_extra_eos_inlist(i)
+         read_extra_eos_inlist(i) = .false.
+         extra(i) = extra_eos_inlist_name(i)
+         extra_eos_inlist_name(i) = 'undefined'
+   
+         if (read_extra(i)) then
+            call read_controls_file(rq, extra(i), level+1, ierr)
+            if (ierr /= 0) return
+         end if
+      end do
 
-      read_extra1 = read_extra_eos_inlist1
-      read_extra_eos_inlist1 = .false.
-      extra1 = extra_eos_inlist1_name
-      extra_eos_inlist1_name = 'undefined'
-
-      read_extra2 = read_extra_eos_inlist2
-      read_extra_eos_inlist2 = .false.
-      extra2 = extra_eos_inlist2_name
-      extra_eos_inlist2_name = 'undefined'
-
-      read_extra3 = read_extra_eos_inlist3
-      read_extra_eos_inlist3 = .false.
-      extra3 = extra_eos_inlist3_name
-      extra_eos_inlist3_name = 'undefined'
-
-      read_extra4 = read_extra_eos_inlist4
-      read_extra_eos_inlist4 = .false.
-      extra4 = extra_eos_inlist4_name
-      extra_eos_inlist4_name = 'undefined'
-
-      read_extra5 = read_extra_eos_inlist5
-      read_extra_eos_inlist5 = .false.
-      extra5 = extra_eos_inlist5_name
-      extra_eos_inlist5_name = 'undefined'
-
-      if (read_extra1) then
-         call read_controls_file(rq, extra1, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra2) then
-         call read_controls_file(rq, extra2, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra3) then
-         call read_controls_file(rq, extra3, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra4) then
-         call read_controls_file(rq, extra4, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra5) then
-         call read_controls_file(rq, extra5, level+1, ierr)
-         if (ierr /= 0) return
-      end if
 
    end subroutine read_controls_file
 

--- a/kap/defaults/kap.defaults
+++ b/kap/defaults/kap.defaults
@@ -454,9 +454,9 @@
 
 
          ! read_extra_kap_inlist(1..5)
-         ! ~~~~~~~~~~~~~~~~~~~~~~
+         ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
          ! extra_kap_inlist_name(1..5)
-         ! ~~~~~~~~~~~~~~~~~~~~~~
+         ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
          ! If ``read_extra_kap_inlist(i)`` is true, then read &eos from the file ``extra_kap_inlist_name(i)``.
          ! ::

--- a/kap/defaults/kap.defaults
+++ b/kap/defaults/kap.defaults
@@ -446,6 +446,26 @@
 
       use_other_radiative_opacity = .false.
 
+! Extra inlist controls
+! ---------------------
+
+   ! One can split a kap inlist into pieces using the following parameters.
+   ! It works recursively, so the extras can read extras too.
+
+
+         ! read_extra_kap_inlist(1..5)
+         ! ~~~~~~~~~~~~~~~~~~~~~~
+         ! extra_kap_inlist_name(1..5)
+         ! ~~~~~~~~~~~~~~~~~~~~~~
+
+         ! If ``read_extra_kap_inlist(i)`` is true, then read &eos from the file ``extra_kap_inlist_name(i)``.
+         ! ::
+
+      read_extra_kap_inlist(:) = .false.
+      extra_kap_inlist_name(:) = 'undefined'
+      
+      
+      
 
 ! Debugging controls
 ! ------------------

--- a/kap/private/kap_ctrls_io.f90
+++ b/kap/private/kap_ctrls_io.f90
@@ -86,20 +86,8 @@
    real(dp) :: X_lo, X_hi
    real(dp) :: Z_lo, Z_hi
 
-   logical :: read_extra_kap_inlist1
-   character (len=128) :: extra_kap_inlist1_name
-
-   logical :: read_extra_kap_inlist2
-   character (len=128) :: extra_kap_inlist2_name
-
-   logical :: read_extra_kap_inlist3
-   character (len=128) :: extra_kap_inlist3_name
-
-   logical :: read_extra_kap_inlist4
-   character (len=128) :: extra_kap_inlist4_name
-
-   logical :: read_extra_kap_inlist5
-   character (len=128) :: extra_kap_inlist5_name
+   logical, dimension(max_extra_inlists) :: read_extra_kap_inlist
+   character (len=strlen), dimension(max_extra_inlists) :: extra_kap_inlist_name
 
 
    namelist /kap/ &
@@ -134,12 +122,7 @@
       use_other_compton_opacity, &
       use_other_radiative_opacity, &
 
-      read_extra_kap_inlist1, extra_kap_inlist1_name, &
-      read_extra_kap_inlist2, extra_kap_inlist2_name, &
-      read_extra_kap_inlist3, extra_kap_inlist3_name, &
-      read_extra_kap_inlist4, extra_kap_inlist4_name, &
-      read_extra_kap_inlist5, extra_kap_inlist5_name
-
+      read_extra_kap_inlist, extra_kap_inlist_name
 
    contains
 
@@ -166,9 +149,10 @@
       type (Kap_General_Info), pointer :: rq
       integer, intent(in) :: level
       integer, intent(out) :: ierr
-      logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-      character (len=128) :: message, extra1, extra2, extra3, extra4, extra5
-      integer :: unit
+      logical, dimension(max_extra_inlists) :: read_extra
+      character (len=strlen) :: message
+      character (len=strlen), dimension(max_extra_inlists) :: extra
+      integer :: unit, i
 
       ierr = 0
       if (level >= 10) then
@@ -217,56 +201,17 @@
       if (len_trim(filename) == 0) return
 
       ! recursive calls to read other inlists
-
-      read_extra1 = read_extra_kap_inlist1
-      read_extra_kap_inlist1 = .false.
-      extra1 = extra_kap_inlist1_name
-      extra_kap_inlist1_name = 'undefined'
-
-      read_extra2 = read_extra_kap_inlist2
-      read_extra_kap_inlist2 = .false.
-      extra2 = extra_kap_inlist2_name
-      extra_kap_inlist2_name = 'undefined'
-
-      read_extra3 = read_extra_kap_inlist3
-      read_extra_kap_inlist3 = .false.
-      extra3 = extra_kap_inlist3_name
-      extra_kap_inlist3_name = 'undefined'
-
-      read_extra4 = read_extra_kap_inlist4
-      read_extra_kap_inlist4 = .false.
-      extra4 = extra_kap_inlist4_name
-      extra_kap_inlist4_name = 'undefined'
-
-      read_extra5 = read_extra_kap_inlist5
-      read_extra_kap_inlist5 = .false.
-      extra5 = extra_kap_inlist5_name
-      extra_kap_inlist5_name = 'undefined'
-
-      if (read_extra1) then
-         call read_controls_file(rq, extra1, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra2) then
-         call read_controls_file(rq, extra2, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra3) then
-         call read_controls_file(rq, extra3, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra4) then
-         call read_controls_file(rq, extra4, level+1, ierr)
-         if (ierr /= 0) return
-      end if
-
-      if (read_extra5) then
-         call read_controls_file(rq, extra5, level+1, ierr)
-         if (ierr /= 0) return
-      end if
+      do i=1, max_extra_inlists
+         read_extra(i) = read_extra_kap_inlist(i)
+         read_extra_kap_inlist(i) = .false.
+         extra(i) = extra_kap_inlist_name(i)
+         extra_kap_inlist_name(i) = 'undefined'
+   
+         if (read_extra(i)) then
+            call read_controls_file(rq, extra(i), level+1, ierr)
+            if (ierr /= 0) return
+         end if
+      end do
 
    end subroutine read_controls_file
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -11732,9 +11732,9 @@
 
 
       ! read_extra_controls_inlist(1..5)
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ! extra_controls_inlist_name(1..5)
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
       ! If ``read_extra_controls_inlist(1)`` is true, then read &controls from this namelist file.
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -11731,71 +11731,17 @@
       ! BTW: it works recursively, so the extras can read extras too.
 
 
-      ! read_extra_controls_inlist1
+      ! read_extra_controls_inlist(1..5)
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! extra_controls_inlist1_name
+      ! extra_controls_inlist_name(1..5)
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! If ``read_extra_controls_inlist1`` is true, then read &controls from this namelist file.
+      ! If ``read_extra_controls_inlist(1)`` is true, then read &controls from this namelist file.
 
       ! ::
 
-    read_extra_controls_inlist1 = .false.
-    extra_controls_inlist1_name = 'undefined'
-
-
-      ! read_extra_controls_inlist2
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! extra_controls_inlist2_name
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! If ``read_extra_controls_inlist2`` is true, then read &controls from this namelist file.
-
-      ! ::
-
-    read_extra_controls_inlist2 = .false.
-    extra_controls_inlist2_name = 'undefined'
-
-      ! read_extra_controls_inlist3
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! extra_controls_inlist3_name
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! If ``read_extra_controls_inlist3`` is true, then read &controls from this namelist file.
-
-      ! ::
-
-    read_extra_controls_inlist3 = .false.
-    extra_controls_inlist3_name = 'undefined'
-
-
-      ! read_extra_controls_inlist4
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! extra_controls_inlist4_name
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! If ``read_extra_controls_inlist4`` is true, then read &controls from this namelist file.
-
-      ! ::
-
-    read_extra_controls_inlist4 = .false.
-    extra_controls_inlist4_name = 'undefined'
-
-
-      ! read_extra_controls_inlist5
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! extra_controls_inlist5_name
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! If ``read_extra_controls_inlist5`` is true, then read &controls from this namelist file.
-
-      ! ::
-
-    read_extra_controls_inlist5 = .false.
-    extra_controls_inlist5_name = 'undefined'
-
-
-
+    read_extra_controls_inlist(:) = .false.
+    extra_controls_inlist_name(:) = 'undefined'
 
       ! save_controls_namelist
       ! ~~~~~~~~~~~~~~~~~~~~~~

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -7770,35 +7770,7 @@
 
       ! ::
 
-    read_extra_pgstar_inlist1 = .false.
-    extra_pgstar_inlist1_name = 'undefined'
+    read_extra_pgstar_inlist(:) = .false.
+    extra_pgstar_inlist_name(:) = 'undefined'
 
-      ! if ``read_extra_pgstar_inlist1`` is true, then read &pgstar from this namelist file
-
-      ! ::
-
-    read_extra_pgstar_inlist2 = .false.
-    extra_pgstar_inlist2_name = 'undefined'
-
-      ! if ``read_extra_pgstar_inlist2`` is true, then read &pgstar from this namelist file
-
-      ! ::
-
-    read_extra_pgstar_inlist3 = .false.
-    extra_pgstar_inlist3_name = 'undefined'
-
-      ! if ``read_extra_pgstar_inlist3`` is true, then read &pgstar from this namelist file
-
-      ! ::
-
-    read_extra_pgstar_inlist4 = .false.
-    extra_pgstar_inlist4_name = 'undefined'
-
-      ! if ``read_extra_pgstar_inlist4`` is true, then read &pgstar from this namelist file
-
-      ! ::
-
-    read_extra_pgstar_inlist5 = .false.
-    extra_pgstar_inlist5_name = 'undefined'
-
-      ! if ``read_extra_pgstar_inlist5`` is true, then read &pgstar from this namelist file
+      ! if ``read_extra_pgstar_inlist(i)`` is true, then read &pgstar from this namelist file

--- a/star/defaults/star_job.defaults
+++ b/star/defaults/star_job.defaults
@@ -2970,26 +2970,18 @@
       ! BTW: it works recursively, so the extras can read extras too.
 
 
-      ! read_extra_star_job_inlist{1..5}
+      ! read_extra_star_job_inlist(1..5)
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! extra_star_job_inlist{1..5}_name
+      ! extra_star_job_inlist_name(1..5)
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! if ``read_extra_star_job_inlist{1..5}`` is true,
+      ! if ``read_extra_star_job_inlist(i)`` is true,
       ! then read &star_job from this namelist file
 
       ! ::
 
-    read_extra_star_job_inlist1 = .false.
-    extra_star_job_inlist1_name = 'undefined'
-    read_extra_star_job_inlist2 = .false.
-    extra_star_job_inlist2_name = 'undefined'
-    read_extra_star_job_inlist3 = .false.
-    extra_star_job_inlist3_name = 'undefined'
-    read_extra_star_job_inlist4 = .false.
-    extra_star_job_inlist4_name = 'undefined'
-    read_extra_star_job_inlist5 = .false.
-    extra_star_job_inlist5_name = 'undefined'
+    read_extra_star_job_inlist(:) = .false.
+    extra_star_job_inlist_name(:) = 'undefined'
 
 
       ! save_star_job_namelist

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_rsp2_header
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_rsp2_header
@@ -1,31 +1,31 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_rsp2_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_rsp2_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_rsp2_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_rsp2_Cepheid'
 / ! end of controls namelist
 
 &pgstar

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_tdc_header
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_tdc_header
@@ -1,36 +1,36 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_tdc_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_tdc_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_tdc_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_tdc_Cepheid'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_tdc_Cepheid'
 / ! end of pgstar namelist

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp2_header
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp2_header
@@ -1,36 +1,36 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_rsp2_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_rsp2_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_rsp2_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_rsp2_Cepheid'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_rsp2_Cepheid'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_rsp2_Cepheid'
 / ! end of pgstar namelist

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp_header
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp_header
@@ -1,31 +1,31 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_rsp_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_rsp_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_rsp_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_rsp_Cepheid'
 / ! end of controls namelist
 
 &pgstar

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_rsp_header
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_rsp_header
@@ -1,31 +1,31 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_rsp_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_rsp_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_rsp_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_rsp_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_rsp_Cepheid'
 / ! end of controls namelist
 
 &pgstar

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_tdc_header
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_tdc_header
@@ -1,36 +1,36 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_tdc_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_tdc_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_tdc_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_tdc_Cepheid'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_tdc_Cepheid'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_tdc_Cepheid'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BLAP/inlist_common
+++ b/star/dev_cases_star_to_RSP2/dev_BLAP/inlist_common
@@ -85,8 +85,8 @@
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BLAP/inlist_rsp2_header
+++ b/star/dev_cases_star_to_RSP2/dev_BLAP/inlist_rsp2_header
@@ -1,46 +1,46 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_BLAP'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_rsp2'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_BLAP'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_rsp2'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_BLAP'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_rsp2'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_BLAP'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_rsp2'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_BLAP'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_rsp2'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_BLAP'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_rsp2'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_BLAP'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_rsp2'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_BLAP'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_rsp2'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_common'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_BLAP'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_common'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_BLAP'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_common_post_zams
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_common_post_zams
@@ -1,21 +1,21 @@
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
 / !end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
 
 ! mlt
 

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_convert_header
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_convert_header
@@ -1,42 +1,42 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_convert'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_convert'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_convert'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_convert'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_convert'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_convert'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_convert'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_convert'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_convert'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_convert'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_initialize_header
@@ -1,42 +1,42 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_pulse_header
@@ -1,42 +1,42 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_near_pulses_header
@@ -1,38 +1,38 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_pulse_header
@@ -1,38 +1,38 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_zams_header
@@ -1,38 +1,38 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_common_post_zams
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_common_post_zams
@@ -1,21 +1,21 @@
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
 / !end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
 
 ! mlt
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_convert_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_convert_header
@@ -1,42 +1,42 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_convert'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_convert'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_convert'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_convert'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_convert'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_convert'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_convert'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_convert'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_convert'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_convert'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_initialize_header
@@ -1,42 +1,42 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_pulse_header
@@ -1,42 +1,42 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_near_pulses_header
@@ -1,38 +1,38 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_pulse_header
@@ -1,38 +1,38 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_zams_header
@@ -1,38 +1,38 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_nearer_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_nearer_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_nearer_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_nearer_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_nearer_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_nearer_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_nearer_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_nearer_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_nearer_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_initialize_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_initialize_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_initialize_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_initialize_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_remesh_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remesh_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remesh_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remesh_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_remove_core_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_remove_core_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_remove_core_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_remove_core_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_near_pulses_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_near_pulses_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_near_pulses_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_pulse_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_pulse_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_pulse_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_zams_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_to_zams_header'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_to_zams_header'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_to_zams_header'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_common_post_zams
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_common_post_zams
@@ -1,21 +1,21 @@
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
 / !end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
 
 ! atm
    atm_option = 'T_tau'

--- a/star/dev_cases_star_to_RSP2/shared/inlist_initialize_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_initialize_header
@@ -1,43 +1,43 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_initialize'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_initialize'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_initialize'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_initialize'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_initialize'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_initialize'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_common_rsp2'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = '../shared/inlist_initialize'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_common_rsp2'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= '../shared/inlist_initialize'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = '../shared/inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_initialize'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= '../shared/inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_initialize'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_pgstar
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_pgstar
@@ -1,4 +1,4 @@
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../../rsp2_utils/inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../../rsp2_utils/inlist_pgstar'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_pgstar_pulses
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_pgstar_pulses
@@ -1,4 +1,4 @@
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../../rsp2_utils/inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../../rsp2_utils/inlist_pgstar_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_pulse_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_pulse_header
@@ -1,43 +1,43 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_common_rsp2'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = '../shared/inlist_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_common_rsp2'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= '../shared/inlist_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = '../shared/inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= '../shared/inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_remesh_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_remesh_header
@@ -1,43 +1,43 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_remesh'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_remesh'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_remesh'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_remesh'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_remesh'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_remesh'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_common_rsp2'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = '../shared/inlist_remesh'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_common_rsp2'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= '../shared/inlist_remesh'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = '../shared/inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_remesh'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= '../shared/inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_remesh'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_remove_core_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_remove_core_header
@@ -1,41 +1,41 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_remove_core'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_remove_core'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_remove_core'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_remove_core'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_remove_core'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_remove_core'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_remove_core'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_remove_core'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = '../shared/inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = '../shared/inlist_pgstar_pulses'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_remove_core'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= '../shared/inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= '../shared/inlist_pgstar_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_remove_core'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_to_near_pulses_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_to_near_pulses_header
@@ -1,37 +1,37 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_to_near_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_to_nearer_pulses_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_to_nearer_pulses_header
@@ -1,37 +1,37 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_to_nearer_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_to_nearer_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_to_nearer_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_to_nearer_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_to_nearer_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_to_nearer_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_to_nearer_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_to_nearer_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_to_nearer_pulses'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_to_nearer_pulses'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_to_pulse_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_to_pulse_header
@@ -1,37 +1,37 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = '../shared/inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = '../shared/inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= '../shared/inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = '../shared/inlist_to_pulse'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= '../shared/inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/dev_cases_star_to_RSP2/shared/inlist_to_zams_header
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_to_zams_header
@@ -1,37 +1,37 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = '../shared/inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = '../shared/inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = '../shared/inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = '../shared/inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = '../shared/inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = '../shared/inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = '../shared/inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= '../shared/inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = '../shared/inlist_to_zams'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= '../shared/inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_BEP/inlist_rsp2_BEP_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_BEP/inlist_rsp2_BEP_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_BEP'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_BEP'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_BEP'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_BEP'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_BEP'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_BEP'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_BEP'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_BEP'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_BEP'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_BEP'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_BLAP/inlist_rsp2_BLAP_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_BLAP/inlist_rsp2_BLAP_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_BLAP'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_BLAP'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_BLAP'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_BLAP'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_BLAP'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_BLAP'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_BLAP'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_BLAP'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_BLAP'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_BLAP'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_Cepheid/inlist_rsp2_Cepheid_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Cepheid/inlist_rsp2_Cepheid_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_Cepheid'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_Cepheid'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_Cepheid'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_Cepheid_6M/inlist_rsp2_Cepheid_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Cepheid_6M/inlist_rsp2_Cepheid_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_Cepheid'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_Cepheid'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_Cepheid'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_Delta_Scuti/inlist_rsp2_Delta_Scuti_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Delta_Scuti/inlist_rsp2_Delta_Scuti_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_Delta_Scuti'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_Delta_Scuti'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_Delta_Scuti'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_Delta_Scuti'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_Delta_Scuti'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_Delta_Scuti'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_Delta_Scuti'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_Delta_Scuti'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_Delta_Scuti'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_Delta_Scuti'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_RR_Lyrae/inlist_rsp2_RR_Lyrae_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_RR_Lyrae/inlist_rsp2_RR_Lyrae_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_RR_Lyrae'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_RR_Lyrae'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_RR_Lyrae'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_RR_Lyrae'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_RR_Lyrae'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_RR_Lyrae'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_RR_Lyrae'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_RR_Lyrae'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_RR_Lyrae'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_RR_Lyrae'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_RSP2/dev_rsp2_Type_II_Cepheid/inlist_rsp2_Type_II_Cepheid_header
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Type_II_Cepheid/inlist_rsp2_Type_II_Cepheid_header
@@ -1,30 +1,30 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_rsp2_Type_II_Cepheid'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_rsp2_Type_II_Cepheid'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_rsp2_Type_II_Cepheid'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_rsp2_Type_II_Cepheid'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_rsp2_Type_II_Cepheid'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_rsp2_Type_II_Cepheid'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_rsp2_Type_II_Cepheid'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_rsp2_Type_II_Cepheid'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pulse_pgstar_default'
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_rsp2_Type_II_Cepheid'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pulse_pgstar_default'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_rsp2_Type_II_Cepheid'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_TDC/dev_TDC_he_core_flash/inlist_to_end_core_he_burn_for_TDC_header
+++ b/star/dev_cases_test_TDC/dev_TDC_he_core_flash/inlist_to_end_core_he_burn_for_TDC_header
@@ -1,28 +1,28 @@
 
 &star_job
    mesa_dir = '../../..'
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_to_end_core_he_burn_for_TDC'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_to_end_core_he_burn_for_TDC'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_to_end_core_he_burn_for_TDC'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_to_end_core_he_burn_for_TDC'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_to_end_core_he_burn_for_TDC'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_to_end_core_he_burn_for_TDC'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_to_end_core_he_burn_for_TDC'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_to_end_core_he_burn_for_TDC'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn_for_TDC'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn_for_TDC'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_to_cc_header
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_to_cc_header
@@ -1,43 +1,43 @@
 
 &star_job
       mesa_dir = '../../..'
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_cc'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_cc'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_cc'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_cc'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_cc'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_cc'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_cc'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_cc'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_cc'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_cc'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_to_cc_header
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_to_cc_header
@@ -1,43 +1,43 @@
 
 &star_job
       mesa_dir = '../../..'
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_cc'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_cc'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_cc'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_cc'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_cc'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_cc'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_cc'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_cc'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_cc'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_cc'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_finish_header
+++ b/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_finish_header
@@ -1,53 +1,53 @@
 
 &star_job
       mesa_dir = '../../..'
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_common_converted'
-      read_extra_star_job_inlist4 = .true.
-      extra_star_job_inlist4_name = 'inlist_finish'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_common_converted'
+      read_extra_star_job_inlist(4) = .true.
+      extra_star_job_inlist_name(4) = 'inlist_finish'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_common_converted'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_finish'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_common_converted'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_finish'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_common_converted'
-      read_extra_kap_inlist4 = .true.
-      extra_kap_inlist4_name = 'inlist_finish'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_common_converted'
+      read_extra_kap_inlist(4) = .true.
+      extra_kap_inlist_name(4) = 'inlist_finish'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_common_converted'
-      read_extra_controls_inlist4 = .true.
-      extra_controls_inlist4_name = 'inlist_finish'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_common_converted'
+      read_extra_controls_inlist(4) = .true.
+      extra_controls_inlist_name(4)= 'inlist_finish'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_common_converted'
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_finish'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_common_converted'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_finish'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_part1_header
+++ b/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_part1_header
@@ -1,53 +1,53 @@
 
 &star_job
       mesa_dir = '../../..'
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_common_converted'
-      read_extra_star_job_inlist4 = .true.
-      extra_star_job_inlist4_name = 'inlist_part1'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_common_converted'
+      read_extra_star_job_inlist(4) = .true.
+      extra_star_job_inlist_name(4) = 'inlist_part1'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_common_converted'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_part1'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_common_converted'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_part1'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_common_converted'
-      read_extra_kap_inlist4 = .true.
-      extra_kap_inlist4_name = 'inlist_part1'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_common_converted'
+      read_extra_kap_inlist(4) = .true.
+      extra_kap_inlist_name(4) = 'inlist_part1'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_common_converted'
-      read_extra_controls_inlist4 = .true.
-      extra_controls_inlist4_name = 'inlist_part1'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_common_converted'
+      read_extra_controls_inlist(4) = .true.
+      extra_controls_inlist_name(4)= 'inlist_part1'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_common_converted'
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_part1'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_common_converted'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_part1'
 / ! end of pgstar namelist

--- a/star/dev_cases_test_TDC/dev_TDC_wd_nova_burst/inlist_wd_nova_burst_header
+++ b/star/dev_cases_test_TDC/dev_TDC_wd_nova_burst/inlist_wd_nova_burst_header
@@ -3,24 +3,24 @@
 
       mesa_dir = '../../..'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_nova_burst'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_nova_burst'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_nova_burst'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_nova_burst'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_nova_burst'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_nova_burst'
 
 / ! end of kap namelist
 
@@ -28,8 +28,8 @@
 
 &controls
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_wd_nova_burst'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_wd_nova_burst'
 
 / ! end of controls namelist
 
@@ -37,10 +37,10 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_wd_nova_burst'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_wd_nova_burst'
 
 / ! end of pgstar namelist

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -33,21 +33,8 @@
  include 'star_controls.inc'
  include 'star_controls_dev.inc'
 
- logical :: read_extra_controls_inlist1
- character (len=strlen) :: extra_controls_inlist1_name
-
- logical :: read_extra_controls_inlist2
- character (len=strlen) :: extra_controls_inlist2_name
-
- logical :: read_extra_controls_inlist3
- character (len=strlen) :: extra_controls_inlist3_name
-
- logical :: read_extra_controls_inlist4
- character (len=strlen) :: extra_controls_inlist4_name
-
- logical :: read_extra_controls_inlist5
- character (len=strlen) :: extra_controls_inlist5_name
-
+ logical, dimension(max_extra_inlists) :: read_extra_controls_inlist
+ character (len=strlen), dimension(max_extra_inlists) :: extra_controls_inlist_name
  logical :: save_controls_namelist
  character (len=strlen) :: controls_namelist_name
 
@@ -541,9 +528,7 @@
     x_ctrl, x_integer_ctrl, x_logical_ctrl, x_character_ctrl, &
     
     ! extra files
-    read_extra_controls_inlist1, extra_controls_inlist1_name, read_extra_controls_inlist2, &
-    extra_controls_inlist2_name, read_extra_controls_inlist3, extra_controls_inlist3_name, &
-    read_extra_controls_inlist4, extra_controls_inlist4_name, read_extra_controls_inlist5, extra_controls_inlist5_name, &
+    read_extra_controls_inlist, extra_controls_inlist_name, &
     save_controls_namelist, controls_namelist_name
 
 
@@ -652,9 +637,10 @@
  type (star_info), pointer :: s
  integer, intent(in) :: level
  integer, intent(out) :: ierr
- logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
- character (len=strlen) :: message, extra1, extra2, extra3, extra4, extra5
- integer :: unit
+ logical, dimension(max_extra_inlists) :: read_extra
+ character (len=strlen) :: message
+ character (len=strlen), dimension(max_extra_inlists) :: extra
+ integer :: unit, i
 
  ierr = 0
 
@@ -690,61 +676,19 @@
  call store_controls(s, ierr)
 
  ! recursive calls to read other inlists
+ do i=1, max_extra_inlists
+    read_extra(i) = read_extra_controls_inlist(i)
+    read_extra_controls_inlist(i) = .false.
+    extra(i) = extra_controls_inlist_name(i)
+    extra_controls_inlist_name(i) = 'undefined'
+   
+    if (read_extra(i)) then
+       write(*,*) 'read ' // trim(extra(i))
+       call read_controls_file(s, extra(i), level+1, ierr)
+       if (ierr /= 0) return
+    end if
+ end do
 
- read_extra1 = read_extra_controls_inlist1
- read_extra_controls_inlist1 = .false.
- extra1 = extra_controls_inlist1_name
- extra_controls_inlist1_name = 'undefined'
-
- read_extra2 = read_extra_controls_inlist2
- read_extra_controls_inlist2 = .false.
- extra2 = extra_controls_inlist2_name
- extra_controls_inlist2_name = 'undefined'
-
- read_extra3 = read_extra_controls_inlist3
- read_extra_controls_inlist3 = .false.
- extra3 = extra_controls_inlist3_name
- extra_controls_inlist3_name = 'undefined'
-
- read_extra4 = read_extra_controls_inlist4
- read_extra_controls_inlist4 = .false.
- extra4 = extra_controls_inlist4_name
- extra_controls_inlist4_name = 'undefined'
-
- read_extra5 = read_extra_controls_inlist5
- read_extra_controls_inlist5 = .false.
- extra5 = extra_controls_inlist5_name
- extra_controls_inlist5_name = 'undefined'
-
- if (read_extra1) then
- write(*,*) 'read ' // trim(extra1)
- call read_controls_file(s, extra1, level+1, ierr)
- if (ierr /= 0) return
- end if
-
- if (read_extra2) then
- write(*,*) 'read ' // trim(extra2)
- call read_controls_file(s, extra2, level+1, ierr)
- if (ierr /= 0) return
- end if
-
- if (read_extra3) then
- write(*,*) 'read ' // trim(extra3)
- call read_controls_file(s, extra3, level+1, ierr)
- if (ierr /= 0) return
- end if
-
- if (read_extra4) then
-    write(*,*) 'read ' // trim(extra4)
-    call read_controls_file(s, extra4, level+1, ierr)
-    if (ierr /= 0) return
- end if
-
- if (read_extra5) then
-    write(*,*) 'read ' // trim(extra5)
-    call read_controls_file(s, extra5, level+1, ierr)
-    if (ierr /= 0) return
- end if
 
  end subroutine read_controls_file
  
@@ -4201,7 +4145,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
       call set_controls_for_writing(s, ierr)
       if(ierr/=0) return
 
-      ! Write namelist to temporay file
+      ! Write namelist to temporary file
       open(newunit=iounit,status='scratch')
       write(iounit,nml=controls)
       rewind(iounit)

--- a/star/private/pgstar_ctrls_io.f90
+++ b/star/private/pgstar_ctrls_io.f90
@@ -3061,20 +3061,8 @@
             annotation3_coord, &
             annotation3_fjust, &
 
-            read_extra_pgstar_inlist1, &
-            extra_pgstar_inlist1_name, &
-
-            read_extra_pgstar_inlist2, &
-            extra_pgstar_inlist2_name, &
-
-            read_extra_pgstar_inlist3, &
-            extra_pgstar_inlist3_name, &
-
-            read_extra_pgstar_inlist4, &
-            extra_pgstar_inlist4_name, &
-
-            read_extra_pgstar_inlist5, &
-            extra_pgstar_inlist5_name
+            read_extra_pgstar_inlist, &
+            extra_pgstar_inlist_name
 
 
 
@@ -3103,9 +3091,10 @@
          type (star_info), pointer :: s
          integer, intent(in) :: level
          integer, intent(out) :: ierr
-         logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-         character (len=strlen) :: message, extra1, extra2, extra3, extra4, extra5
-         integer :: unit
+         logical, dimension(max_extra_inlists) :: read_extra
+         character (len=strlen) :: message
+         character (len=strlen), dimension(max_extra_inlists) :: extra
+         integer :: unit, i
 
          ierr = 0
 
@@ -3143,56 +3132,17 @@
          call store_pgstar_controls(s, ierr)
 
          ! recursive calls to read other inlists
-
-         read_extra1 = read_extra_pgstar_inlist1
-         read_extra_pgstar_inlist1 = .false.
-         extra1 = extra_pgstar_inlist1_name
-         extra_pgstar_inlist1_name = 'undefined'
-
-         read_extra2 = read_extra_pgstar_inlist2
-         read_extra_pgstar_inlist2 = .false.
-         extra2 = extra_pgstar_inlist2_name
-         extra_pgstar_inlist2_name = 'undefined'
-
-         read_extra3 = read_extra_pgstar_inlist3
-         read_extra_pgstar_inlist3 = .false.
-         extra3 = extra_pgstar_inlist3_name
-         extra_pgstar_inlist3_name = 'undefined'
-
-         read_extra4 = read_extra_pgstar_inlist4
-         read_extra_pgstar_inlist4 = .false.
-         extra4 = extra_pgstar_inlist4_name
-         extra_pgstar_inlist4_name = 'undefined'
-
-         read_extra5 = read_extra_pgstar_inlist5
-         read_extra_pgstar_inlist5 = .false.
-         extra5 = extra_pgstar_inlist5_name
-         extra_pgstar_inlist5_name = 'undefined'
-
-         if (read_extra1) then
-            call read_pgstar_file(s, extra1, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra2) then
-            call read_pgstar_file(s, extra2, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra3) then
-            call read_pgstar_file(s, extra3, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra4) then
-            call read_pgstar_file(s, extra4, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra5) then
-            call read_pgstar_file(s, extra5, level+1, ierr)
-            if (ierr /= 0) return
-         end if
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_pgstar_inlist(i)
+            read_extra_pgstar_inlist(i) = .false.
+            extra(i) = extra_pgstar_inlist_name(i)
+            extra_pgstar_inlist_name(i) = 'undefined'
+   
+            if (read_extra(i)) then
+               call read_pgstar_file(s, extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
 
       end subroutine read_pgstar_file
 
@@ -6297,21 +6247,8 @@
          s% pg% annotation3_coord = annotation3_coord
          s% pg% annotation3_fjust = annotation3_fjust
 
-         s% pg% read_extra_pgstar_inlist1 = read_extra_pgstar_inlist1
-         s% pg% extra_pgstar_inlist1_name = extra_pgstar_inlist1_name
-
-         s% pg% read_extra_pgstar_inlist2 = read_extra_pgstar_inlist2
-         s% pg% extra_pgstar_inlist2_name = extra_pgstar_inlist2_name
-
-         s% pg% read_extra_pgstar_inlist3 = read_extra_pgstar_inlist3
-         s% pg% extra_pgstar_inlist3_name = extra_pgstar_inlist3_name
-
-         s% pg% read_extra_pgstar_inlist4 = read_extra_pgstar_inlist4
-         s% pg% extra_pgstar_inlist4_name = extra_pgstar_inlist4_name
-
-         s% pg% read_extra_pgstar_inlist5 = read_extra_pgstar_inlist5
-         s% pg% extra_pgstar_inlist5_name = extra_pgstar_inlist5_name
-
+         s% pg% read_extra_pgstar_inlist = read_extra_pgstar_inlist
+         s% pg% extra_pgstar_inlist_name = extra_pgstar_inlist_name
 
       end subroutine store_pgstar_controls
 

--- a/star/private/star_job_ctrls_io.f90
+++ b/star/private/star_job_ctrls_io.f90
@@ -495,16 +495,8 @@
          jina_reaclib_min_T9, &
          rate_tables_dir, &
          rate_cache_suffix, &
-         read_extra_star_job_inlist1, &
-         extra_star_job_inlist1_name, &
-         read_extra_star_job_inlist2, &
-         extra_star_job_inlist2_name, &
-         read_extra_star_job_inlist3, &
-         extra_star_job_inlist3_name, &
-         read_extra_star_job_inlist4, &
-         extra_star_job_inlist4_name, &
-         read_extra_star_job_inlist5, &
-         extra_star_job_inlist5_name, &
+         read_extra_star_job_inlist, &
+         extra_star_job_inlist_name, &
          set_abundance_nzlo, &
          set_abundance_nzhi, &
          set_abundance, &
@@ -569,9 +561,10 @@
          type (star_info), pointer :: s
          integer, intent(in) :: level
          integer, intent(out) :: ierr
-         logical :: read_extra1, read_extra2, read_extra3, read_extra4, read_extra5
-         character (len=strlen) :: message, extra1, extra2, extra3, extra4, extra5
-         integer :: unit
+         logical, dimension(max_extra_inlists) :: read_extra
+         character (len=strlen) :: message
+         character (len=strlen), dimension(max_extra_inlists) :: extra
+         integer :: unit, i
 
          ierr = 0
 
@@ -609,56 +602,18 @@
          call store_star_job_controls(s, ierr)
 
          ! recursive calls to read other inlists
+         do i=1, max_extra_inlists
+            read_extra(i) = read_extra_star_job_inlist(i)
+            read_extra_star_job_inlist(i) = .false.
+            extra(i) = extra_star_job_inlist_name(i)
+            extra_star_job_inlist_name(i) = 'undefined'
+            
+            if (read_extra(i)) then
+               call read_star_job_file(s, extra(i), level+1, ierr)
+               if (ierr /= 0) return
+            end if
+         end do
 
-         read_extra1 = read_extra_star_job_inlist1
-         read_extra_star_job_inlist1 = .false.
-         extra1 = extra_star_job_inlist1_name
-         extra_star_job_inlist1_name = 'undefined'
-
-         read_extra2 = read_extra_star_job_inlist2
-         read_extra_star_job_inlist2 = .false.
-         extra2 = extra_star_job_inlist2_name
-         extra_star_job_inlist2_name = 'undefined'
-
-         read_extra3 = read_extra_star_job_inlist3
-         read_extra_star_job_inlist3 = .false.
-         extra3 = extra_star_job_inlist3_name
-         extra_star_job_inlist3_name = 'undefined'
-
-         read_extra4 = read_extra_star_job_inlist4
-         read_extra_star_job_inlist4 = .false.
-         extra4 = extra_star_job_inlist4_name
-         extra_star_job_inlist4_name = 'undefined'
-
-         read_extra5 = read_extra_star_job_inlist5
-         read_extra_star_job_inlist5 = .false.
-         extra5 = extra_star_job_inlist5_name
-         extra_star_job_inlist5_name = 'undefined'
-
-         if (read_extra1) then
-            call read_star_job_file(s, extra1, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra2) then
-            call read_star_job_file(s, extra2, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra3) then
-            call read_star_job_file(s, extra3, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra4) then
-            call read_star_job_file(s, extra4, level+1, ierr)
-            if (ierr /= 0) return
-         end if
-
-         if (read_extra5) then
-            call read_star_job_file(s, extra5, level+1, ierr)
-            if (ierr /= 0) return
-         end if
 
       end subroutine read_star_job_file
 
@@ -1125,16 +1080,8 @@
          s% job% jina_reaclib_min_T9 = jina_reaclib_min_T9
          s% job% rate_tables_dir = rate_tables_dir
          s% job% rate_cache_suffix = rate_cache_suffix
-         s% job% read_extra_star_job_inlist1 = read_extra_star_job_inlist1
-         s% job% extra_star_job_inlist1_name = extra_star_job_inlist1_name
-         s% job% read_extra_star_job_inlist2 = read_extra_star_job_inlist2
-         s% job% extra_star_job_inlist2_name = extra_star_job_inlist2_name
-         s% job% read_extra_star_job_inlist3 = read_extra_star_job_inlist3
-         s% job% extra_star_job_inlist3_name = extra_star_job_inlist3_name
-         s% job% read_extra_star_job_inlist4 = read_extra_star_job_inlist4
-         s% job% extra_star_job_inlist4_name = extra_star_job_inlist4_name
-         s% job% read_extra_star_job_inlist5 = read_extra_star_job_inlist5
-         s% job% extra_star_job_inlist5_name = extra_star_job_inlist5_name
+         s% job% read_extra_star_job_inlist = read_extra_star_job_inlist
+         s% job% extra_star_job_inlist_name = extra_star_job_inlist_name
          s% job% set_abundance_nzlo = set_abundance_nzlo
          s% job% set_abundance_nzhi = set_abundance_nzhi
          s% job% set_abundance = set_abundance
@@ -1681,16 +1628,8 @@
          jina_reaclib_min_T9 = s% job% jina_reaclib_min_T9
          rate_tables_dir = s% job% rate_tables_dir
          rate_cache_suffix = s% job% rate_cache_suffix
-         read_extra_star_job_inlist1 = s% job% read_extra_star_job_inlist1
-         extra_star_job_inlist1_name = s% job% extra_star_job_inlist1_name
-         read_extra_star_job_inlist2 = s% job% read_extra_star_job_inlist2
-         extra_star_job_inlist2_name = s% job% extra_star_job_inlist2_name
-         read_extra_star_job_inlist3 = s% job% read_extra_star_job_inlist3
-         extra_star_job_inlist3_name = s% job% extra_star_job_inlist3_name
-         read_extra_star_job_inlist4 = s% job% read_extra_star_job_inlist4
-         extra_star_job_inlist4_name = s% job% extra_star_job_inlist4_name
-         read_extra_star_job_inlist5 = s% job% read_extra_star_job_inlist5
-         extra_star_job_inlist5_name = s% job% extra_star_job_inlist5_name
+         read_extra_star_job_inlist = s% job% read_extra_star_job_inlist
+         extra_star_job_inlist_name = s% job% extra_star_job_inlist_name
          set_abundance_nzlo = s% job% set_abundance_nzlo
          set_abundance_nzhi = s% job% set_abundance_nzhi
          set_abundance = s% job% set_abundance

--- a/star/test_suite/1.3M_ms_high_Z/inlist_1.3M_ms_high_Z_header
+++ b/star/test_suite/1.3M_ms_high_Z/inlist_1.3M_ms_high_Z_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.3M_ms_high_Z'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.3M_ms_high_Z'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.3M_ms_high_Z'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.3M_ms_high_Z'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.3M_ms_high_Z'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.3M_ms_high_Z'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.3M_ms_high_Z'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.3M_ms_high_Z'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1.3M_ms_high_Z/inlist_zams_header
+++ b/star/test_suite/1.3M_ms_high_Z/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_initial_model_header
+++ b/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_initial_model_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.4M_ms_initial_model'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.4M_ms_initial_model'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.4M_ms_initial_model'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.4M_ms_initial_model'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.4M_ms_initial_model'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.4M_ms_initial_model'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.4M_ms_initial_model'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.4M_ms_initial_model'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1.4M_ms_op_mono'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_op_mono_alt_header
+++ b/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_op_mono_alt_header
@@ -2,42 +2,42 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.4M_ms_op_mono'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.4M_ms_op_mono'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.4M_ms_op_mono'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.4M_ms_op_mono'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_1.4M_ms_op_mono_alt'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_1.4M_ms_op_mono_alt'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1.4M_ms_op_mono'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_op_mono_header
+++ b/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_op_mono_header
@@ -2,42 +2,42 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.4M_ms_op_mono'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.4M_ms_op_mono'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.4M_ms_op_mono'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.4M_ms_op_mono'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_1.4M_ms_op_mono_mombarg'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_1.4M_ms_op_mono_mombarg'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1.4M_ms_op_mono'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1.4M_ms_op_mono'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1.5M_with_diffusion/inlist_1.5M_with_diffusion_header
+++ b/star/test_suite/1.5M_with_diffusion/inlist_1.5M_with_diffusion_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.5M_with_diffusion'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.5M_with_diffusion'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.5M_with_diffusion'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.5M_with_diffusion'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.5M_with_diffusion'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.5M_with_diffusion'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.5M_with_diffusion'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.5M_with_diffusion'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1.5M_with_diffusion'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1.5M_with_diffusion'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1.5M_with_diffusion/inlist_to_ZAMS_header
+++ b/star/test_suite/1.5M_with_diffusion/inlist_to_ZAMS_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_ZAMS'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_ZAMS'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_ZAMS'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_ZAMS'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_ZAMS'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_ZAMS'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_ZAMS'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_ZAMS'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_ZAMS'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_ZAMS'
 
 / ! end of pgstar namelist

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_make_late_pre_zams_header
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_make_late_pre_zams_header
@@ -1,36 +1,36 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_make_late_pre_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_make_late_pre_zams'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_mass_Z_wind_rotation'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_make_late_pre_zams'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_make_late_pre_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_cc_header
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_cc_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_cc'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_cc'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_cc'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_cc'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_cc'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_cc'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_cc'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_cc'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_cc'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_cc'
 / ! end of pgstar namelist

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_end_core_c_burn_header
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_end_core_c_burn_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_c_burn'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_c_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_c_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_he_burn'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_lgTmax_header
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_lgTmax_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_lgTmax'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_lgTmax'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_lgTmax'
 / ! end of pgstar namelist

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_zams_header
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_zams_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_zams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/test_suite/15M_dynamo/inlist_15M_dynamo_header
+++ b/star/test_suite/15M_dynamo/inlist_15M_dynamo_header
@@ -2,33 +2,33 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_15M_dynamo'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_15M_dynamo'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_15M_dynamo'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_15M_dynamo'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_15M_dynamo'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_15M_dynamo'
 
 / ! end of kap namelist
 
@@ -36,18 +36,18 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_15M_dynamo'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_15M_dynamo'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
 / ! end of pgstar namelist

--- a/star/test_suite/15M_dynamo/inlist_to_he_burn_header
+++ b/star/test_suite/15M_dynamo/inlist_to_he_burn_header
@@ -2,33 +2,33 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_he_burn'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_he_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_to_he_burn'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_to_he_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_to_he_burn'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_to_he_burn'
 
 / ! end of kap namelist
 
@@ -36,18 +36,18 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_to_he_burn'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_to_he_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
 / ! end of pgstar namelist

--- a/star/test_suite/15M_dynamo/inlist_zams_header
+++ b/star/test_suite/15M_dynamo/inlist_zams_header
@@ -2,33 +2,33 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_zams'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_zams'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -36,18 +36,18 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_zams'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
 / ! end of pgstar namelist

--- a/star/test_suite/16M_conv_premix/inlist_16M_conv_premix_header
+++ b/star/test_suite/16M_conv_premix/inlist_16M_conv_premix_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_16M_conv_premix'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_16M_conv_premix'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_16M_conv_premix'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_16M_conv_premix'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_16M_conv_premix'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_16M_conv_premix'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_16M_conv_premix'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_16M_conv_premix'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_16M_conv_premix'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_16M_conv_premix'
 
 / ! end of pgstar namelist

--- a/star/test_suite/16M_conv_premix/inlist_start_header
+++ b/star/test_suite/16M_conv_premix/inlist_start_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_start'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_start'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_start'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_start'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_start'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_start'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_start'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_start'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_start'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_start'
 
 / ! end of pgstar namelist

--- a/star/test_suite/16M_predictive_mix/inlist_16M_predictive_mix_header
+++ b/star/test_suite/16M_predictive_mix/inlist_16M_predictive_mix_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_16M_predictive_mix'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_16M_predictive_mix'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_16M_predictive_mix'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_16M_predictive_mix'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_16M_predictive_mix'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_16M_predictive_mix'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_16M_predictive_mix'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_16M_predictive_mix'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_16M_predictive_mix'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_16M_predictive_mix'
 
 / ! end of pgstar namelist

--- a/star/test_suite/16M_predictive_mix/inlist_start_header
+++ b/star/test_suite/16M_predictive_mix/inlist_start_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_start'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_start'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_start'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_start'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_start'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_start'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_start'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_start'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_start'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_start'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_start_header
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_start_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_start'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_start'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_start'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_start'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_start'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_start'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_start'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_start'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_start'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_start'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_agb_header
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_agb_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_end_agb'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_end_agb'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_end_agb'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_end_agb'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_end_agb'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_end_agb'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_end_agb'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_end_agb'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_end_agb'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_end_agb'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_h_burn_header
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_h_burn_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_end_core_h_burn'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_end_core_h_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_end_core_h_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_end_core_h_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_end_core_h_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_end_core_h_burn'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_end_core_h_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_end_core_h_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_end_core_h_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_end_core_h_burn'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_he_burn_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_end_core_he_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_end_core_he_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_end_core_he_burn'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_end_core_he_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_end_core_he_burn'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_start_he_core_flash_header
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_start_he_core_flash_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_start_he_core_flash'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_start_he_core_flash'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_start_he_core_flash'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_start_he_core_flash'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_start_he_core_flash'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_start_he_core_flash'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_start_he_core_flash'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_start_he_core_flash'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_start_he_core_flash'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_start_he_core_flash'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_wd_header
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_wd_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_wd'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_wd'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_wd'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_wd'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_wd'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_wd'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_wd'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_wd'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_wd'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_wd'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_thermohaline/inlist
+++ b/star/test_suite/1M_thermohaline/inlist
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1M_thermohaline'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1M_thermohaline'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1M_thermohaline'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1M_thermohaline'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1M_thermohaline'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1M_thermohaline'
 
 / ! end of pgstar namelist

--- a/star/test_suite/1M_thermohaline/inlist_1M_thermohaline_header
+++ b/star/test_suite/1M_thermohaline/inlist_1M_thermohaline_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1M_thermohaline'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1M_thermohaline'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1M_thermohaline'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1M_thermohaline'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1M_thermohaline'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1M_thermohaline'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1M_thermohaline'
 
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_make_late_pre_zams_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_make_late_pre_zams_header
@@ -1,36 +1,36 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_make_late_pre_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_make_late_pre_zams'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_mass_Z_wind_rotation'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_make_late_pre_zams'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_make_late_pre_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_remove_envelope_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_remove_envelope_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_remove_envelope'      
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_remove_envelope'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_remove_envelope'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_remove_envelope'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_remove_envelope'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_remove_envelope'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_remove_envelope'
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_cc_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_cc_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_cc'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_cc'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_cc'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_cc'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_cc'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_cc'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_cc'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_cc'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_cc'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_cc'
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_end_core_c_burn_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_end_core_c_burn_header
@@ -1,44 +1,44 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_c_burn'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_c_burn'
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_c_burn'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_to_end_core_c_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_he_burn'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_lgTmax_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_lgTmax_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_lgTmax'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_lgTmax'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_lgTmax'
 / ! end of pgstar namelist

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_zams_header
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_zams_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_zams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/test_suite/20M_z2m2_high_rotation/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/20M_z2m2_high_rotation/inlist_to_end_core_he_burn_header
@@ -1,31 +1,31 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_to_end_core_he_burn'
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_end_core_he_burn'
 / ! end of eos namelist
 
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_end_core_he_burn'
 / ! end of kap namelist
 
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_end_core_he_burn'      
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_end_core_he_burn'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/5M_cepheid_blue_loop/inlist_cepheid_blue_loop_header
+++ b/star/test_suite/5M_cepheid_blue_loop/inlist_cepheid_blue_loop_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_cepheid_blue_loop'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_cepheid_blue_loop'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_cepheid_blue_loop'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_cepheid_blue_loop'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_cepheid_blue_loop'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_cepheid_blue_loop'
 
 / ! end of kap namelist
 
@@ -27,8 +27,8 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_cepheid_blue_loop'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_cepheid_blue_loop'
 
 
 / ! end of controls namelist
@@ -36,7 +36,7 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_cepheid_blue_loop'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_cepheid_blue_loop'
 
 / ! end of pgstar namelist

--- a/star/test_suite/5M_cepheid_blue_loop/inlist_start_header
+++ b/star/test_suite/5M_cepheid_blue_loop/inlist_start_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_start'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_start'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_start'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_start'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_start'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_start'
 
 / ! end of kap namelist
 
@@ -27,8 +27,8 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_start'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_start'
 
 / ! end of controls namelist
 
@@ -36,7 +36,7 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_start'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_start'
 
 / ! end of pgstar namelist

--- a/star/test_suite/7M_prems_to_AGB/inlist_7M_prems_to_AGB_header
+++ b/star/test_suite/7M_prems_to_AGB/inlist_7M_prems_to_AGB_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_7M_prems_to_AGB'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_7M_prems_to_AGB'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_7M_prems_to_AGB'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_7M_prems_to_AGB'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_7M_prems_to_AGB'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_7M_prems_to_AGB'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_7M_prems_to_AGB'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_7M_prems_to_AGB'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_7M_prems_to_AGB'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_7M_prems_to_AGB'
 
 / ! end of pgstar namelist

--- a/star/test_suite/7M_prems_to_AGB/inlist_start_header
+++ b/star/test_suite/7M_prems_to_AGB/inlist_start_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_start'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_start'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_start'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_start'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_start'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_start'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_start'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_start'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_start'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_start'
 
 / ! end of pgstar namelist

--- a/star/test_suite/R_CrB_star/inlist_He_star_header
+++ b/star/test_suite/R_CrB_star/inlist_He_star_header
@@ -2,51 +2,51 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_He_star'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_He_star'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_He_star'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_He_star'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_He_star'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_He_star'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_He_star'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_He_star'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/R_CrB_star/inlist_R_CrB_star_header
+++ b/star/test_suite/R_CrB_star/inlist_R_CrB_star_header
@@ -2,51 +2,51 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_R_CrB_star'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_R_CrB_star'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_R_CrB_star'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_R_CrB_star'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_R_CrB_star'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_R_CrB_star'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_R_CrB_star'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_R_CrB_star'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/R_CrB_star/inlist_change_abundances
+++ b/star/test_suite/R_CrB_star/inlist_change_abundances
@@ -11,8 +11,8 @@
       set_nzlo = -1
 
       ! get nzhi from an inlist auto-generated in the previous part
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_nzhi'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_nzhi'
 
       save_model_when_terminate = .true.
       save_model_filename = 'R_CrB_from_He_star.mod'

--- a/star/test_suite/R_CrB_star/inlist_change_abundances_header
+++ b/star/test_suite/R_CrB_star/inlist_change_abundances_header
@@ -2,51 +2,51 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_change_abundances'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_change_abundances'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_change_abundances'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_change_abundances'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_change_abundances'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_change_abundances'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_change_abundances'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_change_abundances'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/T_tau_gradr/inlist_T_tau_gradr_header
+++ b/star/test_suite/T_tau_gradr/inlist_T_tau_gradr_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_T_tau_gradr'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_T_tau_gradr'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_T_tau_gradr'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_T_tau_gradr'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_T_tau_gradr'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_T_tau_gradr'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_T_tau_gradr'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_T_tau_gradr'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_T_tau_gradr'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_T_tau_gradr'
 
 / ! end of pgstar namelist

--- a/star/test_suite/accreted_material_j/inlist_accreted_material_j_header
+++ b/star/test_suite/accreted_material_j/inlist_accreted_material_j_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_accreted_material_j'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_accreted_material_j'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_accreted_material_j'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_accreted_material_j'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_accreted_material_j'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_accreted_material_j'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_accreted_material_j'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_accreted_material_j'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_accreted_material_j'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_accreted_material_j'
 
 / ! end of pgstar namelist

--- a/star/test_suite/accreted_material_j/inlist_zams_header
+++ b/star/test_suite/accreted_material_j/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/adjust_net/inlist_adjust_net_header
+++ b/star/test_suite/adjust_net/inlist_adjust_net_header
@@ -2,53 +2,53 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_massive_defaults'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_massive_defaults'
 
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_adjust_net'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_adjust_net'
 
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_massive_defaults'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_massive_defaults'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_adjust_net'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_adjust_net'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_massive_defaults'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_massive_defaults'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_adjust_net'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_adjust_net'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_massive_defaults'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_massive_defaults'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_adjust_net'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_adjust_net'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_massive_defaults'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_massive_defaults'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_adjust_net'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_adjust_net'
 
 / ! end of pgstar namelist

--- a/star/test_suite/adjust_net/inlist_zams_header
+++ b/star/test_suite/adjust_net/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/c13_pocket/inlist_c13_pocket_header
+++ b/star/test_suite/c13_pocket/inlist_c13_pocket_header
@@ -1,32 +1,32 @@
 &star_job
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_c13_pocket'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_c13_pocket'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_c13_pocket'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_c13_pocket'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_c13_pocket'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_c13_pocket'
 
 / ! end of kap namelist
 
@@ -35,21 +35,21 @@
 
       x_integer_ctrl(1) = 4 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_TP_AGB'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_TP_AGB'
 
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_c13_pocket'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_c13_pocket'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/c13_pocket/inlist_pre_ms_header
+++ b/star/test_suite/c13_pocket/inlist_pre_ms_header
@@ -1,32 +1,32 @@
 &star_job
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_pre_ms'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_pre_ms'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_pre_ms'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_pre_ms'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_pre_ms'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_pre_ms'
 
 / ! end of kap namelist
 
@@ -36,18 +36,18 @@
 
       x_integer_ctrl(1) = 0 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_pre_ms'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_pre_ms'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/c13_pocket/inlist_to_3DUP_header
+++ b/star/test_suite/c13_pocket/inlist_to_3DUP_header
@@ -1,32 +1,32 @@
 &star_job
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_3DUP'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_3DUP'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_to_3DUP'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_to_3DUP'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_to_3DUP'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_to_3DUP'
 
 / ! end of kap namelist
 
@@ -35,21 +35,21 @@
 
       x_integer_ctrl(1) = 2 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_TP_AGB'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_TP_AGB'
 
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_3DUP'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_3DUP'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/c13_pocket/inlist_to_TACHeB_header
+++ b/star/test_suite/c13_pocket/inlist_to_TACHeB_header
@@ -1,32 +1,32 @@
 &star_job
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_TACHeB'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_TACHeB'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_to_TACHeB'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_to_TACHeB'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_to_TACHeB'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_to_TACHeB'
 
 / ! end of kap namelist
 
@@ -35,18 +35,18 @@
 
       x_integer_ctrl(1) = 1 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_to_TACHeB'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_to_TACHeB'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/c13_pocket/inlist_to_lgL_3.79_header
+++ b/star/test_suite/c13_pocket/inlist_to_lgL_3.79_header
@@ -1,32 +1,32 @@
 &star_job
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_lgL_3.79'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_lgL_3.79'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_to_lgL_3.79'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_to_lgL_3.79'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_to_lgL_3.79'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_to_lgL_3.79'
 
 / ! end of kap namelist
 
@@ -35,21 +35,21 @@
 
       x_integer_ctrl(1) = 3 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_TP_AGB'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_TP_AGB'
 
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_lgL_3.79'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_lgL_3.79'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/carbon_kh/docs/carbon_kh.ipynb
+++ b/star/test_suite/carbon_kh/docs/carbon_kh.ipynb
@@ -78,11 +78,11 @@
     "These convergence study runs can be done by modifying the inlist_carbon_kh to load the variable resolution/equation inlists\n",
     "\n",
     "      ! for convergence studies\n",
-    "      read_extra_controls_inlist2 = .true.\n",
-    "      extra_controls_inlist2_name = 'inlist_resolution'\n",
+    "      read_extra_controls_inlist(2) = .true.\n",
+    "      extra_controls_inlist_name(2)= 'inlist_resolution'\n",
     "\n",
-    "      read_extra_controls_inlist3 = .true.\n",
-    "      extra_controls_inlist3_name = 'inlist_equations'\n",
+    "      read_extra_controls_inlist(3) = .true.\n",
+    "      extra_controls_inlist_name(3)= 'inlist_equations'\n",
     "\n",
     "and then by using the included script ``./rnall``."
    ]

--- a/star/test_suite/carbon_kh/inlist_carbon_kh
+++ b/star/test_suite/carbon_kh/inlist_carbon_kh
@@ -74,11 +74,11 @@
   trace_history_value_name(2) = 'log_rel_run_E_err'
 
   ! for convergence studies
-      read_extra_controls_inlist2 = .false.
-      extra_controls_inlist2_name = 'inlist_resolution'
+      read_extra_controls_inlist(2) = .false.
+      extra_controls_inlist_name(2)= 'inlist_resolution'
 
-      read_extra_controls_inlist3 = .false.
-      extra_controls_inlist3_name = 'inlist_equations'
+      read_extra_controls_inlist(3) = .false.
+      extra_controls_inlist_name(3)= 'inlist_equations'
 
 / ! end of controls namelist
 

--- a/star/test_suite/carbon_kh/inlist_carbon_kh_header
+++ b/star/test_suite/carbon_kh/inlist_carbon_kh_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_carbon_kh'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_carbon_kh'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_carbon_kh'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_carbon_kh'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_carbon_kh'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_carbon_kh'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_carbon_kh'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_carbon_kh'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_carbon_kh'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_carbon_kh'
 
 / ! end of pgstar namelist

--- a/star/test_suite/cburn_inward/inlist_cburn_inward_header
+++ b/star/test_suite/cburn_inward/inlist_cburn_inward_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_cburn_inward'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_cburn_inward'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_cburn_inward'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_cburn_inward'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_cburn_inward'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_cburn_inward'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_cburn_inward'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_cburn_inward'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_cburn_inward'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_cburn_inward'
 
 / ! end of pgstar namelist

--- a/star/test_suite/cburn_inward/inlist_initial_header
+++ b/star/test_suite/cburn_inward/inlist_initial_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_initial'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_initial'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_initial'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_initial'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_initial'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_initial'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_initial'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_initial'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_initial'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_initial'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ccsn_IIp/inlist_common
+++ b/star/test_suite/ccsn_IIp/inlist_common
@@ -1,8 +1,8 @@
 ! inlist_common
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_mass_Z'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_mass_Z'
  
    show_log_description_at_start = .false.
 
@@ -22,16 +22,16 @@ use_Skye = .false.
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_mass_Z'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_mass_Z'
 
    kap_file_prefix = 'gs98'
    use_Type2_opacities = .false.
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_mass_Z'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_mass_Z'
 
    ! high center T limit to avoid negative mass fractions
    sig_min_factor_for_high_Tcenter = 0.01

--- a/star/test_suite/ccsn_IIp/inlist_edep_header
+++ b/star/test_suite/ccsn_IIp/inlist_edep_header
@@ -2,57 +2,57 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_edep'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_edep'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_edep'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_edep'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_edep'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_edep'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_edep'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_edep'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_edep'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_edep'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ccsn_IIp/inlist_end_infall_header
+++ b/star/test_suite/ccsn_IIp/inlist_end_infall_header
@@ -1,57 +1,57 @@
 
 &star_job
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_common'
 
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_end_infall'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_end_infall'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_end_infall'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_end_infall'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_end_infall'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_end_infall'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_end_infall'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_end_infall'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_end_infall'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_end_infall'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ccsn_IIp/inlist_infall_header
+++ b/star/test_suite/ccsn_IIp/inlist_infall_header
@@ -1,57 +1,57 @@
 
 &star_job
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_common'
 
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_infall'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_infall'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_infall'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_infall'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_infall'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_infall'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name =  'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)=  'inlist_common'
 
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_infall'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_infall'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_infall'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_infall'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ccsn_IIp/inlist_shock_part1_header
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part1_header
@@ -1,48 +1,48 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_shock_common'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_shock_part1'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_shock_common'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_shock_part1'
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_shock_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_shock_part1'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_shock_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_shock_part1'
 / ! end of eos namelist
 
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_shock_common'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_shock_part1'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_shock_common'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_shock_part1'
 / ! end of kap namelist
 
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_shock_common'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_shock_part1'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_shock_common'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_shock_part1'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_shock_part1'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_shock_part1'
 / ! end of pgstar namelist
 

--- a/star/test_suite/ccsn_IIp/inlist_shock_part2_header
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part2_header
@@ -1,48 +1,48 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_shock_common'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_shock_part2'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_shock_common'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_shock_part2'
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_shock_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_shock_part2'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_shock_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_shock_part2'
 / ! end of eos namelist
 
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_shock_common'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_shock_part2'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_shock_common'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_shock_part2'
 / ! end of kap namelist
 
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_shock_common'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_shock_part2'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_shock_common'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_shock_part2'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_shock_part2'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_shock_part2'
 / ! end of pgstar namelist
 

--- a/star/test_suite/ccsn_IIp/inlist_shock_part3_header
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part3_header
@@ -1,48 +1,48 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_shock_common'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_shock_part3'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_shock_common'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_shock_part3'
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_shock_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_shock_part3'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_shock_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_shock_part3'
 / ! end of eos namelist
 
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_shock_common'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_shock_part3'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_shock_common'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_shock_part3'
 / ! end of kap namelist
 
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_shock_common'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_shock_part3'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_shock_common'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_shock_part3'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_shock_part3'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_shock_part3'
 / ! end of pgstar namelist
 

--- a/star/test_suite/ccsn_IIp/inlist_shock_part4_header
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part4_header
@@ -1,48 +1,48 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_shock_common'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_shock_part4'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_shock_common'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_shock_part4'
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_shock_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_shock_part4'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_shock_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_shock_part4'
 / ! end of eos namelist
 
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_shock_common'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_shock_part4'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_shock_common'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_shock_part4'
 / ! end of kap namelist
 
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_shock_common'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_shock_part4'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_shock_common'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_shock_part4'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_shock_part4'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_shock_part4'
 / ! end of pgstar namelist
 

--- a/star/test_suite/ccsn_IIp/inlist_shock_part5_header
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part5_header
@@ -1,48 +1,48 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_shock_common'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_shock_part5'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_shock_common'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_shock_part5'
 / ! end of star_job namelist
 
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_shock_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_shock_part5'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_shock_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_shock_part5'
 / ! end of eos namelist
 
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_shock_common'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_shock_part5'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_shock_common'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_shock_part5'
 / ! end of kap namelist
 
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_shock_common'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_shock_part5'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_shock_common'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_shock_part5'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_shock_part5'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_shock_part5'
 / ! end of pgstar namelist
 

--- a/star/test_suite/check_pulse_atm/inlist_check_pulse_atm_header
+++ b/star/test_suite/check_pulse_atm/inlist_check_pulse_atm_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_check_pulse_atm'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_check_pulse_atm'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_check_pulse_atm'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_check_pulse_atm'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_check_pulse_atm'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_check_pulse_atm'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_check_pulse_atm'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_check_pulse_atm'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_check_pulse_atm'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_check_pulse_atm'
 
 / ! end of pgstar namelist

--- a/star/test_suite/check_redo/inlist
+++ b/star/test_suite/check_redo/inlist
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_check_redo'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_check_redo'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_check_redo'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_check_redo'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_check_redo'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_check_redo'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_check_redo'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_check_redo'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_check_redo'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_check_redo'
 
 / ! end of pgstar namelist

--- a/star/test_suite/conductive_flame/inlist_conductive_flame_header
+++ b/star/test_suite/conductive_flame/inlist_conductive_flame_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_conductive_flame'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_conductive_flame'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_conductive_flame'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_conductive_flame'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_conductive_flame'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_conductive_flame'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_conductive_flame'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_conductive_flame'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/conserve_angular_momentum/inlist_conserve_J_header
+++ b/star/test_suite/conserve_angular_momentum/inlist_conserve_J_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_conserve_J'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_conserve_J'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_conserve_J'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_conserve_J'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_conserve_J'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_conserve_J'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_conserve_J'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_conserve_J'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_conserve_J'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_conserve_J'
 
 / ! end of pgstar namelist

--- a/star/test_suite/conserve_angular_momentum/inlist_zams_header
+++ b/star/test_suite/conserve_angular_momentum/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_colors/inlist
+++ b/star/test_suite/custom_colors/inlist
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.0'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.0'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.0'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.0'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.0'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.0'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.0'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.0'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1.0'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1.0'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_colors/inlist_1.0_header
+++ b/star/test_suite/custom_colors/inlist_1.0_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_1.0'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_1.0'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_1.0'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_1.0'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_1.0'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_1.0'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_1.0'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_1.0'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_1.0'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_1.0'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_rates/inlist_NCO_flash_header
+++ b/star/test_suite/custom_rates/inlist_NCO_flash_header
@@ -1,37 +1,37 @@
 
 &star_job
   
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_NCO_flash'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_NCO_flash'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_NCO_flash'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_NCO_flash'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_NCO_flash'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_NCO_flash'
 
 / ! end of kap namelist
 
 
 &controls
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_NCO_flash'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_NCO_flash'
 
 
 / ! end of controls namelist
 
 &pgstar
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_rates/inlist_NCO_hashimoto_header
+++ b/star/test_suite/custom_rates/inlist_NCO_hashimoto_header
@@ -1,35 +1,35 @@
 
 &star_job
 
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_NCO_hashimoto'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_NCO_hashimoto'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_NCO_hashimoto'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_NCO_hashimoto'
 
 / ! end of eos namelist
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_NCO_hashimoto'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_NCO_hashimoto'
 
 / ! end of kap namelist
 
 &controls
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_NCO_hashimoto'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_NCO_hashimoto'
 
 
 / ! end of controls namelist
 
 &pgstar
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_rates/inlist_cool_header
+++ b/star/test_suite/custom_rates/inlist_cool_header
@@ -1,24 +1,24 @@
 
 &star_job
 
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_cool'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_cool'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_cool'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_cool'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_cool'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_cool'
 
 / ! end of kap namelist
 
@@ -26,14 +26,14 @@
 
 &controls
 
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_cool'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_cool'
 
 / ! end of controls namelist
 
 &pgstar
 
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_rates/inlist_core_header
+++ b/star/test_suite/custom_rates/inlist_core_header
@@ -1,37 +1,37 @@
 
 &star_job
 
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_core'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_core'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_core'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_core'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_core'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_core'
 
 / ! end of kap namelist
 
 
 &controls
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_core'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_core'
 
 
 / ! end of controls namelist
 
 &pgstar
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/custom_rates/inlist_make_he_wd_header
+++ b/star/test_suite/custom_rates/inlist_make_he_wd_header
@@ -1,37 +1,37 @@
 
 &star_job
 
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_make_he_wd'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_make_he_wd'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_make_he_wd'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_make_he_wd'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_make_he_wd'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_make_he_wd'
 
 / ! end of kap namelist
 
 
 &controls
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_make_he_wd'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_make_he_wd'
 
 
 / ! end of controls namelist
 
 &pgstar
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness_header
+++ b/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_diffusion_smoothness'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_diffusion_smoothness'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_diffusion_smoothness'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_diffusion_smoothness'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_diffusion_smoothness'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_diffusion_smoothness'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_diffusion_smoothness'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_diffusion_smoothness'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_diffusion_smoothness'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_diffusion_smoothness'
 
 / ! end of pgstar namelist

--- a/star/test_suite/diffusion_smoothness/inlist_zams_header
+++ b/star/test_suite/diffusion_smoothness/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_zams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/extended_convective_penetration/inlist_extended_convective_penetration_header
+++ b/star/test_suite/extended_convective_penetration/inlist_extended_convective_penetration_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_extended_convective_penetration'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_extended_convective_penetration'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_extended_convective_penetration'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_extended_convective_penetration'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_extended_convective_penetration'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_extended_convective_penetration'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_extended_convective_penetration'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_extended_convective_penetration'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_extended_convective_penetration'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_extended_convective_penetration'
 
 / ! end of pgstar namelist

--- a/star/test_suite/extended_convective_penetration/inlist_zams_header
+++ b/star/test_suite/extended_convective_penetration/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_bcep/inlist_gyre_in_mesa_bcep_header
+++ b/star/test_suite/gyre_in_mesa_bcep/inlist_gyre_in_mesa_bcep_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_gyre_in_mesa_bcep'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_gyre_in_mesa_bcep'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_gyre_in_mesa_bcep'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_gyre_in_mesa_bcep'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_gyre_in_mesa_bcep'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_gyre_in_mesa_bcep'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_gyre_in_mesa_bcep'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_gyre_in_mesa_bcep'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_gyre_in_mesa_bcep'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_gyre_in_mesa_bcep'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_bcep/inlist_zams_header
+++ b/star/test_suite/gyre_in_mesa_bcep/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_pulse_header
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_common'
-  read_extra_star_job_inlist2 = .true.
-  extra_star_job_inlist2_name = 'inlist_pulse'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_common'
+  read_extra_star_job_inlist(2) = .true.
+  extra_star_job_inlist_name(2) = 'inlist_pulse'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_pulse'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_pulse'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_pulse'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_pulse'
 
 / ! end of kap namelist
 
 
 &controls
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_common'
-  read_extra_controls_inlist2 = .true.
-  extra_controls_inlist2_name = 'inlist_pulse'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_common'
+  read_extra_controls_inlist(2) = .true.
+  extra_controls_inlist_name(2)= 'inlist_pulse'
 
 / ! end of controls namelist
 
 &pgstar
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_remove_center_header
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_remove_center_header
@@ -1,39 +1,39 @@
 
 &star_job
-  read_extra_star_job_inlist1 = .true.
-  extra_star_job_inlist1_name = 'inlist_common'
-  read_extra_star_job_inlist2 = .true.
-  extra_star_job_inlist2_name = 'inlist_remove_center'
+  read_extra_star_job_inlist(1) = .true.
+  extra_star_job_inlist_name(1) = 'inlist_common'
+  read_extra_star_job_inlist(2) = .true.
+  extra_star_job_inlist_name(2) = 'inlist_remove_center'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_remove_center'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_remove_center'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_remove_center'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_remove_center'
 
 / ! end of kap namelist
 
 
 &controls
-  read_extra_controls_inlist1 = .true.
-  extra_controls_inlist1_name = 'inlist_common'
-  read_extra_controls_inlist2 = .true.
-  extra_controls_inlist2_name = 'inlist_remove_center'
+  read_extra_controls_inlist(1) = .true.
+  extra_controls_inlist_name(1)= 'inlist_common'
+  read_extra_controls_inlist(2) = .true.
+  extra_controls_inlist_name(2)= 'inlist_remove_center'
 
 / ! end of controls namelist
 
 &pgstar
-  read_extra_pgstar_inlist1 = .true.
-  extra_pgstar_inlist1_name = 'inlist_pgstar'
+  read_extra_pgstar_inlist(1) = .true.
+  extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_tams_header
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_tams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_tams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_tams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_tams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_tams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_tams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_tams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_tams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_tams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_tams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_tams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_zams_header
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_ms/inlist_gyre_in_mesa_ms_header
+++ b/star/test_suite/gyre_in_mesa_ms/inlist_gyre_in_mesa_ms_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_gyre_in_mesa_ms'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_gyre_in_mesa_ms'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_gyre_in_mesa_ms'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_gyre_in_mesa_ms'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_gyre_in_mesa_ms'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_gyre_in_mesa_ms'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_gyre_in_mesa_ms'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_gyre_in_mesa_ms'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_gyre_in_mesa_ms'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_gyre_in_mesa_ms'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_ms/inlist_zams_header
+++ b/star/test_suite/gyre_in_mesa_ms/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_common_post_zams
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_common_post_zams
@@ -1,21 +1,21 @@
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
 / !end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
 
 ! atm
    atm_option = 'T_tau'

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_gyre_in_mesa_rsg_header
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_gyre_in_mesa_rsg_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_gyre_in_mesa_rsg'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_gyre_in_mesa_rsg'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_gyre_in_mesa_rsg'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_gyre_in_mesa_rsg'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_gyre_in_mesa_rsg'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_gyre_in_mesa_rsg'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_gyre_in_mesa_rsg'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_gyre_in_mesa_rsg'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_gyre_in_mesa_rsg'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_gyre_in_mesa_rsg'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_near_pulses_header
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_near_pulses_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_near_pulses'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_common_post_zams'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_near_pulses'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_near_pulses'
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_pulse_header
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_pulse_header
@@ -1,39 +1,39 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common_post_zams'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_to_pulse'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_to_pulse'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common_post_zams'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_to_pulse'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_to_pulse'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common_post_zams'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_to_pulse'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common_post_zams'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_to_pulse'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common_post_zams'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_to_pulse'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_to_pulse'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_common_post_zams'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_to_pulse'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_common_post_zams'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_to_pulse'
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_zams_header
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_zams_header
@@ -1,37 +1,37 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_common'
-   read_extra_star_job_inlist3 = .true.
-   extra_star_job_inlist3_name = 'inlist_to_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_common'
+   read_extra_star_job_inlist(3) = .true.
+   extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_common'
-   read_extra_eos_inlist3 = .true.
-   extra_eos_inlist3_name = 'inlist_to_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_common'
+   read_extra_eos_inlist(3) = .true.
+   extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_common'
-   read_extra_kap_inlist3 = .true.
-   extra_kap_inlist3_name = 'inlist_to_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_common'
+   read_extra_kap_inlist(3) = .true.
+   extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_common'
-   read_extra_controls_inlist3 = .true.
-   extra_controls_inlist3_name = 'inlist_to_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_common'
+   read_extra_controls_inlist(3) = .true.
+   extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 
 &pgstar
-   read_extra_pgstar_inlist3 = .true.
-   extra_pgstar_inlist3_name = 'inlist_to_zams'
+   read_extra_pgstar_inlist(3) = .true.
+   extra_pgstar_inlist_name(3)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_spb/inlist_gyre_in_mesa_spb_header
+++ b/star/test_suite/gyre_in_mesa_spb/inlist_gyre_in_mesa_spb_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_gyre_in_mesa_spb'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_gyre_in_mesa_spb'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_gyre_in_mesa_spb'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_gyre_in_mesa_spb'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_gyre_in_mesa_spb'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_gyre_in_mesa_spb'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_gyre_in_mesa_spb'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_gyre_in_mesa_spb'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_gyre_in_mesa_spb'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_gyre_in_mesa_spb'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_spb/inlist_zams_header
+++ b/star/test_suite/gyre_in_mesa_spb/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_wd/inlist_pulse_wd_header
+++ b/star/test_suite/gyre_in_mesa_wd/inlist_pulse_wd_header
@@ -2,54 +2,54 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_pulse_wd'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_pulse_wd'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_pulse_wd'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_pulse_wd'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_pulse_wd'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_pulse_wd'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_pulse_wd'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_pulse_wd'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pulse_wd'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pulse_wd'
 
 / ! end of pgstar namelist

--- a/star/test_suite/hb_2M/inlist_hb_2M_header
+++ b/star/test_suite/hb_2M/inlist_hb_2M_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_hb_2M'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_hb_2M'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_hb_2M'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_hb_2M'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_hb_2M'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_hb_2M'
 
 / ! end of kap namelist
 
@@ -28,15 +28,15 @@
 
       x_integer_ctrl(1) = 3 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_hb_2M'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_hb_2M'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_hb_2M'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_hb_2M'
 
 / ! end of pgstar namelist

--- a/star/test_suite/hb_2M/inlist_to_TAMS_header
+++ b/star/test_suite/hb_2M/inlist_to_TAMS_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_TAMS'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_TAMS'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_TAMS'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_TAMS'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_TAMS'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_TAMS'
 
 / ! end of kap namelist
 
@@ -28,15 +28,15 @@
 
       x_integer_ctrl(1) = 1 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_TAMS'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_TAMS'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_TAMS'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_TAMS'
 
 / ! end of pgstar namelist

--- a/star/test_suite/hb_2M/inlist_to_ZACHeB_header
+++ b/star/test_suite/hb_2M/inlist_to_ZACHeB_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_ZACHeB'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_ZACHeB'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_ZACHeB'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_ZACHeB'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_ZACHeB'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_ZACHeB'
 
 / ! end of kap namelist
 
@@ -28,15 +28,15 @@
 
       x_integer_ctrl(1) = 2 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_ZACHeB'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_ZACHeB'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_ZACHeB'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_ZACHeB'
 
 / ! end of pgstar namelist

--- a/star/test_suite/high_mass/inlist_high_mass_header
+++ b/star/test_suite/high_mass/inlist_high_mass_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_high_mass'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_high_mass'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_high_mass'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_high_mass'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_high_mass'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_high_mass'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_high_mass'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_high_mass'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_high_mass'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_high_mass'
 
 / ! end of pgstar namelist

--- a/star/test_suite/high_rot_darkening/inlist_high_rot_darkening_header
+++ b/star/test_suite/high_rot_darkening/inlist_high_rot_darkening_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_high_rot_darkening'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_high_rot_darkening'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_high_rot_darkening'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_high_rot_darkening'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_high_rot_darkening'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_high_rot_darkening'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_high_rot_darkening'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_high_rot_darkening'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_high_rot_darkening'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_high_rot_darkening'
 
 / ! end of pgstar namelist

--- a/star/test_suite/high_rot_darkening/inlist_zams_header
+++ b/star/test_suite/high_rot_darkening/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/high_z/inlist_high_z_header
+++ b/star/test_suite/high_z/inlist_high_z_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_high_z'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_high_z'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_high_z'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_high_z'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_high_z'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_high_z'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_high_z'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_high_z'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_high_z'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_high_z'
 
 / ! end of pgstar namelist

--- a/star/test_suite/high_z/inlist_zams_header
+++ b/star/test_suite/high_z/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/hot_cool_wind/inlist_hot_cool_wind_header
+++ b/star/test_suite/hot_cool_wind/inlist_hot_cool_wind_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_hot_cool_wind'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_hot_cool_wind'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_hot_cool_wind'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_hot_cool_wind'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_hot_cool_wind'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_hot_cool_wind'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_hot_cool_wind'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_hot_cool_wind'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_hot_cool_wind'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_hot_cool_wind'
 
 / ! end of pgstar namelist

--- a/star/test_suite/hse_riemann/inlist_finish_header
+++ b/star/test_suite/hse_riemann/inlist_finish_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_finish'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_finish'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_finish'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_finish'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_finish'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_finish'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_finish'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_finish'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_finish'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_finish'
 
 / ! end of pgstar namelist

--- a/star/test_suite/irradiated_planet/inlist_create_header
+++ b/star/test_suite/irradiated_planet/inlist_create_header
@@ -2,23 +2,23 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_create'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_create'
 
 / ! end of star_job namelist
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_create'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_create'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_create'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_create'
 
 / ! end of kap namelist
 
@@ -26,15 +26,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_create'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_create'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_create'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_create'
 
 / ! end of pgstar namelist

--- a/star/test_suite/irradiated_planet/inlist_evolve_header
+++ b/star/test_suite/irradiated_planet/inlist_evolve_header
@@ -2,23 +2,23 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_evolve'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_evolve'
 
 / ! end of star_job namelist
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_evolve'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_evolve'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_evolve'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_evolve'
 
 / ! end of kap namelist
 
@@ -26,15 +26,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_evolve'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_evolve'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_evolve'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_evolve'
 
 / ! end of pgstar namelist

--- a/star/test_suite/low_z/inlist_low_Z_header
+++ b/star/test_suite/low_z/inlist_low_Z_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_low_Z'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_low_Z'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_low_Z'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_low_Z'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_low_Z'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_low_Z'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_low_Z'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_low_Z'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_low_Z'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_low_Z'
 
 / ! end of pgstar namelist

--- a/star/test_suite/low_z/inlist_zams_header
+++ b/star/test_suite/low_z/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/magnetic_braking/inlist_braking_header
+++ b/star/test_suite/magnetic_braking/inlist_braking_header
@@ -2,38 +2,38 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_braking'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_braking'
 
 / ! end of star_job namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_braking'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_braking'
 
 / ! end of controls namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_braking'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_braking'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_braking'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_braking'
 
 / ! end of kap namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_braking_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_braking_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/magnetic_braking/inlist_zams_header
+++ b/star/test_suite/magnetic_braking/inlist_zams_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_zams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .false.
-      extra_pgstar_inlist1_name = 'inlist_zams_pgstar'
+      read_extra_pgstar_inlist(1) = .false.
+      extra_pgstar_inlist_name(1)= 'inlist_zams_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_brown_dwarf/inlist_make_brown_dwarf_header
+++ b/star/test_suite/make_brown_dwarf/inlist_make_brown_dwarf_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_make_brown_dwarf'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_make_brown_dwarf'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_make_brown_dwarf'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_make_brown_dwarf'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_make_brown_dwarf'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_make_brown_dwarf'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_make_brown_dwarf'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_make_brown_dwarf'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_make_brown_dwarf'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_make_brown_dwarf'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_co_wd/inlist_co_core_header
+++ b/star/test_suite/make_co_wd/inlist_co_core_header
@@ -2,53 +2,53 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_co_core'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_co_core'
 
 / ! end of star_job namelist
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_co_core'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_co_core'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_co_core'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_co_core'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_co_core'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_co_core'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_co_core'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_co_core'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_co_wd/inlist_remove_env_header
+++ b/star/test_suite/make_co_wd/inlist_remove_env_header
@@ -2,54 +2,54 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_remove_env'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_remove_env'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_remove_env'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_remove_env'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_remove_env'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_remove_env'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_remove_env'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_remove_env'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_remove_env'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_remove_env'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_co_wd/inlist_settle_header
+++ b/star/test_suite/make_co_wd/inlist_settle_header
@@ -2,54 +2,54 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_settle'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_settle'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_settle'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_settle'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_settle'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_settle'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_settle'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_settle'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_settle'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_settle'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_co_wd/inlist_to_end_he_core_burn_header
+++ b/star/test_suite/make_co_wd/inlist_to_end_he_core_burn_header
@@ -2,54 +2,54 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_end_he_core_burn'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_end_he_core_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_to_end_he_core_burn'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_to_end_he_core_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_to_end_he_core_burn'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_to_end_he_core_burn'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_to_end_he_core_burn'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_to_end_he_core_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_he_core_burn'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_he_core_burn'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_co_wd/inlist_zams_header
+++ b/star/test_suite/make_co_wd/inlist_zams_header
@@ -2,54 +2,54 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_zams'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_zams'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_zams'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_zams'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_zams'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_env/inlist_env_header
+++ b/star/test_suite/make_env/inlist_env_header
@@ -2,54 +2,54 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_env'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_env'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_env'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_env'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_env'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_env'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_env'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_env'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_env'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_env'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_he_wd/inlist_evolve_header
+++ b/star/test_suite/make_he_wd/inlist_evolve_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_evolve'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_evolve'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_evolve'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_evolve'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_evolve'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_evolve'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_evolve'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_evolve'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_evolve'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_evolve'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_he_wd/inlist_remove_envelope_header
+++ b/star/test_suite/make_he_wd/inlist_remove_envelope_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_remove_envelope'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_remove_envelope'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_remove_envelope'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_remove_envelope'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_remove_envelope'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_remove_envelope'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_remove_envelope'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_remove_envelope'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_remove_envelope'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_remove_envelope'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_he_wd/inlist_to_he_core_header
+++ b/star/test_suite/make_he_wd/inlist_to_he_core_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_to_he_core'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_to_he_core'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_he_core'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_he_core'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_he_core'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_he_core'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_he_core'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_he_core'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_he_core'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_he_core'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_metals/inlist_make_metals_header
+++ b/star/test_suite/make_metals/inlist_make_metals_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_make_metals'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_make_metals'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_make_metals'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_make_metals'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_make_metals'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_make_metals'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_make_metals'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_make_metals'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_make_metals'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_make_metals'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_c_burn_header
+++ b/star/test_suite/make_o_ne_wd/inlist_c_burn_header
@@ -2,57 +2,57 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_c_burn'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_c_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_c_burn'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_c_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_c_burn'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_c_burn'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_c_burn'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_c_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_c_burn'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_c_burn'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_o_ne_wd_header
+++ b/star/test_suite/make_o_ne_wd/inlist_o_ne_wd_header
@@ -2,57 +2,57 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_o_ne_wd'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_o_ne_wd'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_o_ne_wd'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_o_ne_wd'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_o_ne_wd'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_o_ne_wd'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_o_ne_wd'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_o_ne_wd'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_o_ne_wd'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_o_ne_wd'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_remove_envelope_header
+++ b/star/test_suite/make_o_ne_wd/inlist_remove_envelope_header
@@ -2,57 +2,57 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_remove_envelope'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_remove_envelope'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_remove_envelope'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_remove_envelope'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_remove_envelope'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_remove_envelope'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_remove_envelope'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_remove_envelope'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_remove_envelope'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_remove_envelope'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_settle_envelope_header
+++ b/star/test_suite/make_o_ne_wd/inlist_settle_envelope_header
@@ -2,57 +2,57 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_settle_envelope'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_settle_envelope'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_settle_envelope'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_settle_envelope'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_settle_envelope'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_settle_envelope'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_settle_envelope'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_settle_envelope'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_settle_envelope'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_settle_envelope'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_to_agb_header
+++ b/star/test_suite/make_o_ne_wd/inlist_to_agb_header
@@ -2,57 +2,57 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_agb'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_agb'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_to_agb'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_to_agb'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_to_agb'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_to_agb'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_to_agb'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_to_agb'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_to_agb'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_to_agb'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_zams_header
+++ b/star/test_suite/make_o_ne_wd/inlist_zams_header
@@ -2,33 +2,33 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
 
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_zams'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
 
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_zams'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -36,21 +36,21 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_zams'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_zams'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_planets/inlist_core_header
+++ b/star/test_suite/make_planets/inlist_core_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_core'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_core'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_core'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_core'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_core'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_core'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_core'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_core'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_core'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_core'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_planets/inlist_create_header
+++ b/star/test_suite/make_planets/inlist_create_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_create'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_create'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_create'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_create'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_create'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_create'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_create'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_create'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_create'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_create'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_planets/inlist_evolve_header
+++ b/star/test_suite/make_planets/inlist_evolve_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_evolve'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_evolve'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_evolve'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_evolve'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_evolve'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_evolve'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_evolve'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_evolve'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_evolve'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_evolve'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_sdb/inlist_make_sdb_header
+++ b/star/test_suite/make_sdb/inlist_make_sdb_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_make_sdb'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_make_sdb'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_make_sdb'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_make_sdb'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_make_sdb'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_make_sdb'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_make_sdb'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_make_sdb'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_make_sdb'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_make_sdb'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_zams/inlist_zams_header
+++ b/star/test_suite/make_zams/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_zams_low_mass/inlist_zams_header
+++ b/star/test_suite/make_zams_low_mass/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_zams_ultra_high_mass/inlist_zams_ultra_high_mass_header
+++ b/star/test_suite/make_zams_ultra_high_mass/inlist_zams_ultra_high_mass_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams_ultra_high_mass'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams_ultra_high_mass'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams_ultra_high_mass'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams_ultra_high_mass'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams_ultra_high_mass'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams_ultra_high_mass'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams_ultra_high_mass'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams_ultra_high_mass'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams_ultra_high_mass'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams_ultra_high_mass'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ns_c/inlist_to_c_flash_header
+++ b/star/test_suite/ns_c/inlist_to_c_flash_header
@@ -2,42 +2,42 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_to_c_flash'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_to_c_flash'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_c_flash'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_c_flash'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_c_flash'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_c_flash'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_c_flash'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_c_flash'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_c_flash'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_c_flash'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ns_h/inlist_add_he_layer_header
+++ b/star/test_suite/ns_h/inlist_add_he_layer_header
@@ -2,42 +2,42 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_add_he_layer'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_add_he_layer'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_add_he_layer'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_add_he_layer'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_add_he_layer'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_add_he_layer'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_add_he_layer'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_add_he_layer'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_add_he_layer'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_add_he_layer'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ns_h/inlist_to_steady_h_burn_header
+++ b/star/test_suite/ns_h/inlist_to_steady_h_burn_header
@@ -2,42 +2,42 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_to_steady_h_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_to_steady_h_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_steady_h_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_steady_h_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_steady_h_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_steady_h_burn'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_steady_h_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_steady_h_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_steady_h_burn'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_steady_h_burn'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ns_he/inlist_to_flash_header
+++ b/star/test_suite/ns_he/inlist_to_flash_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_to_flash'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_to_flash'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_flash'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_flash'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_flash'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_flash'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_flash'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_flash'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_flash'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_flash'
 
 / ! end of pgstar namelist

--- a/star/test_suite/other_physics_hooks/inlist_other_physics_hooks_header
+++ b/star/test_suite/other_physics_hooks/inlist_other_physics_hooks_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_other_physics_hooks'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_other_physics_hooks'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_other_physics_hooks'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_other_physics_hooks'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_other_physics_hooks'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_other_physics_hooks'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_other_physics_hooks'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_other_physics_hooks'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_other_physics_hooks'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_other_physics_hooks'
 
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_convert_header
+++ b/star/test_suite/pisn/inlist_convert_header
@@ -1,52 +1,52 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_common_converted'
-      read_extra_star_job_inlist4 = .true.
-      extra_star_job_inlist4_name = 'inlist_convert'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_common_converted'
+      read_extra_star_job_inlist(4) = .true.
+      extra_star_job_inlist_name(4) = 'inlist_convert'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_common_converted'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_convert'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_common_converted'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_convert'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_common_converted'
-      read_extra_kap_inlist4 = .true.
-      extra_kap_inlist4_name = 'inlist_convert'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_common_converted'
+      read_extra_kap_inlist(4) = .true.
+      extra_kap_inlist_name(4) = 'inlist_convert'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_common_converted'
-      read_extra_controls_inlist4 = .true.
-      extra_controls_inlist4_name = 'inlist_convert'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_common_converted'
+      read_extra_controls_inlist(4) = .true.
+      extra_controls_inlist_name(4)= 'inlist_convert'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_common_converted'
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_convert'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_common_converted'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_convert'
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_finish_header
+++ b/star/test_suite/pisn/inlist_finish_header
@@ -1,52 +1,52 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_common_converted'
-      read_extra_star_job_inlist4 = .true.
-      extra_star_job_inlist4_name = 'inlist_finish'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_common_converted'
+      read_extra_star_job_inlist(4) = .true.
+      extra_star_job_inlist_name(4) = 'inlist_finish'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist2 = .true.
-      extra_eos_inlist2_name = 'inlist_common_converted'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_finish'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(2) = .true.
+      extra_eos_inlist_name(2) = 'inlist_common_converted'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_finish'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_common_converted'
-      read_extra_kap_inlist4 = .true.
-      extra_kap_inlist4_name = 'inlist_finish'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_common_converted'
+      read_extra_kap_inlist(4) = .true.
+      extra_kap_inlist_name(4) = 'inlist_finish'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_common_converted'
-      read_extra_controls_inlist4 = .true.
-      extra_controls_inlist4_name = 'inlist_finish'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_common_converted'
+      read_extra_controls_inlist(4) = .true.
+      extra_controls_inlist_name(4)= 'inlist_finish'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_common_converted'
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_finish'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_common_converted'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_finish'
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_make_late_pre_zams_header
+++ b/star/test_suite/pisn/inlist_make_late_pre_zams_header
@@ -1,32 +1,32 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_make_late_pre_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_make_late_pre_zams'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_mass_Z_wind_rotation'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_make_late_pre_zams'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_make_late_pre_zams'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_make_late_pre_zams'
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_remove_envelope_header
+++ b/star/test_suite/pisn/inlist_remove_envelope_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_remove_envelope'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_remove_envelope'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_remove_envelope'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_remove_envelope'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_remove_envelope'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_remove_envelope'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_remove_envelope'
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_to_end_core_c_burn_header
+++ b/star/test_suite/pisn/inlist_to_end_core_c_burn_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_c_burn'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_c_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_c_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/pisn/inlist_to_end_core_he_burn_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_he_burn'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/pisn/inlist_to_zams_header
+++ b/star/test_suite/pisn/inlist_to_zams_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_zams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/test_suite/ppisn/inlist_ppisn
+++ b/star/test_suite/ppisn/inlist_ppisn
@@ -9,8 +9,8 @@
    ! Zbase defined in inlist_extra
    use_Type2_opacities = .true.
 
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_extra'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_extra'
 /
 
 &eos
@@ -44,8 +44,8 @@
    change_w_div_wc_flag = .true.
    new_w_div_wc_flag = .true.
 
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_extra'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_extra'
 
    pgstar_flag = .false.
    save_pgstar_files_when_terminate = .true.
@@ -113,8 +113,8 @@
    ! in principle this is the only thing that needs changing
    ! it is set in inlist_extra
    !initial_mass = 72
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_extra'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_extra'
 
    ! our wind implementation follows Brott+ 2011
    use_other_wind = .true.

--- a/star/test_suite/ppisn/inlist_pulses
+++ b/star/test_suite/ppisn/inlist_pulses
@@ -1,11 +1,11 @@
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_ppisn'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_ppisn'
 /
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_ppisn'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_ppisn'
 /
 
 &star_job
@@ -18,8 +18,8 @@
    load_saved_model = .true.
    load_model_filename = 'he_dep.mod'
 
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_ppisn'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_ppisn'
 
    change_initial_v_flag = .true.
    new_v_flag = .true.
@@ -29,8 +29,8 @@
 
 &controls
 
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_ppisn'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_ppisn'
 
    x_logical_ctrl(2) = .true.
 
@@ -42,7 +42,7 @@
 
 &pgstar
 
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ppisn/inlist_pulses_header
+++ b/star/test_suite/ppisn/inlist_pulses_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_pulses'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_pulses'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_pulses'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_pulses'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_pulses'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_pulses'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_pulses'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_pulses'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pulses'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pulses'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ppisn/inlist_to_he_dep
+++ b/star/test_suite/ppisn/inlist_to_he_dep
@@ -1,11 +1,11 @@
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_ppisn'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_ppisn'
 /
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_ppisn'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_ppisn'
 /
 
 &star_job
@@ -15,16 +15,16 @@
    save_model_filename = 'he_dep.mod'
    required_termination_code_string = 'xa_central_lower_limit'
 
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_ppisn'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_ppisn'
 
 / !end of star_job namelist
 
 
 &controls
 
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_ppisn'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_ppisn'
 
   ! stop when the center mass fraction of h1 drops below this limit
     xa_central_lower_limit_species(1) = 'he4'
@@ -41,7 +41,7 @@
 
 &pgstar
 
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/ppisn/inlist_to_he_dep_header
+++ b/star/test_suite/ppisn/inlist_to_he_dep_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_to_he_dep'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_to_he_dep'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_to_he_dep'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_to_he_dep'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_to_he_dep'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_to_he_dep'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_to_he_dep'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_to_he_dep'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_to_he_dep'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_to_he_dep'
 
 / ! end of pgstar namelist

--- a/star/test_suite/radiative_levitation/inlist_radiative_levitation_header
+++ b/star/test_suite/radiative_levitation/inlist_radiative_levitation_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_radiative_levitation'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_radiative_levitation'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_radiative_levitation'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_radiative_levitation'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_radiative_levitation'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_radiative_levitation'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_radiative_levitation'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_radiative_levitation'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_radiative_levitation'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_radiative_levitation'
 
 / ! end of pgstar namelist

--- a/star/test_suite/relax_composition_j_entropy/inlist_create_input
+++ b/star/test_suite/relax_composition_j_entropy/inlist_create_input
@@ -13,8 +13,8 @@
 / ! end of star_job namelist
 
 &kap
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -25,8 +25,8 @@
 &controls
     x_integer_ctrl(1) = 1 ! to keep track of the inlist being run
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1)= 'inlist_common'
 
     initial_mass = 10d0
     MLT_option='Cox'

--- a/star/test_suite/relax_composition_j_entropy/inlist_create_input_header
+++ b/star/test_suite/relax_composition_j_entropy/inlist_create_input_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_create_input'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_create_input'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_create_input'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_create_input'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_create_input'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_create_input'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_create_input'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_create_input'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_create_input'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_create_input'
 
 / ! end of pgstar namelist

--- a/star/test_suite/relax_composition_j_entropy/inlist_relax_composition_j_entropy
+++ b/star/test_suite/relax_composition_j_entropy/inlist_relax_composition_j_entropy
@@ -19,8 +19,8 @@
 
 
 &kap
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -44,8 +44,8 @@
     xa_central_lower_limit_species(1) = 'he4'
     xa_central_lower_limit(1) = 1d-3
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1)= 'inlist_common'
     
     use_gold_tolerances = .true.
 

--- a/star/test_suite/relax_composition_j_entropy/inlist_relax_composition_j_entropy_header
+++ b/star/test_suite/relax_composition_j_entropy/inlist_relax_composition_j_entropy_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_relax_composition_j_entropy'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_relax_composition_j_entropy'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_relax_composition_j_entropy'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_relax_composition_j_entropy'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_relax_composition_j_entropy'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_relax_composition_j_entropy'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_relax_composition_j_entropy'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_relax_composition_j_entropy'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_relax_composition_j_entropy'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_relax_composition_j_entropy'
 
 / ! end of pgstar namelist

--- a/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy
+++ b/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy
@@ -38,8 +38,8 @@
 / ! end of star_job namelist
 
 &kap
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_common'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_common'
 
 / ! end of kap namelist
 
@@ -58,8 +58,8 @@
     max_timestep = 1d0
     max_model_number = 1
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_common'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1)= 'inlist_common'
 
 / ! end of controls namelist
 

--- a/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy_header
+++ b/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_start_relax_composition_j_entropy'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_start_relax_composition_j_entropy'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_start_relax_composition_j_entropy'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_start_relax_composition_j_entropy'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_start_relax_composition_j_entropy'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_start_relax_composition_j_entropy'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_start_relax_composition_j_entropy'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_start_relax_composition_j_entropy'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_start_relax_composition_j_entropy'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_start_relax_composition_j_entropy'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP_header
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_BEP'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_BEP'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_BEP'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_BEP'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_BEP'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_BEP'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_BEP'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_BEP'
 
 / ! end of controls namelist
 
@@ -35,10 +35,10 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_pgstar_default'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_BEP'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_BEP'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_header
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_BLAP'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_BLAP'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_BLAP'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_BLAP'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_BLAP'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_BLAP'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_BLAP'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_BLAP'
 
 / ! end of controls namelist
 
@@ -35,11 +35,11 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_pgstar_default'
 
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_BLAP'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_BLAP'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_header
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_Cepheid'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_Cepheid'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_Cepheid'
 
 / ! end of controls namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_Cepheid'
 
 / ! end of controls namelist
 
@@ -35,11 +35,11 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_pgstar_default'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_Cepheid'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_Cepheid'
       
       
 

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_header
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_Cepheid'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_Cepheid'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_Cepheid'
 
 / ! end of controls namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_Cepheid'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_Cepheid'
 
 / ! end of controls namelist
 
@@ -35,11 +35,11 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_pgstar_default'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_Cepheid'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_Cepheid'
       
       
 

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_header
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_Delta_Scuti'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_Delta_Scuti'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_Delta_Scuti'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_Delta_Scuti'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_Delta_Scuti'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_Delta_Scuti'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_Delta_Scuti'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_Delta_Scuti'
 
 / ! end of controls namelist
 
@@ -35,10 +35,10 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_pgstar_default'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_Delta_Scuti'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_Delta_Scuti'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_header
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_RR_Lyrae'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_RR_Lyrae'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_RR_Lyrae'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_RR_Lyrae'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_RR_Lyrae'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_RR_Lyrae'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_RR_Lyrae'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_RR_Lyrae'
 
 / ! end of controls namelist
 
@@ -35,11 +35,11 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_pgstar_default'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_RR_Lyrae'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_RR_Lyrae'
 
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_header
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_header
@@ -2,32 +2,32 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_Type_II_Cepheid'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_Type_II_Cepheid'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_Type_II_Cepheid'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_Type_II_Cepheid'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_Type_II_Cepheid'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_Type_II_Cepheid'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_Type_II_Cepheid'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_Type_II_Cepheid'
 
 / ! end of controls namelist
 
@@ -35,10 +35,10 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pulse_pgstar_default'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pulse_pgstar_default'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_Type_II_Cepheid'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_Type_II_Cepheid'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_check_2nd_crossing/inlist_rsp_check_2nd_crossing_header
+++ b/star/test_suite/rsp_check_2nd_crossing/inlist_rsp_check_2nd_crossing_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_check_2nd_crossing'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_check_2nd_crossing'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_check_2nd_crossing'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_check_2nd_crossing'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_check_2nd_crossing'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_check_2nd_crossing'
 
 / ! end of kap namelist
 
@@ -27,8 +27,8 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_check_2nd_crossing'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_check_2nd_crossing'
 
 / ! end of controls namelist
 

--- a/star/test_suite/rsp_gyre/inlist_rsp_gyre_header
+++ b/star/test_suite/rsp_gyre/inlist_rsp_gyre_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_rsp_gyre'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_rsp_gyre'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_gyre'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_gyre'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_gyre'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_gyre'
 
 / ! end of kap namelist
 
@@ -27,8 +27,8 @@
 
 &controls
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_rsp_gyre'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_rsp_gyre'
 
 / ! end of controls namelist
 
@@ -36,11 +36,11 @@
 
 &pgstar
 
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_pgstar_cepheid'
-      read_extra_pgstar_inlist3 = .true.
-      extra_pgstar_inlist3_name = 'inlist_rsp_gyre'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_pgstar_cepheid'
+      read_extra_pgstar_inlist(3) = .true.
+      extra_pgstar_inlist_name(3)= 'inlist_rsp_gyre'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_save_and_load_file/inlist_rsp_load_file_header
+++ b/star/test_suite/rsp_save_and_load_file/inlist_rsp_load_file_header
@@ -2,45 +2,45 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_rsp_load_file'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_rsp_load_file'
 
 / ! end of star_job namelist
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_common'
 
 / ! end of controls namelist
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_common'
 
 / ! end of controls namelist
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_rsp_load_file'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_rsp_load_file'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_load_file'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_load_file'
 
 / ! end of pgstar namelist

--- a/star/test_suite/rsp_save_and_load_file/inlist_rsp_save_file_header
+++ b/star/test_suite/rsp_save_and_load_file/inlist_rsp_save_file_header
@@ -2,35 +2,35 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_rsp_common'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_rsp_common'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_rsp_save_file'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_rsp_save_file'
 
 / ! end of star_job namelist
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_rsp_common'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_rsp_common'
 
 / ! end of controls namelist
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_rsp_common'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_rsp_common'
 
 / ! end of controls namelist
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_rsp_common'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_rsp_common'
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_rsp_save_file'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_rsp_save_file'
 
 / ! end of controls namelist
 
@@ -38,10 +38,10 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_rsp_common'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_rsp_common'
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_rsp_save_file'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_rsp_save_file'
 
 / ! end of pgstar namelist

--- a/star/test_suite/semiconvection/inlist_semiconvection_header
+++ b/star/test_suite/semiconvection/inlist_semiconvection_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_semiconvection'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_semiconvection'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_semiconvection'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_semiconvection'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_semiconvection'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_semiconvection'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_semiconvection'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_semiconvection'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_semiconvection'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_semiconvection'
 
 / ! end of pgstar namelist

--- a/star/test_suite/simplex_solar_calibration/inlist_prezams_header
+++ b/star/test_suite/simplex_solar_calibration/inlist_prezams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_prezams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_prezams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_prezams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_prezams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_prezams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_prezams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_prezams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_prezams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_prezams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_prezams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/simplex_solar_calibration/inlist_solar_header
+++ b/star/test_suite/simplex_solar_calibration/inlist_solar_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_solar'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_solar'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_solar'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_solar'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_solar'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_solar'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_solar'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_solar'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_solar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_solar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/split_burn_big_net/inlist_big_net_header
+++ b/star/test_suite/split_burn_big_net/inlist_big_net_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_big_net'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_big_net'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_big_net'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_big_net'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_big_net'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_big_net'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_big_net'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_big_net'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_big_net'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_big_net'
 / ! end of pgstar namelist

--- a/star/test_suite/starspots/inlist_starspots_header
+++ b/star/test_suite/starspots/inlist_starspots_header
@@ -3,39 +3,39 @@
 
       mesa_dir = '../../..'
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_starspots'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_starspots'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_starspots'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_starspots'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_starspots'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_starspots'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_starspots'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_starspots'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_starspots'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_starspots'
 
 / ! end of pgstar namelist

--- a/star/test_suite/test_case_template/inlist_start_header
+++ b/star/test_suite/test_case_template/inlist_start_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_x'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_x'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_x'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_x'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_x'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_x'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_x'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_x'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_x'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_x'
 
 / ! end of pgstar namelist

--- a/star/test_suite/test_case_template/inlist_x_header
+++ b/star/test_suite/test_case_template/inlist_x_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_x'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_x'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_x'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_x'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_x'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_x'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_x'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_x'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_x'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_x'
 
 / ! end of pgstar namelist

--- a/star/test_suite/timing/inlist_timing_header
+++ b/star/test_suite/timing/inlist_timing_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_timing'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_timing'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_timing'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_timing'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_timing'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_timing'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_timing'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_timing'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_timing'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_timing'
 
 / ! end of pgstar namelist

--- a/star/test_suite/timing/inlist_zams_header
+++ b/star/test_suite/timing/inlist_zams_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_zams'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_zams'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_zams'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_zams'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_zams'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_zams'
 
 / ! end of pgstar namelist

--- a/star/test_suite/twin_studies/inlist_star1_header
+++ b/star/test_suite/twin_studies/inlist_star1_header
@@ -1,35 +1,35 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_star1'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_to_end_core_he_burn_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_star1'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_star1'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_to_end_core_he_burn_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_star1'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_star1'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_to_end_core_he_burn_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_star1'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_star1'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_to_end_core_he_burn_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_star1'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_star1'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_to_end_core_he_burn_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_star1'
 / ! end of pgstar namelist

--- a/star/test_suite/twin_studies/inlist_star2_header
+++ b/star/test_suite/twin_studies/inlist_star2_header
@@ -1,35 +1,35 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_star2'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_to_end_core_he_burn_header'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_star2'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_eos_inlist2 = .true.
-   extra_eos_inlist2_name = 'inlist_star2'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_to_end_core_he_burn_header'
+   read_extra_eos_inlist(2) = .true.
+   extra_eos_inlist_name(2) = 'inlist_star2'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_star2'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_to_end_core_he_burn_header'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_star2'
 / ! end of kap namelist
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_star2'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_to_end_core_he_burn_header'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_star2'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_to_end_core_he_burn_header'
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_star2'
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_to_end_core_he_burn_header'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_star2'
 / ! end of pgstar namelist

--- a/star/test_suite/twin_studies/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/twin_studies/inlist_to_end_core_he_burn_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_he_burn'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/wd_acc_small_dm/inlist_wd_acc_small_dm_header
+++ b/star/test_suite/wd_acc_small_dm/inlist_wd_acc_small_dm_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_acc_small_dm'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_acc_small_dm'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_acc_small_dm'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_acc_small_dm'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_acc_small_dm'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_acc_small_dm'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_wd_acc_small_dm'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_wd_acc_small_dm'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_aic/inlist_accrete_header
+++ b/star/test_suite/wd_aic/inlist_accrete_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_accrete'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_accrete'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_accrete'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_accrete'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_accrete'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_accrete'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_accrete'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_accrete'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_aic/inlist_initial_model_header
+++ b/star/test_suite/wd_aic/inlist_initial_model_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_initial_model'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_initial_model'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_initial_model'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_initial_model'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_initial_model'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_initial_model'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_initial_model'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_initial_model'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_aic/inlist_relax_composition_header
+++ b/star/test_suite/wd_aic/inlist_relax_composition_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_relax_composition'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_relax_composition'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_relax_composition'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_relax_composition'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_relax_composition'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_relax_composition'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_relax_composition'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_relax_composition'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_aic/inlist_wd_aic_header
+++ b/star/test_suite/wd_aic/inlist_wd_aic_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_aic'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_aic'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_aic'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_aic'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_aic'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_aic'
 
 / ! end of kap namelist
 
@@ -28,15 +28,15 @@
 
       x_integer_ctrl(1) = 1 ! part number
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_wd_aic'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_wd_aic'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_c_core_ignition/inlist_relax_mass_header
+++ b/star/test_suite/wd_c_core_ignition/inlist_relax_mass_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_relax_mass'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_relax_mass'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_relax_mass'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_relax_mass'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_relax_mass'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_relax_mass'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_relax_mass'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_relax_mass'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_relax_mass'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_relax_mass'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_c_core_ignition/inlist_wd_c_core_ignition_header
+++ b/star/test_suite/wd_c_core_ignition/inlist_wd_c_core_ignition_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_c_core_ignition'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_c_core_ignition'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_c_core_ignition'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_c_core_ignition'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_c_core_ignition'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_c_core_ignition'
 
 / ! end of kap namelist
 
@@ -27,16 +27,16 @@
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_c_core_ignition'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_c_core_ignition'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_c_core_ignition'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_c_core_ignition'
 
 / ! end of kap namelist
 
@@ -44,15 +44,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_wd_c_core_ignition'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_wd_c_core_ignition'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_wd_c_core_ignition'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_wd_c_core_ignition'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_cool_0.6M/inlist_wd_cool_0.6M_header
+++ b/star/test_suite/wd_cool_0.6M/inlist_wd_cool_0.6M_header
@@ -2,39 +2,39 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_cool_0.6M'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_cool_0.6M'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_cool_0.6M'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_cool_0.6M'
 
 / ! end of controls namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_cool_0.6M'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_cool_0.6M'
 
 / ! end of kap namelist
 
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_wd_cool_0.6M'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_wd_cool_0.6M'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_wd_cool_0.6M'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_wd_cool_0.6M'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_diffusion/inlist_wd_diff_header
+++ b/star/test_suite/wd_diffusion/inlist_wd_diff_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_diff'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_diff'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_diff'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_diff'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_diff'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_diff'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_wd_diff'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_wd_diff'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_wd_diff'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_wd_diff'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_he_shell_ignition/inlist_he_shell_ignition_header
+++ b/star/test_suite/wd_he_shell_ignition/inlist_he_shell_ignition_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_he_shell_ignition'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_he_shell_ignition'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_he_shell_ignition'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_he_shell_ignition'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_he_shell_ignition'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_he_shell_ignition'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_he_shell_ignition'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_he_shell_ignition'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_he_shell_ignition'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_he_shell_ignition'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_nova_burst/inlist_setup_header
+++ b/star/test_suite/wd_nova_burst/inlist_setup_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_setup'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_setup'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_setup'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_setup'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_setup'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_setup'
 
 / ! end of kap namelist
 
@@ -27,8 +27,8 @@
 
 &controls
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_setup'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_setup'
 
 / ! end of controls namelist
 
@@ -36,7 +36,7 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_setup'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_setup'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_nova_burst/inlist_wd_nova_burst_header
+++ b/star/test_suite/wd_nova_burst/inlist_wd_nova_burst_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_nova_burst'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_nova_burst'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_nova_burst'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_nova_burst'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_nova_burst'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_nova_burst'
 
 / ! end of kap namelist
 
@@ -27,8 +27,8 @@
 
 &controls
 
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_wd_nova_burst'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_wd_nova_burst'
 
 / ! end of controls namelist
 
@@ -36,7 +36,7 @@
 
 &pgstar
 
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_wd_nova_burst'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_wd_nova_burst'
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_stable_h_burn/inlist_wd_stable_h_burn_header
+++ b/star/test_suite/wd_stable_h_burn/inlist_wd_stable_h_burn_header
@@ -2,24 +2,24 @@
 &star_job
 
 
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_wd_stable_h_burn'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_wd_stable_h_burn'
 
 / ! end of star_job namelist
 
 
 &eos
 
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_wd_stable_h_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_wd_stable_h_burn'
 
 / ! end of eos namelist
 
 
 &kap
 
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_wd_stable_h_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_wd_stable_h_burn'
 
 / ! end of kap namelist
 
@@ -27,15 +27,15 @@
 
 &controls
 
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_wd_stable_h_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_wd_stable_h_burn'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_wd_stable_h_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_wd_stable_h_burn'
 
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_make_late_pre_zams_header
+++ b/star/test_suite/zams_to_cc_80/inlist_make_late_pre_zams_header
@@ -1,37 +1,37 @@
 
 &star_job
-   read_extra_star_job_inlist1 = .true.
-   extra_star_job_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_star_job_inlist2 = .true.
-   extra_star_job_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_star_job_inlist(2) = .true.
+   extra_star_job_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of star_job namelist
 
 &eos
-   read_extra_eos_inlist1 = .true.
-   extra_eos_inlist1_name = 'inlist_make_late_pre_zams'
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_make_late_pre_zams'
 / ! end of eos namelist
 
 &kap
-   read_extra_kap_inlist1 = .true.
-   extra_kap_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_kap_inlist2 = .true.
-   extra_kap_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_mass_Z_wind_rotation'
+   read_extra_kap_inlist(2) = .true.
+   extra_kap_inlist_name(2) = 'inlist_make_late_pre_zams'
 / ! end of kap namelist
 
 
 &controls
-   read_extra_controls_inlist1 = .true.
-   extra_controls_inlist1_name = 'inlist_mass_Z_wind_rotation'
-   read_extra_controls_inlist2 = .true.
-   extra_controls_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_mass_Z_wind_rotation'
+   read_extra_controls_inlist(2) = .true.
+   extra_controls_inlist_name(2)= 'inlist_make_late_pre_zams'
 / ! end of controls namelist
 
 &pgstar
-   read_extra_pgstar_inlist1 = .true.
-   extra_pgstar_inlist1_name = 'inlist_pgstar' 
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'
    
-   read_extra_pgstar_inlist2 = .true.
-   extra_pgstar_inlist2_name = 'inlist_make_late_pre_zams'
+   read_extra_pgstar_inlist(2) = .true.
+   extra_pgstar_inlist_name(2)= 'inlist_make_late_pre_zams'
 
 
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_remove_envelope_header
+++ b/star/test_suite/zams_to_cc_80/inlist_remove_envelope_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_remove_envelope'      
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_remove_envelope'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_remove_envelope'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_remove_envelope'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_remove_envelope'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_remove_envelope'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_remove_envelope'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_remove_envelope'
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_to_cc_header
+++ b/star/test_suite/zams_to_cc_80/inlist_to_cc_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_cc'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_cc'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_cc'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_cc'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_cc'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_cc'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_cc'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_cc'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_cc'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_cc'
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_to_end_core_c_burn_header
+++ b/star/test_suite/zams_to_cc_80/inlist_to_end_core_c_burn_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_c_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_c_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_c_burn'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_c_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_c_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_to_end_core_he_burn_header
+++ b/star/test_suite/zams_to_cc_80/inlist_to_end_core_he_burn_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_end_core_he_burn'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_end_core_he_burn'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_end_core_he_burn'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_end_core_he_burn'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_end_core_he_burn'
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_to_lgTmax_header
+++ b/star/test_suite/zams_to_cc_80/inlist_to_lgTmax_header
@@ -1,42 +1,42 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_lgTmax'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_lgTmax'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_lgTmax'
 / ! end of controls namelist
 
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_lgTmax'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_lgTmax'
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_to_zams_header
+++ b/star/test_suite/zams_to_cc_80/inlist_to_zams_header
@@ -1,41 +1,41 @@
 
 &star_job
-      read_extra_star_job_inlist1 = .true.
-      extra_star_job_inlist1_name = 'inlist_common'
-      read_extra_star_job_inlist2 = .true.
-      extra_star_job_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_star_job_inlist3 = .true.
-      extra_star_job_inlist3_name = 'inlist_to_zams'
+      read_extra_star_job_inlist(1) = .true.
+      extra_star_job_inlist_name(1) = 'inlist_common'
+      read_extra_star_job_inlist(2) = .true.
+      extra_star_job_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_star_job_inlist(3) = .true.
+      extra_star_job_inlist_name(3) = 'inlist_to_zams'
 / ! end of star_job namelist
 
 &eos
-      read_extra_eos_inlist1 = .true.
-      extra_eos_inlist1_name = 'inlist_common'
-      read_extra_eos_inlist3 = .true.
-      extra_eos_inlist3_name = 'inlist_to_zams'
+      read_extra_eos_inlist(1) = .true.
+      extra_eos_inlist_name(1) = 'inlist_common'
+      read_extra_eos_inlist(3) = .true.
+      extra_eos_inlist_name(3) = 'inlist_to_zams'
 / ! end of eos namelist
 
 &kap
-      read_extra_kap_inlist1 = .true.
-      extra_kap_inlist1_name = 'inlist_common'
-      read_extra_kap_inlist2 = .true.
-      extra_kap_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_kap_inlist3 = .true.
-      extra_kap_inlist3_name = 'inlist_to_zams'
+      read_extra_kap_inlist(1) = .true.
+      extra_kap_inlist_name(1) = 'inlist_common'
+      read_extra_kap_inlist(2) = .true.
+      extra_kap_inlist_name(2) = 'inlist_mass_Z_wind_rotation'
+      read_extra_kap_inlist(3) = .true.
+      extra_kap_inlist_name(3) = 'inlist_to_zams'
 / ! end of kap namelist
 
 &controls
-      read_extra_controls_inlist1 = .true.
-      extra_controls_inlist1_name = 'inlist_common'
-      read_extra_controls_inlist2 = .true.
-      extra_controls_inlist2_name = 'inlist_mass_Z_wind_rotation'
-      read_extra_controls_inlist3 = .true.
-      extra_controls_inlist3_name = 'inlist_to_zams'
+      read_extra_controls_inlist(1) = .true.
+      extra_controls_inlist_name(1)= 'inlist_common'
+      read_extra_controls_inlist(2) = .true.
+      extra_controls_inlist_name(2)= 'inlist_mass_Z_wind_rotation'
+      read_extra_controls_inlist(3) = .true.
+      extra_controls_inlist_name(3)= 'inlist_to_zams'
 / ! end of controls namelist
 
 &pgstar
-      read_extra_pgstar_inlist1 = .true.
-      extra_pgstar_inlist1_name = 'inlist_pgstar'
-      read_extra_pgstar_inlist2 = .true.
-      extra_pgstar_inlist2_name = 'inlist_to_zams'
+      read_extra_pgstar_inlist(1) = .true.
+      extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+      read_extra_pgstar_inlist(2) = .true.
+      extra_pgstar_inlist_name(2)= 'inlist_to_zams'
 / ! end of pgstar namelist

--- a/star/work/inlist
+++ b/star/work/inlist
@@ -6,39 +6,39 @@
 
 &star_job
 
-    read_extra_star_job_inlist1 = .true.
-    extra_star_job_inlist1_name = 'inlist_project'
+    read_extra_star_job_inlist(1) = .true.
+    extra_star_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
 
 &eos
 
-    read_extra_eos_inlist1 = .true.
-    extra_eos_inlist1_name = 'inlist_project'
+    read_extra_eos_inlist(1) = .true.
+    extra_eos_inlist_name(1) = 'inlist_project'
 
 / ! end of eos namelist
 
 
 &kap
 
-    read_extra_kap_inlist1 = .true.
-    extra_kap_inlist1_name = 'inlist_project'
+    read_extra_kap_inlist(1) = .true.
+    extra_kap_inlist_name(1) = 'inlist_project'
 
 / ! end of kap namelist
 
 
 &controls
 
-    read_extra_controls_inlist1 = .true.
-    extra_controls_inlist1_name = 'inlist_project'
+    read_extra_controls_inlist(1) = .true.
+    extra_controls_inlist_name(1)= 'inlist_project'
 
 / ! end of controls namelist
 
 
 &pgstar
 
-    read_extra_pgstar_inlist1 = .true.
-    extra_pgstar_inlist1_name = 'inlist_pgstar'
+    read_extra_pgstar_inlist(1) = .true.
+    extra_pgstar_inlist_name(1)= 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star/work/inlist
+++ b/star/work/inlist
@@ -31,7 +31,7 @@
 &controls
 
     read_extra_controls_inlist(1) = .true.
-    extra_controls_inlist_name(1)= 'inlist_project'
+    extra_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
@@ -39,6 +39,6 @@
 &pgstar
 
     read_extra_pgstar_inlist(1) = .true.
-    extra_pgstar_inlist_name(1)= 'inlist_pgstar'
+    extra_pgstar_inlist_name(1) = 'inlist_pgstar'
 
 / ! end of pgstar namelist

--- a/star_data/private/pgstar_controls.inc
+++ b/star_data/private/pgstar_controls.inc
@@ -2076,22 +2076,8 @@
       character :: annotation3_side
       real :: annotation3_disp, annotation3_coord, annotation3_fjust
 
-
-
-      logical :: read_extra_pgstar_inlist1
-      character (len=strlen) :: extra_pgstar_inlist1_name
-
-      logical :: read_extra_pgstar_inlist2
-      character (len=strlen) :: extra_pgstar_inlist2_name
-
-      logical :: read_extra_pgstar_inlist3
-      character (len=strlen) :: extra_pgstar_inlist3_name
-
-      logical :: read_extra_pgstar_inlist4
-      character (len=strlen) :: extra_pgstar_inlist4_name
-
-      logical :: read_extra_pgstar_inlist5
-      character (len=strlen) :: extra_pgstar_inlist5_name
+      logical, dimension(max_extra_inlists) :: read_extra_pgstar_inlist
+      character (len=strlen), dimension(max_extra_inlists) :: extra_pgstar_inlist_name
 
       logical :: Abundance_use_decorator, &
             Color_Magnitude1_use_decorator, &

--- a/star_data/private/star_job_controls.inc
+++ b/star_data/private/star_job_controls.inc
@@ -334,20 +334,8 @@
 
       character (len=strlen) :: rate_tables_dir, rate_cache_suffix
 
-      logical :: read_extra_star_job_inlist1
-      character (len=strlen) :: extra_star_job_inlist1_name
-
-      logical :: read_extra_star_job_inlist2
-      character (len=strlen) :: extra_star_job_inlist2_name
-
-      logical :: read_extra_star_job_inlist3
-      character (len=strlen) :: extra_star_job_inlist3_name
-
-      logical :: read_extra_star_job_inlist4
-      character (len=strlen) :: extra_star_job_inlist4_name
-
-      logical :: read_extra_star_job_inlist5
-      character (len=strlen) :: extra_star_job_inlist5_name
+      logical, dimension(max_extra_inlists) :: read_extra_star_job_inlist
+      character (len=strlen), dimension(max_extra_inlists) :: extra_star_job_inlist_name
 
       integer :: save_pulse_data_for_model_number
       logical :: save_pulse_data_when_terminate

--- a/star_data/private/star_job_controls_params.inc
+++ b/star_data/private/star_job_controls_params.inc
@@ -1,2 +1,2 @@
-      integer, parameter :: max_extras_params = 20, max_extras_cpar_len = strlen
-      integer, parameter :: max_num_special_rate_factors = 20
+      integer, parameter :: max_extras_params = 20, max_extras_cpar_len = strlen, &
+            max_num_special_rate_factors = 20, star_num_xtra_vals = 30

--- a/star_data/public/star_data_def.f90
+++ b/star_data/public/star_data_def.f90
@@ -29,7 +29,7 @@
       use rates_def, only: rates_reaction_id_max, other_screening_interface, other_rate_get_interface
       use utils_def, only: integer_dict
       use chem_def, only: num_categories, iso_name_length
-      use const_def, only: sp, dp, qp, strlen
+      use const_def, only: sp, dp, qp, strlen, max_extra_inlists
       use rates_def, only: maxlen_reaction_Name
       use eos_def, only: EoS_General_Info
       use kap_def, only: Kap_General_Info
@@ -41,12 +41,7 @@
       implicit none      
       
       include "star_data_def.inc"
-      
-      integer, parameter :: max_extras_params = 20, max_extras_cpar_len = strlen
-      integer, parameter :: max_num_special_rate_factors = 20
-
-      integer, parameter :: star_num_xtra_vals = 30
-
+      include "star_job_controls_params.inc"
       type star_job_controls
          include "star_job_controls.inc"
          include "star_job_controls_dev.inc"


### PR DESCRIPTION
This PR just exists to migrate #470 (@matthiasfabry) from a testing branch into main once it is ready. I'll leave it as a draft PR until testing is complete and @warrickball's comments are addressed.

https://github.com/MESAHub/mesa/pull/470#issuecomment-1359639171
> Nice! As I already said in the issue, I think this is an improvement and, at a glance, it looks like you've caught all the occurrences (including in the docs!). I think three things remain to be done.
> 
> 1. The `astero` module should be refactored in the same way. This should be straightforward.
> 2. Can you merge into a target branch `MESAHub:inlist_arrays`? We learned from the last PR that we should do things that way so we can run the full test suite before merging with `MESAHub:main`. We might need to create the `MESAHub:inlist_arrays` branch for you to merge into.
> 3. This will be disruptive for users, so it'd be nice to distribute a script that will make the appropriate changes. I haven't cooked one up but I imagine there's a single `sed` command that will do it, though we need something that works on both Macs and Linux.
> 
> Also, though I don't mind too much, I would've gone a step further and removed the `read_extra_star_job_inlist` logical completely in favour of just ignoring empty filenames but perhaps there's a use case I'm not foreseeing.

