### PR TITLE
Turn off gold2_tolerances in defaults but leave on in test suite

### DIFF
--- a/astero/test_suite/astero_adipls/inlist_astero_adipls
+++ b/astero/test_suite/astero_adipls/inlist_astero_adipls
@@ -30,6 +30,7 @@
       x_ctrl(1) = 375d0 ! target frequency
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/astero_adipls/inlist_zams
+++ b/astero/test_suite/astero_adipls/inlist_zams
@@ -33,6 +33,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/astero_gyre/inlist_astero_gyre
+++ b/astero/test_suite/astero_gyre/inlist_astero_gyre
@@ -30,6 +30,7 @@
       x_ctrl(1) = 375d0 ! target frequency
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/example_astero/inlist_example_astero
+++ b/astero/test_suite/example_astero/inlist_example_astero
@@ -45,6 +45,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/fast_from_file/inlist_fast_from_file
+++ b/astero/test_suite/fast_from_file/inlist_fast_from_file
@@ -38,6 +38,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/fast_newuoa/inlist_fast_newuoa
+++ b/astero/test_suite/fast_newuoa/inlist_fast_newuoa
@@ -38,6 +38,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/fast_scan_grid/inlist_fast_scan_grid
+++ b/astero/test_suite/fast_scan_grid/inlist_fast_scan_grid
@@ -38,6 +38,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/fast_simplex/inlist_fast_simplex
+++ b/astero/test_suite/fast_simplex/inlist_fast_simplex
@@ -38,6 +38,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/astero/test_suite/surface_effects/inlist_surface_effects
+++ b/astero/test_suite/surface_effects/inlist_surface_effects
@@ -47,6 +47,7 @@
       mesh_delta_coeff = 0.5
       
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/binary/test_suite/double_bh/inlist1
+++ b/binary/test_suite/double_bh/inlist1
@@ -60,6 +60,7 @@
     solver_iters_timestep_limit = 10
 
     max_model_number = 2000
+    use_gold2_tolerances = .true.
 
     ! extra controls for timestep
     ! these are for changes in mdot, to avoid violent increase in mass transfer rate

--- a/binary/test_suite/double_bh/inlist2
+++ b/binary/test_suite/double_bh/inlist2
@@ -62,6 +62,7 @@
     solver_iters_timestep_limit = 10
 
     max_model_number = 2000
+    use_gold2_tolerances = .true.
 
     ! extra controls for timestep
     ! these are for changes in mdot, to avoid violent increase in mass transfer rate

--- a/binary/test_suite/evolve_both_stars/inlist1
+++ b/binary/test_suite/evolve_both_stars/inlist1
@@ -24,6 +24,7 @@
       ! you can/should delete this for use outside of test_suite
          max_number_retries = 80
          retry_limit = 100
+         use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log1' 
       log_directory = 'LOGS1'

--- a/binary/test_suite/evolve_both_stars/inlist2
+++ b/binary/test_suite/evolve_both_stars/inlist2
@@ -23,6 +23,7 @@
       ! you can/should delete this for use outside of test_suite
          retry_limit = 100
          max_number_retries = 80
+         use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log2' 
       log_directory = 'LOGS2'

--- a/binary/test_suite/jdot_gr_check/inlist1
+++ b/binary/test_suite/jdot_gr_check/inlist1
@@ -26,6 +26,7 @@
       write_header_frequency = 10
       
       max_age = 1.4d10
+      use_gold2_tolerances = .true.
 
 / ! end of controls namelist
 

--- a/binary/test_suite/jdot_gr_check/inlist2
+++ b/binary/test_suite/jdot_gr_check/inlist2
@@ -18,6 +18,8 @@
       terminal_interval = 1
       write_header_frequency = 10
 
+      use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 

--- a/binary/test_suite/jdot_ls_check/inlist1
+++ b/binary/test_suite/jdot_ls_check/inlist1
@@ -31,6 +31,7 @@
          max_number_retries = 8
       ! you probably want to change this
       max_age = 1e10
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log1' 
       log_directory = 'LOGS1'

--- a/binary/test_suite/jdot_ls_check/inlist2
+++ b/binary/test_suite/jdot_ls_check/inlist2
@@ -14,6 +14,7 @@
       max_number_retries = 80
 
       max_model_number = 70
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log2' 
       log_directory = 'LOGS2'

--- a/binary/test_suite/jdot_ml_check/inlist1
+++ b/binary/test_suite/jdot_ml_check/inlist1
@@ -32,6 +32,7 @@
       write_header_frequency = 10
       
       varcontrol_target = 5d-4
+      use_gold2_tolerances = .true.
       
 
 / ! end of controls namelist

--- a/binary/test_suite/jdot_ml_check/inlist2
+++ b/binary/test_suite/jdot_ml_check/inlist2
@@ -23,6 +23,7 @@
       write_header_frequency = 10
       
       varcontrol_target = 1d-3
+      use_gold2_tolerances = .true.
       
 
 / ! end of controls namelist

--- a/binary/test_suite/star_plus_point_mass/inlist1
+++ b/binary/test_suite/star_plus_point_mass/inlist1
@@ -22,6 +22,7 @@
       max_number_retries = 80
 
       max_model_number = 1000
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log1' 
       log_directory = 'LOGS1'

--- a/binary/test_suite/star_plus_point_mass/inlist2
+++ b/binary/test_suite/star_plus_point_mass/inlist2
@@ -12,6 +12,7 @@
       ! check for retries as part of test_suite
       ! you can/should delete this for use outside of test_suite
       max_number_retries = 80
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log2' 
       log_directory = 'LOGS2'

--- a/binary/test_suite/star_plus_point_mass_explicit_mdot/inlist1
+++ b/binary/test_suite/star_plus_point_mass_explicit_mdot/inlist1
@@ -22,6 +22,7 @@
       max_number_retries = 80
 
       max_model_number = 1000
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log1' 
       log_directory = 'LOGS1'

--- a/binary/test_suite/star_plus_point_mass_explicit_mdot/inlist2
+++ b/binary/test_suite/star_plus_point_mass_explicit_mdot/inlist2
@@ -12,6 +12,7 @@
       ! check for retrie as part of test_suite
       ! you can/should delete this for use outside of test_suite
       max_number_retries = 80
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log2' 
       log_directory = 'LOGS2'

