### PR TITLE
allow access to `do_star_job_controls_before`

### DIFF
--- a/star/job/run_star_support.f90
+++ b/star/job/run_star_support.f90
@@ -54,7 +54,7 @@
       public :: failed
       public :: id_from_read_star_job
       public :: MESA_INLIST_RESOLVED
-      public :: do_star_job_controls_after
+      public :: do_star_job_controls_before, do_star_job_controls_after
       
       ! deprecated, but kept around for use by binary
       public :: before_evolve_loop, after_step_loop, before_step_loop, do_saves, &


### PR DESCRIPTION
allow access to `do_star_job_controls_before` in `run_star_support`, which is needed by `data/star_data/zams_models/create_zams_models`.

I'm not entirely sure why this module turned private since r15140, but `create_zams_models` is pretty useful imo and someone forgot to leave this function public. In general, do we risk anything by leaving stuff public? Maybe name clashes or the like?