### PR TITLE
Updates to some documentation about the structure of MESA Developers

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -96,8 +96,8 @@ The missions of the MESA Team are:
   facilitating and encouraging appropriate scientific collaborative
 
 
-1st Author
-----------
+1st Author Emeritus
+-------------------
 
 * `Bill Paxton <https://www.kitp.ucsb.edu/paxton>`__
 
@@ -112,7 +112,6 @@ Developers
 * Aaron Dotter
 * `Robert Farmer <http://rjfarmer.io/>`__
 * Eoin Farrell
-* `Adam Jermyn <http://adamjermyn.com/>`__
 * `Meridith Joyce <http://www.meridithjoyce.com/>`__
 * Pablo Marchant
 * `Radek Smolec <https://www.camk.edu.pl/en/staff/smolec/>`__
@@ -126,6 +125,7 @@ Past Developers
 
 * `Ed Brown <http://web.pa.msu.edu/people/ebrown/>`__
 * `Falk Herwig <http://www.astro.uvic.ca/~fherwig/>`__
+* `Adam Jermyn <http://adamjermyn.com/>`__
 * `Josiah Schwab <https://yoshiyahu.org/>`__ (2013-2021)
 
 

--- a/docs/source/developing/collaboration.rst
+++ b/docs/source/developing/collaboration.rst
@@ -82,31 +82,17 @@ is appropriate and documented, and communicating individual developer
 contributions to the astrophysics community so that the careers of
 developers are enhanced by their engagement.
 
+Currently, the MAC is Lars, Rich, and Frank.
+
 **Onboarding and offboarding processes**
 
 These groups are not static and will change as individuals' engagement
 with MESA evolves. If someone is permanently or temporarily unable to
-fulfill their responsibilities, they must inform the MAC of the
-situation. The MAC will reevaluate the membership of these groups on a
-recurring basis. Removal from MD, MTC, and MAC can be for inactivity,
+fulfill their responsibilities, they must inform the MD.
+Removal from MD, MTC, and MAC can be for inactivity,
 harm to the Project, or simply opting out.
 
-Onboarding to MD is done by the MAC in consultation with the MTC and
-the MD.  When a candidate developer is identified, there will be a
-comment period where any MD can privately provide feedback to the MAC
-about the addition to the MESA team.  Nominations and suggestions from
-any MDs are welcome. Currently, the MD are Bill P., Warrick, Evan,
-Earl, Lars, Matteo, Aaron, Rob, Adam, Meridith, Pablo, Radek,
-Anne, Rich, Bill W, and Frank.
-
-As MESA's "first author", Bill is an ex-officio member of both MAC and
-MTC.
-
-Initially, the MTC has members appointed by Bill Paxton. These are
-Rich, Pablo, and Rob.
-
-Currently, the MAC is Lars, Rich, and Frank.
-
+Onboarding to the MD is described :doc:`here <developing/new_developers>`.
 
 Instrument Paper Principles
 ===========================
@@ -118,7 +104,7 @@ Instrument Paper Principles
 How do authorship invitations arise?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-During the completion of the first five MESA Instrument Papers, there have been multiple channels for co-author invitations.
+During the completion of the first six MESA Instrument Papers, there have been multiple channels for co-author invitations.
 
 - Running a non-MESA code in a controlled and engaged manner that enables verification of a NEW MESA capability (e.g., Dessart for shocks).
 
@@ -148,9 +134,4 @@ Prospective co-authors should be prepared to participate by:
 
 The MAC can relax any of these four items when there is value in doing so.
 
-
-How is it decided who the authors are and their order?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Final authorship and order is decided by the MAC only near the completion time of the paper.
 

--- a/docs/source/developing/infrastructure.rst
+++ b/docs/source/developing/infrastructure.rst
@@ -54,7 +54,7 @@ ReadTheDocs
 -----------
 
 The Sphinx documentation is hosted by `ReadTheDocs
-<https://readthedocs.org/>`__.  Rich controls the account (and Rob has access to it).  This is
+<https://readthedocs.org/>`__.  Rich controls the account (and Rob and Evan have access to it).  This is
 currently free for open source software.
 
 
@@ -68,11 +68,10 @@ service.
 Website
 ^^^^^^^
 
-We still use the mesa.sourceforge.net website domian name.  
-The source code for this site lives at https://github.com/MESAHub/mesa-website. 
-It must be manually updated by someone with SourceForge permissions.
+We still use the mesa.sourceforge.net website domian name, but only for a top-level
+redirect to docs.mesastar.org.
 
-This site will be made redundant soon and replaced with a redirect to the ReadTheDocs website.
+The source code for the old sourceforge site lives at https://github.com/MESAHub/mesa-website.
 
 Slack
 -----
@@ -115,6 +114,6 @@ is controlled by Pablo.
 Records
 ^^^^^^^
 
-* The `record for MESA releases <https://zenodo.org/record/4311514>`__ is controlled by Josiah.
+* The `record for MESA releases <https://zenodo.org/record/4311514>`__ is controlled by Pablo.
 * The `record for OP Mono data <https://zenodo.org/record/4390522>`__ is controlled by Josiah.
 * The records for MESA SDK releases (`macOS <https://zenodo.org/record/4638654>`__, `linux <https://zenodo.org/record/4638535>`__) are controlled by Pablo.

--- a/docs/source/developing/new_developers.rst
+++ b/docs/source/developing/new_developers.rst
@@ -9,7 +9,7 @@ New developers
 What is a developer?
 --------------------
 