--- a/binary/test_suite/wind_fed_bhhmxb/inlist1
+++ b/binary/test_suite/wind_fed_bhhmxb/inlist1
@@ -26,6 +26,7 @@
       max_number_retries = 15
 
       max_model_number = 2000
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log1' 
       log_directory = 'LOGS1'

--- a/binary/test_suite/wind_fed_bhhmxb/inlist2
+++ b/binary/test_suite/wind_fed_bhhmxb/inlist2
@@ -19,6 +19,7 @@
       ! check for retries as part of test_suite
       ! you can/should delete this for use outside of test_suite
       max_number_retries = 80
+      use_gold2_tolerances = .true.
 
       extra_terminal_output_file = 'log2' 
       log_directory = 'LOGS2'

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -1784,7 +1784,7 @@
 
       ! ::
 
-    max_abs_rel_run_E_err = 0.01d0
+    max_abs_rel_run_E_err = -1
 
 
       ! max_number_retries
@@ -11427,7 +11427,7 @@
 
       ! ::
 
-    warn_when_large_rel_run_E_err = 0.01d0
+    warn_when_large_rel_run_E_err = 0.1d0
 
       ! absolute_cumulative_energy_err
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -8957,7 +8957,7 @@
 
       ! ::
 
-    use_gold2_tolerances = .true.
+    use_gold2_tolerances = .false.
     steps_before_use_gold2_tolerances = -1
 
       ! if >= 0, then after this many steps in run, act as if use_gold2_tolerances true

--- a/star/test_suite/1.3M_ms_high_Z/inlist_1.3M_ms_high_Z
+++ b/star/test_suite/1.3M_ms_high_Z/inlist_1.3M_ms_high_Z
@@ -43,6 +43,7 @@
 
   ! limit max_model_number as part of test_suite
    max_model_number = 500
+   use_gold2_tolerances = .true.
 
   ! the initial model comes from this thread via Philip Hall
   ! https://lists.mesastar.org/pipermail/mesa-users/2017-June/007738.html

--- a/star/test_suite/1.3M_ms_high_Z/inlist_1.3M_ms_high_Z
+++ b/star/test_suite/1.3M_ms_high_Z/inlist_1.3M_ms_high_Z
@@ -44,6 +44,7 @@
   ! limit max_model_number as part of test_suite
    max_model_number = 500
    use_gold2_tolerances = .true.
+   max_abs_rel_run_E_err = 1d-2
 
   ! the initial model comes from this thread via Philip Hall
   ! https://lists.mesastar.org/pipermail/mesa-users/2017-June/007738.html

--- a/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_initial_model
+++ b/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_initial_model
@@ -98,6 +98,8 @@
    terminal_interval = 50
    write_header_frequency = 50
 
+   use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 &pgstar

--- a/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_op_mono
+++ b/star/test_suite/1.4M_ms_op_mono/inlist_1.4M_ms_op_mono
@@ -41,6 +41,7 @@
       report_ierr = .true.
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       ! limit max_model_number as part of test_suite
       max_model_number = 10

--- a/star/test_suite/1.5M_with_diffusion/inlist_1.5M_with_diffusion
+++ b/star/test_suite/1.5M_with_diffusion/inlist_1.5M_with_diffusion
@@ -53,6 +53,7 @@
 
       energy_eqn_option = 'dedt'
       convergence_ignore_equL_residuals = .true.
+      use_gold2_tolerances = .true.
             
       limit_for_rel_error_in_energy_conservation = -1
       hard_limit_for_rel_error_in_energy_conservation = -1

--- a/star/test_suite/1.5M_with_diffusion/inlist_to_ZAMS
+++ b/star/test_suite/1.5M_with_diffusion/inlist_to_ZAMS
@@ -69,6 +69,8 @@
 
       mesh_delta_coeff = 0.5
 
+      use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 &pgstar

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_common
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_common
@@ -172,6 +172,8 @@
       gold2_tol_max_residual3 = 5d-4
       gold_tol_max_residual2 = 5d-4
 
+      max_abs_rel_run_E_err = 1d-2
+
       convergence_ignore_equL_residuals = .true. 
       make_gradr_sticky_in_solver_iters = .true.
       xa_scale = 1d-5

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_make_late_pre_zams
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_make_late_pre_zams
@@ -28,6 +28,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       max_age = 1d3
 

--- a/star/test_suite/15M_dynamo/inlist_common
+++ b/star/test_suite/15M_dynamo/inlist_common
@@ -83,6 +83,8 @@
       terminal_interval = 50
 
 
+      use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 

--- a/star/test_suite/16M_conv_premix/inlist_16M_conv_premix
+++ b/star/test_suite/16M_conv_premix/inlist_16M_conv_premix
@@ -75,6 +75,7 @@
    do_conv_premix = .true.
    do_premix_heating = .true.
    use_gold2_tolerances = .true.
+   max_abs_rel_run_E_err = 1d-2
 
    ! Timestep and grid
 

--- a/star/test_suite/16M_conv_premix/inlist_16M_conv_premix
+++ b/star/test_suite/16M_conv_premix/inlist_16M_conv_premix
@@ -74,6 +74,7 @@
 
    do_conv_premix = .true.
    do_premix_heating = .true.
+   use_gold2_tolerances = .true.
 
    ! Timestep and grid
 

--- a/star/test_suite/16M_conv_premix/inlist_start
+++ b/star/test_suite/16M_conv_premix/inlist_start
@@ -88,6 +88,8 @@
    ! limit max_model_number as part of test_suite
    max_model_number = 10 !  2500
 
+   use_gold2_tolerances = .true.
+
 /
 
 &pgstar

--- a/star/test_suite/16M_predictive_mix/inlist_16M_predictive_mix
+++ b/star/test_suite/16M_predictive_mix/inlist_16M_predictive_mix
@@ -98,6 +98,7 @@
 
    energy_eqn_option = 'dedt'
    use_gold2_tolerances = .true.
+   max_abs_rel_run_E_err = 1d-2
 
    num_trace_history_values = 2
    trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/16M_predictive_mix/inlist_16M_predictive_mix
