### PR TITLE
Add shebang #!/bin/bash to $MESA_DIR/star/work ?

### DIFF
--- a/star/work/clean
+++ b/star/work/clean
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 cd make
 make clean


### PR DESCRIPTION
If 'clean' is an executable why is there no /bin/bash shebang like in the 'mk' or 'rn' executables. I unable to execute it through Python while doing `subprocess.Popen('./clean')`. I get, `OSError: [Errno 8] Exec format error: './clean'`.
Adding a shebang solved it for me.

However, I can technically bypass this issue if I run it with `subprocess.Popen('./clean', shell=True)` or if I run it via `os.system('./clean')`. Both of these run as intended.  

TL;DR I believe that adding a shebang here would allow non-shell processes to execute this file.