### PR TITLE
restoring eps_nuc_neu to split burn zones

### DIFF
--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -1197,8 +1197,8 @@
          s% d_dxdt_nuc_dRho(:,k) =  0d0
          s% d_dxdt_nuc_dT(:,k) =  0d0
          s% d_dxdt_nuc_dx(:,:,k) =  0d0
-         s% eps_nuc_neu_total(k) = ending_eps_neu_total ! restore eps_nuc_neu to zones 
-undergoing op_split!
+         ! below, restore eps_nuc_neu to op_split zones.
+         s% eps_nuc_neu_total(k) = ending_eps_neu_total 
          
          do i=1,species ! for use by dX_nuc_drop timestep limiter
             s% dxdt_nuc(i,k) = (s% xa(i,k)-xa_start(i))/dt

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -1197,7 +1197,8 @@
          s% d_dxdt_nuc_dRho(:,k) =  0d0
          s% d_dxdt_nuc_dT(:,k) =  0d0
          s% d_dxdt_nuc_dx(:,:,k) =  0d0
-         s% eps_nuc_neu_total(k) = 0d0
+         s% eps_nuc_neu_total(k) = ending_eps_neu_total ! restore eps_nuc_neu to zones 
+undergoing op_split!
          
          do i=1,species ! for use by dX_nuc_drop timestep limiter
             s% dxdt_nuc(i,k) = (s% xa(i,k)-xa_start(i))/dt

--- a/star_data/private/star_job_controls_params.inc
+++ b/star_data/private/star_job_controls_params.inc
@@ -1,2 +1,2 @@
       integer, parameter :: max_extras_params = 20, max_extras_cpar_len = strlen, &
-            max_num_special_rate_factors = 20, star_num_xtra_vals = 30
+            max_num_special_rate_factors = 500, star_num_xtra_vals = 30


### PR DESCRIPTION
restoring eps_nuc_neu to zones undergoing operator split burn. This fixes the history output for 'eps_nuc_neu_total', 'log_Lneu', and 'log_Lneu_nuc'