+++ b/star/test_suite/16M_predictive_mix/inlist_16M_predictive_mix
@@ -97,6 +97,7 @@
    
 
    energy_eqn_option = 'dedt'
+   use_gold2_tolerances = .true.
 
    num_trace_history_values = 2
    trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/16M_predictive_mix/inlist_start
+++ b/star/test_suite/16M_predictive_mix/inlist_start
@@ -81,10 +81,10 @@
    history_interval = 10
    terminal_interval = 50
    write_header_frequency = 10
-   
-   
+
    ! limit max_model_number as part of test_suite
    max_model_number = 10 !  2500
+   use_gold2_tolerances = .true.
 
 /
 

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_start
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_start
@@ -46,6 +46,8 @@
       history_interval = 10
       terminal_interval = 10
       write_header_frequency = 10
+
+      use_gold2_tolerances = .true.
       
       !photo_interval = 1
       !profile_interval = 1

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_agb
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_agb
@@ -36,6 +36,7 @@
       envelope_mass_limit = 1d-2 ! Msun
 
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_h_burn
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_h_burn
@@ -38,6 +38,7 @@
       xa_central_lower_limit(1) = 0.0001
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_he_burn
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_end_core_he_burn
@@ -41,6 +41,7 @@
       xa_central_lower_limit(1) = 0.0001
 
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
       
       convergence_ignore_equL_residuals = .true.
 

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_start_he_core_flash
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_start_he_core_flash
@@ -35,6 +35,7 @@
       power_he_burn_upper_limit = 10d0
 
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/1M_pre_ms_to_wd/inlist_to_wd
+++ b/star/test_suite/1M_pre_ms_to_wd/inlist_to_wd
@@ -35,6 +35,7 @@
       eps_nuc_factor = 0d0
 
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/1M_thermohaline/inlist_1M_thermohaline
+++ b/star/test_suite/1M_thermohaline/inlist_1M_thermohaline
@@ -104,6 +104,7 @@
          
          use_gold2_tolerances = .true.
          use_gold_tolerances = .true.
+         max_abs_rel_run_E_err = 1d-2
 
          mass_change_full_on_dt = 1d7 ! (seconds)
          mass_change_full_off_dt = 1d6 ! (seconds)

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_common
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_common
@@ -175,6 +175,8 @@
       gold2_tol_max_residual3 = 5d-4
       gold_tol_max_residual2 = 5d-4
 
+      max_abs_rel_run_E_err = 1d-2
+
       energy_eqn_option = 'dedt'
       max_tries_for_implicit_wind = 0      
 

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_make_late_pre_zams
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_make_late_pre_zams
@@ -28,6 +28,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       max_age = 1d3
 

--- a/star/test_suite/5M_cepheid_blue_loop/inlist_cepheid_blue_loop
+++ b/star/test_suite/5M_cepheid_blue_loop/inlist_cepheid_blue_loop
@@ -57,6 +57,7 @@
    initial_Z = 0.008d0
    
    energy_eqn_option = 'dedt'
+   use_gold2_tolerances = .true.
 
    mixing_length_alpha = 1.8d0
    MLT_option = 'TDC'

--- a/star/test_suite/5M_cepheid_blue_loop/inlist_start
+++ b/star/test_suite/5M_cepheid_blue_loop/inlist_start
@@ -84,6 +84,8 @@ steps_before_use_TDC = 10
 
    delta_HR_limit = 0.002
 
+   use_gold2_tolerances = .true.
+
 
 ! output controls
 

--- a/star/test_suite/7M_prems_to_AGB/inlist_7M_prems_to_AGB
+++ b/star/test_suite/7M_prems_to_AGB/inlist_7M_prems_to_AGB
@@ -30,6 +30,7 @@
 &controls
       
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/7M_prems_to_AGB/inlist_7M_prems_to_AGB
+++ b/star/test_suite/7M_prems_to_AGB/inlist_7M_prems_to_AGB
@@ -31,6 +31,7 @@
       
       energy_eqn_option = 'dedt'
       use_gold2_tolerances = .true.
+      max_abs_rel_run_E_err = 1d-2
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/7M_prems_to_AGB/inlist_start
+++ b/star/test_suite/7M_prems_to_AGB/inlist_start
@@ -25,6 +25,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 150
+      use_gold2_tolerances = .true.
       
       max_age = 0.5d0
 

--- a/star/test_suite/R_CrB_star/inlist_common
+++ b/star/test_suite/R_CrB_star/inlist_common
@@ -39,6 +39,7 @@
 
       energy_eqn_option = 'dedt'
       varcontrol_target = 1d-3
+      use_gold2_tolerances = .true.
 
       photo_interval = 100
       profile_interval = 100

--- a/star/test_suite/T_tau_gradr/inlist_T_tau_gradr
+++ b/star/test_suite/T_tau_gradr/inlist_T_tau_gradr
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 50
+      use_gold2_tolerances = .true.
 
       atm_T_tau_relation = 'Eddington'
       use_T_tau_gradr_factor = .true.

--- a/star/test_suite/accreted_material_j/inlist_accreted_material_j
+++ b/star/test_suite/accreted_material_j/inlist_accreted_material_j
@@ -47,6 +47,7 @@
       ignore_species_in_max_correction = .true.
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/accreted_material_j/inlist_zams
+++ b/star/test_suite/accreted_material_j/inlist_zams
@@ -36,6 +36,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/adjust_net/inlist_adjust_net
+++ b/star/test_suite/adjust_net/inlist_adjust_net
@@ -49,6 +49,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/adjust_net/inlist_massive_defaults
+++ b/star/test_suite/adjust_net/inlist_massive_defaults
@@ -28,7 +28,7 @@
 / ! end of kap namelist
 
 &controls
-         
+         use_gold2_tolerances = .true.
 
          ! high center T limit to avoid negative mass fractions
          sig_min_factor_for_high_Tcenter = 0.01

--- a/star/test_suite/adjust_net/inlist_zams
+++ b/star/test_suite/adjust_net/inlist_zams
@@ -36,6 +36,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/c13_pocket/inlist_common
+++ b/star/test_suite/c13_pocket/inlist_common
@@ -48,6 +48,7 @@
       include_composition_in_eps_grav = .true.
       limit_for_rel_error_in_energy_conservation = 1d99
       hard_limit_for_rel_error_in_energy_conservation = 1d99
