### PR TITLE
Fix eps_nuc output

### DIFF
--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -832,9 +832,11 @@ contains
          end if
          val = s% r(k) / s%r(1)
          if (k == 1) return
-         eps1 = s% eps_nuc(k) - s% eps_nuc_neu_total(k) - s% non_nuc_neu(k)
+         ! Do not subtract s% eps_nuc_neu_total(k)  eps_nuc already contains it
+         eps1 = s% eps_nuc(k) - s% non_nuc_neu(k)
          bv1 = sign(1d0, eps1) * log10(max(1d0, abs(eps1)))
-         eps0 = s% eps_nuc(k - 1) - s% eps_nuc_neu_total(k - 1) - s% non_nuc_neu(k - 1)
+         ! Do not subtract s% eps_nuc_neu_total(k)  eps_nuc already contains it
+         eps0 = s% eps_nuc(k - 1) - s% non_nuc_neu(k - 1)
          bv0 = sign(1d0, eps0) * log10(max(1d0, abs(eps0)))
          bv = max(bv0, bv1)
          eps = pow(10d0, bv)

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -467,9 +467,11 @@
                val = s% eps_grav_ad(k)% val
                val = sign(1d0,val)*log10(max(1d0,abs(val)))
             case (p_net_nuclear_energy)
-               val = s% eps_nuc(k) - s% eps_nuc_neu_total(k) - s% non_nuc_neu(k)
+               ! Do not subtract s% eps_nuc_neu_total(k)  eps_nuc already contains it
+               val = s% eps_nuc(k) - s% non_nuc_neu(k)
                val = sign(1d0,val)*log10(max(1d0,abs(val)))
             case (p_eps_nuc_plus_nuc_neu)
+               !  eps_nuc  subtracts eps_nuc_neu so this is just the total eenrgy from nuclear burning without neutrinos
                val = s% eps_nuc(k) + s% eps_nuc_neu_total(k)
             case (p_eps_nuc_minus_non_nuc_neu)
                val = s% eps_nuc(k) - s% non_nuc_neu(k)

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -221,6 +221,7 @@
       real(dp), pointer :: eps_nuc(:) ! sum of reaction_eps_nuc for all reactions in net
          ! thermal ergs per gram per second from nuclear reactions
          ! (including losses to neutrinos produced in the reactions)
+         ! Thus you should not subtract eps_nuc_neu_total from this
       real(dp), pointer :: eps_nuc_categories(:,:) ! (num_categories, nz)
       real(dp), pointer :: d_epsnuc_dlnd(:) ! partial wrt density
       real(dp), pointer :: d_epsnuc_dlnT(:) ! partial wrt temperature


### PR DESCRIPTION
eps_nuc as reported by net/ already contains the eps_nuc_neu (nuclear neutrino) losses. Thus we should not subtract them again.

Fixes #493