### PR TITLE
Update GYRE to v7.0

### DIFF
--- a/gyre/build_and_test
+++ b/gyre/build_and_test
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ ! -d gyre ]]; then
-    tar xf gyre-6.0.tar.gz
-    mv gyre-6.0 gyre
+    tar xf gyre-7.0.tar.gz
+    mv gyre-7.0 gyre
 fi
 
 ../utils/build_and_test

--- a/gyre/build_and_test_parallel
+++ b/gyre/build_and_test_parallel
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ ! -d gyre ]]; then
-    tar xf gyre-6.0.tar.gz
-    mv gyre-6.0 gyre
+    tar xf gyre-7.0.tar.gz
+    mv gyre-7.0 gyre
 fi
 
 ../utils/build_and_test_parallel

--- a/gyre/gyre-6.0.tar.gz
+++ b/gyre/gyre-6.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87d80969b4dde16a7553fb6e49c2d6f30fb39d096607b7f0687657b2f7002e0a
-size 4800422

--- a/gyre/gyre-7.0.tar.gz
+++ b/gyre/gyre-7.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:417638dfc513e3b4cf6d943a73caea3095bdd84393deda36a69e58711b9cfdb7
+size 4812758

--- a/gyre/public/gyre_lib_stub.f
+++ b/gyre/public/gyre_lib_stub.f
@@ -20,6 +20,7 @@ module gyre_lib ! stub
 
   type :: wave_t
     type(grid_t), allocatable :: gr
+    integer :: n
   contains
     procedure, public :: freq
     procedure, public :: grid
@@ -32,7 +33,6 @@ module gyre_lib ! stub
     integer :: n_pg
     integer :: n_p
     integer :: n_g
-    integer :: n_k
   end type mode_t
 
   interface gyre_set_constant

--- a/star/job/gyre_in_mesa_extras_finish_step.inc
+++ b/star/job/gyre_in_mesa_extras_finish_step.inc
@@ -162,7 +162,7 @@
 
          gr = md%grid()
 
-         do k = 1, md%n_k
+         do k = 1, md%n
             write(unit, 140) gr%pt(k)%x, md%xi_r(k), md%xi_h(k), md%dW_dx(k)
 140         format(6(1X,E24.16))
          end do

--- a/star/job/gyre_in_mesa_extras_set_velocities.inc
+++ b/star/job/gyre_in_mesa_extras_set_velocities.inc
@@ -210,8 +210,8 @@
             gr = md%grid()
 
             period(md%n_pg) = 1d0/freq
-            npts(md%n_pg) = md%n_k
-            do k = 1, md%n_k
+            npts(md%n_pg) = md%n
+            do k = 1, md%n
                r(md%n_pg,k) = gr%pt(k)%x
                v(md%n_pg,k) = md%xi_r(k)            
             end do
@@ -225,7 +225,7 @@
                open(NEWUNIT=unit, FILE=filename, STATUS='REPLACE')
                write(unit, 130) 'x=r/R', 'Real(xi_r/R)', 'Imag(xi_r/R)', 'Real(xi_h/R)', 'Imag(xi_h/R)', 'dW/dx'
 130               format(6(1X,A24))
-               do k = 1, md%n_k
+               do k = 1, md%n
                   write(unit, 140) gr%pt(k)%x, md%xi_r(k), md%xi_h(k), md%dW_dx(k)
 140               format(6(1X,E24.16))
                end do

--- a/star/test_suite/rsp_gyre/src/run_star_extras.f90
+++ b/star/test_suite/rsp_gyre/src/run_star_extras.f90
@@ -238,8 +238,8 @@ module run_star_extras
             gr = md%grid()
 
             period(md%n_pg) = 1d0/freq
-            npts(md%n_pg) = md%n_k
-            do k = 1, md%n_k
+            npts(md%n_pg) = md%n
+            do k = 1, md%n
                r(md%n_pg,k) = gr%pt(k)%x
                v(md%n_pg,k) = md%xi_r(k)            
             end do
@@ -253,7 +253,7 @@ module run_star_extras
                open(NEWUNIT=unit, FILE=filename, STATUS='REPLACE')
                write(unit, 130) 'x=r/R', 'Real(xi_r/R)', 'Imag(xi_r/R)', 'Real(xi_h/R)', 'Imag(xi_h/R)', 'dW/dx'
 130               format(6(1X,A24))
-               do k = 1, md%n_k
+               do k = 1, md%n
                   write(unit, 140) gr%pt(k)%x, md%xi_r(k), md%xi_h(k), md%dW_dx(k)
 140               format(6(1X,E24.16))
                end do


### PR DESCRIPTION
A new version of GYRE ([v7.0](https://github.com/rhdtownsend/gyre/releases/tag/v7.0)) was released Jan 18. This updates MESA by replacing the bundled archive and updating one API change (`md%n_k` → `md%n`) in a few places. I manually cross-checked the results of all the `gyre_in_mesa` tests in `star` as well as `astero_gyre` in `astero` and the only changes were around 10⁻⁷ level changes in some growth rates.

I won't merge this without approval from @rhdtownsend. There's no particular rush but we should merge before the next release.