+      use_gold2_tolerances = .true.
 
 
       num_trace_history_values = 2

--- a/star/test_suite/carbon_kh/inlist_carbon_kh
+++ b/star/test_suite/carbon_kh/inlist_carbon_kh
@@ -73,6 +73,8 @@
   trace_history_value_name(1) = 'rel_E_err'
   trace_history_value_name(2) = 'log_rel_run_E_err'
 
+  use_gold2_tolerances = .true.
+
   ! for convergence studies
       read_extra_controls_inlist(2) = .false.
       extra_controls_inlist_name(2)= 'inlist_resolution'

--- a/star/test_suite/cburn_inward/inlist_cburn_inward
+++ b/star/test_suite/cburn_inward/inlist_cburn_inward
@@ -66,6 +66,7 @@
     
       use_ledoux_criterion = .true.
       make_gradr_sticky_in_solver_iters = .false.
+      use_gold2_tolerances = .true.
 
       ! We need to only use 'top' overshooting because 'bottom'
       ! overshooting generates unphysical dilution of C12 below

--- a/star/test_suite/cburn_inward/inlist_initial
+++ b/star/test_suite/cburn_inward/inlist_initial
@@ -96,6 +96,8 @@
       report_solver_progress = .false. ! set true to see info about solver iterations
       report_ierr = .false. ! if true, produce terminal output when have some internal error
 
+      use_gold2_tolerances = .true.
+
       !trace_evolve = .true.
 
       photo_interval = 50

--- a/star/test_suite/ccsn_IIp/inlist_shock_common
+++ b/star/test_suite/ccsn_IIp/inlist_shock_common
@@ -67,6 +67,7 @@
 ! equation controls
       energy_eqn_option = 'dedt'
       use_dPrad_dm_form_of_T_gradient_eqn = .true.
+      use_gold2_tolerances = .true.
 
       ! turn off energy from nuclear reactions and neutrinos
       eps_nuc_factor = 0d0

--- a/star/test_suite/check_pulse_atm/inlist_check_pulse_atm
+++ b/star/test_suite/check_pulse_atm/inlist_check_pulse_atm
@@ -31,6 +31,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 75
+      use_gold2_tolerances = .true.
 
       atm_T_tau_opacity = 'varying'
       atm_T_tau_relation = 'Trampedach_solar'

--- a/star/test_suite/check_redo/inlist_check_redo
+++ b/star/test_suite/check_redo/inlist_check_redo
@@ -51,6 +51,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 1000
+      use_gold2_tolerances = .true.
    
     
   ! starting specifications

--- a/star/test_suite/conductive_flame/inlist_conductive_flame
+++ b/star/test_suite/conductive_flame/inlist_conductive_flame
@@ -91,6 +91,8 @@
       T_function1_weight = 50
       limit_for_rel_error_in_energy_conservation = 1d-4
       hard_limit_for_rel_error_in_energy_conservation = 1d-3
+
+      use_gold2_tolerances = .true.
       
     ! allow for minuscule timesteps
       min_timestep_limit = 1d-20

--- a/star/test_suite/conserve_angular_momentum/inlist_zams
+++ b/star/test_suite/conserve_angular_momentum/inlist_zams
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/custom_colors/inlist_1.0
+++ b/star/test_suite/custom_colors/inlist_1.0
@@ -67,6 +67,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 2000
+      use_gold2_tolerances = .true.
 
       initial_mass = 1.0d0
       initial_z = 0.014d0

--- a/star/test_suite/custom_rates/inlist_NCO_flash
+++ b/star/test_suite/custom_rates/inlist_NCO_flash
@@ -53,6 +53,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/custom_rates/inlist_NCO_hashimoto
+++ b/star/test_suite/custom_rates/inlist_NCO_hashimoto
@@ -49,6 +49,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       max_age = 44d7
 

--- a/star/test_suite/custom_rates/inlist_cool
+++ b/star/test_suite/custom_rates/inlist_cool
@@ -18,6 +18,7 @@
 
   max_years_for_timestep = 1d6
   log_center_temp_lower_limit = 7.43136
+  use_gold2_tolerances = .true.
 
 / ! end of controls namelist
 

--- a/star/test_suite/custom_rates/inlist_core
+++ b/star/test_suite/custom_rates/inlist_core
@@ -20,6 +20,7 @@
   initial_z = 0.02
 
   he_core_mass_limit = 0.3
+  use_gold2_tolerances = .true.
 
 / ! end of controls namelist
 

--- a/star/test_suite/custom_rates/inlist_make_he_wd
+++ b/star/test_suite/custom_rates/inlist_make_he_wd
@@ -27,6 +27,7 @@
 
   mass_change = -1d-8
   max_age = 1d5
+  use_gold2_tolerances = .true.
 
 / ! end of controls namelist
 

--- a/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness
+++ b/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness
@@ -43,6 +43,7 @@
 
       energy_eqn_option = 'dedt'
       calculate_Brunt_N2 = .true.
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/diffusion_smoothness/inlist_zams
+++ b/star/test_suite/diffusion_smoothness/inlist_zams
@@ -35,6 +35,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/extended_convective_penetration/inlist_extended_convective_penetration
+++ b/star/test_suite/extended_convective_penetration/inlist_extended_convective_penetration
@@ -41,7 +41,7 @@
 
 &controls
 
-
+    use_gold2_tolerances = .true.
 
     xa_central_lower_limit_species(1) = 'h1'
     xa_central_lower_limit(1) = 0.4 

--- a/star/test_suite/extended_convective_penetration/inlist_zams
+++ b/star/test_suite/extended_convective_penetration/inlist_zams
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_bcep/inlist_gyre_in_mesa_bcep
+++ b/star/test_suite/gyre_in_mesa_bcep/inlist_gyre_in_mesa_bcep
@@ -63,6 +63,7 @@
   x_logical_ctrl(1) = .false.
 
   energy_eqn_option = 'dedt'
+  use_gold2_tolerances = .true.
 
   num_trace_history_values = 2
   trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_bcep/inlist_zams
