### PR TITLE
Enable RTI source terms

### DIFF
--- a/star/private/hydro_alpha_rti_eqns.f90
+++ b/star/private/hydro_alpha_rti_eqns.f90
@@ -136,8 +136,7 @@
          instability2 = -dPdr_drhodr ! > 0 means Rayleigh-Taylor unstable         
          if (instability2 <= 0d0 .or. &
                s% q(k) > s% alpha_RTI_src_max_q .or. &
-               s% q(k) < s% alpha_RTI_src_min_q .or. &
-               s% rho(k) < 1d99) then
+               s% q(k) < s% alpha_RTI_src_min_q) then
             source_plus = 0d0
             instability2 = 0d0
             instability = 0d0

--- a/star/test_suite/ccsn_IIp/inlist_end_infall
+++ b/star/test_suite/ccsn_IIp/inlist_end_infall
@@ -148,7 +148,7 @@
 
 &pgstar
          
-pause = .true.
+!pause = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/ccsn_IIp/inlist_infall
+++ b/star/test_suite/ccsn_IIp/inlist_infall
@@ -122,7 +122,7 @@
 
 &pgstar
          
-pause = .true.
+!pause = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1


### PR DESCRIPTION
RTI has been broken for ~2 years since 181c9fac as we had a check for rho < 1d99 and if true we would turn off the RTI source term (and thats of course always true).
