### PR TITLE
change safe_logs test from IEEE_NORMAL to IEEE_FINITE

### DIFF
--- a/math/public/math_lib_crmath.f90
+++ b/math/public/math_lib_crmath.f90
@@ -153,7 +153,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log_x
 
-    if (.NOT. IEEE_IS_NORMAL(x)) then
+    if (.NOT. IEEE_IS_FINITE(x)) then
 
        log_x = 1.E-99_dp
 
@@ -172,7 +172,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log10_x
 
-    if (.NOT. IEEE_IS_NORMAL(x)) then
+    if (.NOT. IEEE_IS_FINITE(x)) then
 
        log10_x = 1.E-99_dp
 

--- a/math/public/math_lib_crmath.f90
+++ b/math/public/math_lib_crmath.f90
@@ -155,7 +155,7 @@ contains
 
     if (.NOT. IEEE_IS_FINITE(x)) then
 
-       log_x = 1.E-99_dp
+       log_x = -99._dp
 
     else
 
@@ -174,7 +174,7 @@ contains
 
     if (.NOT. IEEE_IS_FINITE(x)) then
 
-       log10_x = 1.E-99_dp
+       log10_x = -99._dp
 
     else
 

--- a/math/public/math_lib_intrinsic.f90
+++ b/math/public/math_lib_intrinsic.f90
@@ -173,7 +173,7 @@ contains
 
     if (.NOT. IEEE_IS_FINITE(x)) then
 
-       log_x = 1.E-99_dp
+       log_x = -99._dp
 
     else
 
@@ -192,7 +192,7 @@ contains
 
     if (.NOT. IEEE_IS_FINITE(x)) then
 
-       log10_x = 1.E-99_dp
+       log10_x = -99._dp
 
     else
 

--- a/math/public/math_lib_intrinsic.f90
+++ b/math/public/math_lib_intrinsic.f90
@@ -171,7 +171,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log_x
 
-    if (.NOT. IEEE_IS_NORMAL(x)) then
+    if (.NOT. IEEE_IS_FINITE(x)) then
 
        log_x = 1.E-99_dp
 
@@ -190,7 +190,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log10_x
 
-    if (.NOT. IEEE_IS_NORMAL(x)) then
+    if (.NOT. IEEE_IS_FINITE(x)) then
 
        log10_x = 1.E-99_dp
 


### PR DESCRIPTION
addresses #510.

All tests on [Cannon](https://testhub.mesastar.org/change_safe_logs/commits/3529123) are passing, so I'd propose to implement this change into main. Although we'd probably want to test also on other systems too, since these low level routines could be machine/architecture/compiler dependent.