+++ b/star/test_suite/gyre_in_mesa_bcep/inlist_zams
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_pulse
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_pulse
@@ -26,6 +26,7 @@
 
   initial_z = 0.02
   calculate_Brunt_N2 = .true.
+  use_gold2_tolerances = .true.
 
   ! GYRE output controls
   

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_remove_center
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_remove_center
@@ -30,12 +30,13 @@
 
 &controls
 
-  initial_z = 0.02
-      
-      photo_interval = 1
-      !profile_interval = 1
-      !history_interval = 1
-      terminal_interval = 10 
+   initial_z = 0.02
+   
+   photo_interval = 1
+   !profile_interval = 1
+   !history_interval = 1
+   terminal_interval = 10 
 
+   use_gold2_tolerances = .true.
 
 / ! end of controls namelist

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_tams
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_tams
@@ -36,6 +36,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_envelope/inlist_zams
+++ b/star/test_suite/gyre_in_mesa_envelope/inlist_zams
@@ -36,6 +36,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_ms/inlist_gyre_in_mesa_ms
+++ b/star/test_suite/gyre_in_mesa_ms/inlist_gyre_in_mesa_ms
@@ -36,39 +36,40 @@
       max_model_number = 200  
 
       initial_z = 0.02
-      
+
       calculate_Brunt_N2 = .true.
 
-     ! GYRE output controls
+      ! GYRE output controls
 
-     x_integer_ctrl(1) = 2 ! output GYRE info at this step interval
-     x_logical_ctrl(1) = .false. ! save GYRE info whenever save profile
+      x_integer_ctrl(1) = 2 ! output GYRE info at this step interval
+      x_logical_ctrl(1) = .false. ! save GYRE info whenever save profile
 
-     x_integer_ctrl(2) = 2 ! max number of modes to output per call
-     x_logical_ctrl(2) = .false. ! output eigenfunction files
+      x_integer_ctrl(2) = 2 ! max number of modes to output per call
+      x_logical_ctrl(2) = .false. ! output eigenfunction files
 
-     x_integer_ctrl(3) = 0 ! mode l (e.g. 0 for p modes, 1 for g modes)
-        ! should match gyre.in mode l
-     x_integer_ctrl(4) = 1 ! order
-     x_ctrl(1) = 0.2d-3 ! freq ~ this (Hz)
-     x_ctrl(2) = 1d99 ! growth < this (days)
-     
+      x_integer_ctrl(3) = 0 ! mode l (e.g. 0 for p modes, 1 for g modes)
+      ! should match gyre.in mode l
+      x_integer_ctrl(4) = 1 ! order
+      x_ctrl(1) = 0.2d-3 ! freq ~ this (Hz)
+      x_ctrl(2) = 1d99 ! growth < this (days)
 
-  ! starting specifications
-    initial_mass = 1 ! in Msun units
 
-  ! stop when the center mass fraction of h1 drops below this limit
-    xa_central_lower_limit_species(1) = 'h1'
-    xa_central_lower_limit(1) = 1d-3
+      ! starting specifications
+      initial_mass = 1 ! in Msun units
 
-   energy_eqn_option = 'dedt'
-   
-    
-  ! output
+      ! stop when the center mass fraction of h1 drops below this limit
+      xa_central_lower_limit_species(1) = 'h1'
+      xa_central_lower_limit(1) = 1d-3
 
-   num_trace_history_values = 2
-   trace_history_value_name(1) = 'rel_E_err'
-   trace_history_value_name(2) = 'log_rel_run_E_err'
+      energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
+
+
+      ! output
+
+      num_trace_history_values = 2
+      trace_history_value_name(1) = 'rel_E_err'
+      trace_history_value_name(2) = 'log_rel_run_E_err'
 
       photo_interval = 50
       profile_interval = 100

--- a/star/test_suite/gyre_in_mesa_ms/inlist_zams
+++ b/star/test_suite/gyre_in_mesa_ms/inlist_zams
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_common
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_common
@@ -29,6 +29,7 @@
    
 ! solver
    energy_eqn_option = 'dedt'
+   use_gold2_tolerances = .true.
 
 / ! end of controls namelist
 

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_gyre_in_mesa_rsg
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_gyre_in_mesa_rsg
@@ -36,6 +36,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 20
+      use_gold2_tolerances = .true.
       
       ! GYRE output controls
 

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_near_pulses
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_near_pulses
@@ -36,6 +36,8 @@
    terminal_interval = 10
    write_header_frequency = 10
 
+   use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_pulse
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_pulse
@@ -44,6 +44,8 @@
    terminal_interval = 10 
    write_header_frequency = 10
 
+   use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 &pgstar

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_zams
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_zams
@@ -28,6 +28,7 @@
    
    ! limit max_model_number as part of test_suite
    max_model_number = 1000
+   use_gold2_tolerances = .true.
 
 ! output controls
 

--- a/star/test_suite/gyre_in_mesa_spb/inlist_gyre_in_mesa_spb
+++ b/star/test_suite/gyre_in_mesa_spb/inlist_gyre_in_mesa_spb
@@ -38,6 +38,7 @@
   initial_z = 0.02
   
   calculate_Brunt_N2 = .true.
+  use_gold2_tolerances = .true.
   
   ! GYRE output controls
   

--- a/star/test_suite/gyre_in_mesa_spb/inlist_zams
+++ b/star/test_suite/gyre_in_mesa_spb/inlist_zams
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/gyre_in_mesa_wd/inlist_common
+++ b/star/test_suite/gyre_in_mesa_wd/inlist_common
@@ -37,6 +37,7 @@
 
 ! solver
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
 ! eos
 

--- a/star/test_suite/gyre_in_mesa_wd/inlist_pulse_wd
+++ b/star/test_suite/gyre_in_mesa_wd/inlist_pulse_wd
@@ -25,6 +25,7 @@
 &controls      
       ! limit max_model_number as part of test_suite
       max_model_number = 2000
+      use_gold2_tolerances = .true.
       
       calculate_Brunt_N2 = .true.
 

--- a/star/test_suite/hb_2M/inlist_hb_2M
+++ b/star/test_suite/hb_2M/inlist_hb_2M
@@ -97,6 +97,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 300
+      use_gold2_tolerances = .true.
 
 / ! end of controls namelist
 