-A developer is someone who commits to spend (some) time helping to run and maintain the MESA project. This can include adding new code and documentation but also includes many other tasks that are needed to keep the project running. These include (but not limited to) managing and maintaining infrastructure, running meetings, triaging bug reports, merging Pull Requests, applying for funding for infrastructure, and providing technical and scientific knowledge to other developers.  The amount of time someone commits is up to the individual to decide on, and it is expected to vary over time as various other tasks take priority.
+A developer is someone who commits to spend (some) time helping to run and maintain the MESA project. This can include adding new code and documentation but also includes many other tasks that are needed to keep the project running. These include (but are not limited to) managing and maintaining infrastructure, running meetings, triaging bug reports, merging Pull Requests, applying for funding for infrastructure, and providing technical and scientific knowledge to other developers.  The amount of time someone commits is up to the individual to decide on, and it is expected to vary over time as various other tasks take priority.
 
 If you simply want to fix a bug or get some new code added to MESA then you don't need to be a developer. We welcome PR's and bug reports from the community and you don't need to be a developer to contribute that way. Only if you want to take a more active role in managing the MESA project do you need to be a developer.
 
@@ -33,50 +33,49 @@ Process:
 * To veto someone then either:
 
   * Two separate people should raise objections on their own in either slack or mesa-dev.
-  * Or, one person raises an objection and for privacy reasons they do not want to share this with the entire developer group. In which case they should discuss with another developer, who they trust, and that person can raise the second veto. In this case objections should be communicated to the nominator directly, but the objector does not have to share their reasons.
+  * Or, one person raises an objection and for privacy reasons they do not want to share this with the entire developer group. In this case, they should discuss with another developer, whom they trust, and that person can raise the second veto. In this case objections should be communicated to the nominator directly, but the objector does not have to share their reasons.
 
-If after the minimum time has elapsed there are insufficient objections then the new developer is approved.
+If after the minimum time has elapsed there are insufficient objections, then the new developer is approved.
 
 .. note::
     With this process we are attempting to balance having a flexible procedure for bringing in new developers while providing an environment that all developers can work safely in. There may be reasons why someone does not want to share the reasons for vetoing someone. However we also want to balance the possibility for abuse of the system by allowing arbitrary vetoes, which may preclude people from certain groups. We are adopting this process through the calendar year 2023, and plan to evaluate and vote on whether to make it permanent at the beginning of 2024.
 
-Post acceptance
+Post Acceptance
 ---------------
 
-Assuming the new developer has been accepted then the nominator:
+Assuming the new developer has been accepted, the nominator:
 
 * Makes sure the new developer agrees to the code of conduct and knows that discussions on dev channels should be considered private and may include work in progress and thus should not be shared.
-* Makes sure the new developer gets access to the infrastructure (github, slack, mesa-dev, testhub)
+* Makes sure the new developer gets access to the infrastructure (github, slack, mesa-dev, testhub).
 * Acts as a mentor to the new developer, helping them to get used to the system and the way things are done. This includes making commits, merging PR's, and general development tasks.
 
-Removing a developer
+Removing a Developer
 --------------------
 
 At any time an existing developer can retire for any reason if they need to step back from working on MESA.
 
-At times it may be required to forcibly remove an individual from the developer community. This is a serious action and should not be taken lightly. Reasons for this may include (but not limited to) violations of the code of conduct, abuse or harassment of others, or issues of scientific integrity.
+At times it may be required to forcibly remove an individual from the developer community. This is a serious action and should not be taken lightly. Reasons for this may include (but are not limited to) violations of the code of conduct, abuse or harassment of others, or issues of scientific integrity.
 
 In the event that a developer needs to be removed, then an existing developer should call a vote to remove the person. This vote should be seconded by another developer. Removal then requires a majority of existing developers to vote for removal. If the developer is removed then commit access to MESA will be removed, as well as the developer's access to the MESA developers communication channels (slack, mesa-dev).
 
 In exceptional time-sensitive circumstances the administrators of the MESA infrastructure (mailing lists, github, slack, testhub) may suspend a developer's access if they feel that waiting for a vote would not be appropriate. Reasons can include (but are not limited to): posting abusive messages, denial or degradation of service, committing malicious code, or other actions that the admin feels is damaging the infrastructure. This is not a removal from being a developer, but should be considered a serious issue. The admin should discuss their reasons at the earliest opportunity with the other developers, and this must lead either to a vote to remove the developer or a clear path toward ending the suspension.
 
-Approving this document
+Approving This Document
 -----------------------
 
-As we do not currently have a process for approving documents of this nature we need to bootstrap this process.
+This document was approved by unanimous consent of the current MESA Developers as of December 2022.
 
-Once the document has been iterated on it will be put to a vote of all current developers. Hopefully we can iterate this such that everyone is happy before we put this document to a vote. If someone has serious concerns then please raise them before the vote.
+Changing This Document
+----------------------
+
+Changes to this document will follow the same process as the initial approval process.
+
+Changes will be put to a vote of all current developers. If someone has serious concerns then please raise them before the vote.
 Acceptance will require unanimous consent.
 Abstentions will count as implicit approval. Thus only a direct no vote will count against it.
 The vote will be held on slack (and emailed to mesa-dev) with an appropriate period of time for people to read and approve this document.
 
-Changing this document
-----------------------
-
-Once approved changes to this document will follow the same process as the initial approval process.
-
-
 Changelog
 ---------
 
-* Initial document approved 5th december 2022
+* Initial document approved December 5, 2022


### PR DESCRIPTION
This is mostly focused on bringing some other parts of the documentation on the website in line with the new developer onboarding document. This removes some outdated language about the MAC/MTC playing the primary role in onboarding new developers.

It also contains some cosmetic changes to the onboarding document itself, but nothing that changes the meaning of the document. A few miscellaneous updates to infrastructure documentation as well.