### PR TITLE
Speed up getf2

### DIFF
--- a/mtx/public/mtx_solve_routines.inc
+++ b/mtx/public/mtx_solve_routines.inc
@@ -3,10 +3,10 @@
       subroutine my_getf2(m, a, lda, ipiv, info)
          integer :: info, lda, m
          integer :: ipiv(:)
-         real(dp) :: a(:,:)
+         real(dp) :: a(:,:),aj(m)
          real(dp), parameter :: one=1, zero=0
          integer :: i, j, jp, ii, jj, n, mm
-         real(dp) :: tmp, da
+         real(dp) :: tmp, da, ajjj
          do j = 1, m
             info = 0
             jp = j - 1 + maxloc(abs(a(j:lda,j)),dim=1)
@@ -31,11 +31,13 @@
                info = j
             end if
             if( j.lt.m ) then
+               aj = a(:,j)
                !call dger( m-j, m-j, -one, a( j+1, j ), 1, a( j, j+1 ), lda, a( j+1, j+1 ), lda )
                do jj = j+1, m
+                  ajjj = a(j,jj)
                   !$omp simd
                   do ii = j+1, m
-                     a(ii,jj) = a(ii,jj) - a(ii,j)*a(j,jj)
+                     a(ii,jj) = a(ii,jj) - aj(ii)*ajjj
                   end do
                end do
             end if


### PR DESCRIPTION
The idea is to allow the compiler to have a better guess at what does/not change in a loop. By pulling out some of these array access the compiler can see things don't change.

Testing against split_burn_big_net didn't show any improvement (or worsening) but using the MESA's one zone burner in a standalone mode showed 30% speed up. While also showing no difference in final results. This seems to mostly benefit when running big nets ( few hundred isos), split_burn_big_net only uses 80 isotopes.