--- a/star/test_suite/hb_2M/inlist_to_TAMS
+++ b/star/test_suite/hb_2M/inlist_to_TAMS
@@ -32,6 +32,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       initial_mass = 2.0
       initial_z = 2d-2

--- a/star/test_suite/hb_2M/inlist_to_ZACHeB
+++ b/star/test_suite/hb_2M/inlist_to_ZACHeB
@@ -34,6 +34,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 25000
+      use_gold2_tolerances = .true.
 
       energy_eqn_option = 'dedt'
       convergence_ignore_equL_residuals = .true. ! needed during flash

--- a/star/test_suite/high_mass/inlist_high_mass
+++ b/star/test_suite/high_mass/inlist_high_mass
@@ -31,6 +31,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 1550  
+      use_gold2_tolerances = .true.
 
       initial_mass = 300
       initial_z = 1d-5

--- a/star/test_suite/high_rot_darkening/inlist_high_rot_darkening
+++ b/star/test_suite/high_rot_darkening/inlist_high_rot_darkening
@@ -53,6 +53,7 @@
     history_interval = 1
     terminal_interval = 10
 
+    use_gold2_tolerances = .true.
     gold_solver_iters_timestep_limit = 20
     gold2_solver_iters_timestep_limit = 20
 

--- a/star/test_suite/high_rot_darkening/inlist_zams
+++ b/star/test_suite/high_rot_darkening/inlist_zams
@@ -35,6 +35,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/high_z/inlist_high_z
+++ b/star/test_suite/high_z/inlist_high_z
@@ -40,6 +40,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/high_z/inlist_zams
+++ b/star/test_suite/high_z/inlist_zams
@@ -32,6 +32,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/hot_cool_wind/inlist_hot_cool_wind
+++ b/star/test_suite/hot_cool_wind/inlist_hot_cool_wind
@@ -41,6 +41,7 @@
       log_L_upper_limit = 4.1
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/irradiated_planet/inlist_create
+++ b/star/test_suite/irradiated_planet/inlist_create
@@ -47,6 +47,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 400
+      use_gold2_tolerances = .true.
 
       initial_mass = 0.001
       initial_z = 0.02d0

--- a/star/test_suite/irradiated_planet/inlist_evolve
+++ b/star/test_suite/irradiated_planet/inlist_evolve
@@ -52,6 +52,7 @@
       max_model_number = 650         
       
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
       
       convergence_ignore_equL_residuals = .true.
       

--- a/star/test_suite/low_z/inlist_low_Z
+++ b/star/test_suite/low_z/inlist_low_Z
@@ -37,6 +37,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/low_z/inlist_zams
+++ b/star/test_suite/low_z/inlist_zams
@@ -36,6 +36,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/make_brown_dwarf/inlist_make_brown_dwarf
+++ b/star/test_suite/make_brown_dwarf/inlist_make_brown_dwarf
@@ -28,6 +28,7 @@
    mlt_make_surface_no_mixing = .false.   
    convergence_ignore_equL_residuals = .true.
    make_gradr_sticky_in_solver_iters = .true.
+   use_gold2_tolerances = .true.
 
    ! limit max_model_number as part of test_suite
    max_model_number = 900

--- a/star/test_suite/make_co_wd/inlist_common
+++ b/star/test_suite/make_co_wd/inlist_common
@@ -89,6 +89,7 @@
 
 ! timesteps
       max_years_for_timestep = 1d9
+      use_gold2_tolerances = .true.
       
       varcontrol_target = 1d-3
       dX_nuc_drop_limit = 3d-2

--- a/star/test_suite/make_env/inlist_common
+++ b/star/test_suite/make_env/inlist_common
@@ -39,6 +39,7 @@
 
       max_number_retries = 20
       max_model_number = 2000
+      use_gold2_tolerances = .true.
       
       mesh_delta_coeff = 0.6
       

--- a/star/test_suite/make_he_wd/inlist_evolve
+++ b/star/test_suite/make_he_wd/inlist_evolve
@@ -42,6 +42,7 @@
       max_years_for_timestep = 1d9
       
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
 
       limit_for_rel_error_in_energy_conservation = 1d-5
       hard_limit_for_rel_error_in_energy_conservation = 1d-3

--- a/star/test_suite/make_he_wd/inlist_remove_envelope
+++ b/star/test_suite/make_he_wd/inlist_remove_envelope
@@ -47,6 +47,7 @@
       max_age = 1d8
 
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
 
       warn_when_large_rel_run_E_err = 1d99
       max_abs_rel_run_E_err = 1d99

--- a/star/test_suite/make_he_wd/inlist_to_he_core
+++ b/star/test_suite/make_he_wd/inlist_to_he_core
@@ -47,6 +47,7 @@
       energy_eqn_option = 'eps_grav'
       use_time_centered_eps_grav = .true.
       include_composition_in_eps_grav = .true.
+      use_gold2_tolerances = .true.
 
       warn_when_large_rel_run_E_err = 1d99
       max_abs_rel_run_E_err = 1d99

--- a/star/test_suite/make_metals/inlist_make_metals
+++ b/star/test_suite/make_metals/inlist_make_metals
@@ -39,6 +39,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 1400
+      use_gold2_tolerances = .true.
 
       initial_mass = 3
       initial_z = 0

--- a/star/test_suite/make_o_ne_wd/inlist_c_burn
+++ b/star/test_suite/make_o_ne_wd/inlist_c_burn
@@ -24,6 +24,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 3000
+      use_gold2_tolerances = .true.
 
 ! when to stop
       star_species_mass_max_limit = 0.3d0 ! Msun

--- a/star/test_suite/make_o_ne_wd/inlist_common
+++ b/star/test_suite/make_o_ne_wd/inlist_common
@@ -74,6 +74,7 @@
 
 ! solver
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
 ! output
       num_trace_history_values = 2

--- a/star/test_suite/make_planets/inlist_evolve
+++ b/star/test_suite/make_planets/inlist_evolve
@@ -38,6 +38,7 @@
       warn_when_large_virial_thm_rel_err = 5d-2
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/make_sdb/inlist_make_sdb
+++ b/star/test_suite/make_sdb/inlist_make_sdb
@@ -55,6 +55,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 4200
+      use_gold2_tolerances = .true.
       
       xa_central_upper_limit_species(1) = 'c12'
       xa_central_upper_limit(1) = 0.05d0

--- a/star/test_suite/make_zams/inlist_zams
+++ b/star/test_suite/make_zams/inlist_zams
@@ -33,6 +33,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/make_zams_low_mass/inlist_zams
+++ b/star/test_suite/make_zams_low_mass/inlist_zams
@@ -34,6 +34,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/make_zams_ultra_high_mass/inlist_zams_ultra_high_mass
+++ b/star/test_suite/make_zams_ultra_high_mass/inlist_zams_ultra_high_mass
@@ -48,6 +48,7 @@
       
       ! limit max_model_number as part of test_suite
       max_model_number = 10000
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/ns_c/inlist_to_c_flash
+++ b/star/test_suite/ns_c/inlist_to_c_flash
@@ -106,6 +106,7 @@
 ! solver    
       energy_eqn_option = 'dedt'
 
+      use_gold2_tolerances = .true.
       steps_before_use_gold2_tolerances = 1
 
       use_other_cgrav = .true. ! for GR factor with gravity

--- a/star/test_suite/other_physics_hooks/inlist_other_physics_hooks
+++ b/star/test_suite/other_physics_hooks/inlist_other_physics_hooks
@@ -34,6 +34,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/radiative_levitation/inlist_radiative_levitation
+++ b/star/test_suite/radiative_levitation/inlist_radiative_levitation
@@ -48,6 +48,7 @@
 &controls
 
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
       
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/relax_composition_j_entropy/inlist_common
+++ b/star/test_suite/relax_composition_j_entropy/inlist_common
@@ -12,6 +12,7 @@
 
   ! limit max_model_number as part of test_suite
     max_model_number = 1000
+    use_gold2_tolerances = .true.
 
     use_ledoux_criterion = .true.
     mixing_length_alpha = 1.5
@@ -52,7 +53,7 @@
   ! stop when the center mass fraction of h1 drops below this limit
     xa_central_lower_limit_species(1) = 'he4'
     xa_central_lower_limit(1) = 1d-3
-MLT_option='Cox'
+    MLT_option='Cox'
 / ! end of controls namelist
 
 

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP
@@ -67,6 +67,7 @@
    RSP_max_num_periods = 3000
    
 ! solver
+   use_gold2_tolerances = .true.
    
 ! output controls
    

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP_std
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP_std
@@ -67,6 +67,7 @@
    RSP_max_num_periods = 3000
    
 ! solver
+   use_gold2_tolerances = .true.
    
 ! output controls
    

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP
@@ -74,6 +74,7 @@ use_Skye = .false.
    RSP_kick_vsurf_km_per_sec = 0.5d0
    
 ! solver
+   use_gold2_tolerances = .true.
 
 ! output controls
    

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_std
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_std
@@ -72,6 +72,7 @@
    RSP_kick_vsurf_km_per_sec = 0.5d0
    
 ! solver
+   use_gold2_tolerances = .true.
 
 ! output controls
    

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid
@@ -68,6 +68,7 @@
       
    
 ! solver
+   use_gold2_tolerances = .true.
 
 ! output controls
    

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_std
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_std
@@ -68,6 +68,7 @@
       
    
 ! solver
+   use_gold2_tolerances = .true.
 
 ! output controls
    

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid
@@ -58,6 +58,7 @@
    !   Y = 0.267d0
       
 ! solver
+   use_gold2_tolerances = .true.
 
 ! output controls
    

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_std
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_std
@@ -58,6 +58,7 @@
    !   Y = 0.267d0
       
 ! solver
+   use_gold2_tolerances = .true.
 
 ! output controls
    

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti
@@ -53,6 +53,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 16000
+   use_gold2_tolerances = .true.
 
 ! RSP controls
 

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_std
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_std
@@ -53,6 +53,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 16000
+   use_gold2_tolerances = .true.
 
 ! RSP controls
 

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae
@@ -46,6 +46,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 15000
+   use_gold2_tolerances = .true.
 
 ! RSP controls
 

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_std
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_std
@@ -46,6 +46,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 15000
+   use_gold2_tolerances = .true.
 
 ! RSP controls
 

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid
@@ -53,6 +53,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 18000
+   use_gold2_tolerances = .true.
 
 ! RSP controls
 

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_std
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_std
@@ -53,6 +53,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 18000
+   use_gold2_tolerances = .true.
 
 ! RSP controls
 

--- a/star/test_suite/rsp_check_2nd_crossing/inlist_rsp_check_2nd_crossing
+++ b/star/test_suite/rsp_check_2nd_crossing/inlist_rsp_check_2nd_crossing
@@ -124,6 +124,8 @@
       history_interval = 10
       terminal_interval = 4000
 
+      use_gold2_tolerances = .true.
+
 / ! end of controls namelist
 
 

--- a/star/test_suite/rsp_gyre/inlist_rsp_gyre
+++ b/star/test_suite/rsp_gyre/inlist_rsp_gyre
@@ -43,6 +43,7 @@
 
    ! limit max_model_number as part of test_suite
    max_model_number = 8000
+   use_gold2_tolerances = .true.
    
    calculate_Brunt_N2 = .true.
 

--- a/star/test_suite/rsp_save_and_load_file/inlist_rsp_common
+++ b/star/test_suite/rsp_save_and_load_file/inlist_rsp_common
@@ -283,6 +283,7 @@
 
 ! general 
       set_rho_to_dm_div_dV = .false.
+      use_gold2_tolerances = .true.
 
       !use_eosDT2 = .true.
       !use_eosELM = .true.

--- a/star/test_suite/semiconvection/inlist_semiconvection
+++ b/star/test_suite/semiconvection/inlist_semiconvection
@@ -54,6 +54,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 1000
+      use_gold2_tolerances = .true.
 
       initial_mass = 1.5
       initial_z = 0.02d0

--- a/star/test_suite/semiconvection/inlist_to_ZAMS
+++ b/star/test_suite/semiconvection/inlist_to_ZAMS
@@ -55,6 +55,7 @@
 
       !max_years_for_timestep = 1d4
       !max_timestep_factor = 1.2
+      use_gold2_tolerances = .true.
       
 ! output controls
 

--- a/star/test_suite/simplex_solar_calibration/inlist_prezams
+++ b/star/test_suite/simplex_solar_calibration/inlist_prezams
@@ -35,6 +35,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 1200
+      use_gold2_tolerances = .true.
 
       max_years_for_timestep = 1d6           
       varcontrol_target = 1d-3

--- a/star/test_suite/simplex_solar_calibration/inlist_solar
+++ b/star/test_suite/simplex_solar_calibration/inlist_solar
@@ -69,6 +69,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 1200
+      use_gold2_tolerances = .true.
 
       max_years_for_timestep = 1d7           
       varcontrol_target = 1d-3

--- a/star/test_suite/starspots/inlist_starspots
+++ b/star/test_suite/starspots/inlist_starspots
@@ -104,6 +104,9 @@
 
     do_element_diffusion = .false.
     report_solver_progress = .false.
+
+    ! Solver
+    use_gold2_tolerances = .true.
     
     ! Timestep and grid
     mesh_delta_coeff = 0.8

--- a/star/test_suite/test_case_template/inlist_start
+++ b/star/test_suite/test_case_template/inlist_start
@@ -37,6 +37,7 @@
 ! mesh
 
 ! solver
+      use_gold2_tolerances = .true.
 
 ! output
 

--- a/star/test_suite/test_case_template/inlist_x
+++ b/star/test_suite/test_case_template/inlist_x
@@ -47,6 +47,7 @@
 ! mesh
 
 ! solver
+      use_gold2_tolerances = .true.
 
 ! output
 

--- a/star/test_suite/timing/inlist_timing
+++ b/star/test_suite/timing/inlist_timing
@@ -44,6 +44,7 @@
 &controls
       
       energy_eqn_option = 'dedt'
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/wd_acc_small_dm/inlist_wd_acc_small_dm
+++ b/star/test_suite/wd_acc_small_dm/inlist_wd_acc_small_dm
@@ -45,6 +45,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 500
+      use_gold2_tolerances = .true.
       
       max_age = 3d-4
 

--- a/star/test_suite/wd_aic/inlist_accrete
+++ b/star/test_suite/wd_aic/inlist_accrete
@@ -27,6 +27,7 @@
 
   ! use eps_grav form
     use_gold_tolerances = .true.
+    use_gold2_tolerances = .true.
 
   ! when to stop
     log_center_density_limit = 9.45

--- a/star/test_suite/wd_c_core_ignition/inlist_relax_mass
+++ b/star/test_suite/wd_c_core_ignition/inlist_relax_mass
@@ -30,7 +30,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 200
-
+      use_gold2_tolerances = .true.
       
       mass_change = -1e-9
       star_mass_min_limit = 0.95  ! chosen to remove outer H/He envelope

--- a/star/test_suite/wd_c_core_ignition/inlist_wd_c_core_ignition
+++ b/star/test_suite/wd_c_core_ignition/inlist_wd_c_core_ignition
@@ -52,6 +52,7 @@
       ! energy equation options
       energy_eqn_option = 'eps_grav'
       use_time_centered_eps_grav = .true.
+      use_gold2_tolerances = .true.
 
       limit_for_rel_error_in_energy_conservation = 1d99
       hard_limit_for_rel_error_in_energy_conservation = 1d99

--- a/star/test_suite/wd_cool_0.6M/inlist_wd_cool_0.6M
+++ b/star/test_suite/wd_cool_0.6M/inlist_wd_cool_0.6M
@@ -68,6 +68,7 @@
          ! since have energy_eqn_option = 'eps_grav'
       limit_for_rel_error_in_energy_conservation = 1d-4
       hard_limit_for_rel_error_in_energy_conservation = 1d-3
+      use_gold2_tolerances = .true.
 
       atm_option = 'table'
       atm_table = 'WD_tau_25'

--- a/star/test_suite/wd_diffusion/inlist_wd_diff
+++ b/star/test_suite/wd_diffusion/inlist_wd_diff
@@ -38,6 +38,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 2000
+      use_gold2_tolerances = .true.
 
       energy_eqn_option = 'eps_grav'
 

--- a/star/test_suite/wd_he_shell_ignition/inlist_he_shell_ignition
+++ b/star/test_suite/wd_he_shell_ignition/inlist_he_shell_ignition
@@ -63,6 +63,7 @@
       ! can't make it through the flash at the end with this true
       ! check again after composition derivatives exist
       include_composition_in_eps_grav = .false.
+      use_gold2_tolerances = .true.
 
       num_trace_history_values = 2
       trace_history_value_name(1) = 'rel_E_err'

--- a/star/test_suite/wd_nova_burst/inlist_setup
+++ b/star/test_suite/wd_nova_burst/inlist_setup
@@ -58,6 +58,7 @@
       
 ! solver
       energy_eqn_option = 'eps_grav'
+      use_gold2_tolerances = .true.
 
       limit_for_rel_error_in_energy_conservation = 1d-5
       hard_limit_for_rel_error_in_energy_conservation = 1d-3

--- a/star/test_suite/wd_stable_h_burn/inlist_wd_stable_h_burn
+++ b/star/test_suite/wd_stable_h_burn/inlist_wd_stable_h_burn
@@ -68,6 +68,7 @@
 
       ! limit max_model_number as part of test_suite
       max_model_number = 6000
+      use_gold2_tolerances = .true.
 
       use_Ledoux_criterion = .false.
       

--- a/star/test_suite/zams_to_cc_80/inlist_common
+++ b/star/test_suite/zams_to_cc_80/inlist_common
@@ -170,6 +170,8 @@
       gold2_tol_max_residual3 = 5d-4
       gold_tol_max_residual2 = 5d-4
 
+      max_abs_rel_run_E_err = 1d-2
+
       energy_eqn_option = 'dedt'
       max_tries_for_implicit_wind = 0      
 


### PR DESCRIPTION
Works on #490 

This should leave test cases that explicitly set gold2 on/off alone and only sets cases which don't specify gold2 to now be on.

https://testhub.mesastar.org/rf%2Fgold2_off/commits/dc8a8c4