### PR TITLE
Speed up OP Mono Mombarg Routines

### DIFF
--- a/kap/private/condint.f90
+++ b/kap/private/condint.f90
@@ -25,32 +25,32 @@
 
 
       module condint
-
+      
       use const_def, only: dp
       use math_lib
       use utils_lib, only: mesa_error
-
+      
       implicit none
 
 
       integer, parameter :: num_logTs=29, num_logRhos=71, num_logzs=15
       !!! NB: These parameters must be consistent with the table "condtabl.d"!
       logical :: initialized = .false.
-
+      
       real(dp) :: logTs(num_logTs), logRhos(num_logRhos), logzs(num_logzs)
       real(dp), target :: f_ary(4*num_logRhos*num_logTs*num_logzs) ! for bicubic splines
       real(dp), pointer :: f(:,:,:,:)
       integer :: ilinx(num_logzs), iliny(num_logzs)
-
-
+      
+      
       contains
-
-
+      
+      
       subroutine init_potekhin(ierr)
          use kap_def, only: kap_dir
          use interp_2d_lib_db, only: interp_mkbicub_db
          integer, intent(out) :: ierr
-
+         
          character (len=256) :: filename
          integer :: read_err, iz, it, ir, shift
          integer :: ibcxmin                   ! bc flag for x=xmin
@@ -63,15 +63,15 @@
          real(dp) :: bcymax(num_logRhos)               ! bc data vs. x at y=ymax
          real(dp) :: Z
          real(dp), pointer :: f1(:)
-
+         
          include 'formats'
-
+         
          ierr = 0
          if (initialized) return
-
+         
          shift = 4*num_logRhos*num_logTs
          f(1:4,1:num_logRhos,1:num_logTs,1:num_logzs) => f_ary(1:shift*num_logzs)
-
+                  
          filename = trim(kap_dir) // '/condtabl.data'
          open(1,file=trim(filename),status='OLD',iostat=ierr)
          if (ierr /= 0) then
@@ -123,7 +123,7 @@
          ibcymin = 3; bcymin(1:num_logRhos) = 0d0
          ibcymax = 3; bcymax(1:num_logRhos) = 0d0
          do iz = 1, num_logzs
-            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift)
+            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift) 
             call interp_mkbicub_db( &
                logRhos, num_logRhos, logTs, num_logTs, f1, num_logRhos, &
                ibcxmin, bcxmin, ibcxmax, bcxmax, &
@@ -143,8 +143,8 @@
          end do
          initialized = .true.
       end subroutine init_potekhin
-
-
+      
+      
       subroutine do_electron_conduction_potekhin( &
             zbar, logRho_in, logT_in, kap, dlogkap_dlogRho, dlogkap_dlogT, ierr)
 
@@ -152,7 +152,7 @@
          real(dp), intent(in) :: zbar, logRho_in, logT_in
          real(dp), intent(out) :: kap, dlogkap_dlogRho, dlogkap_dlogT
          integer, intent(out) :: ierr
-
+         
          integer :: iz, iz1, iz2, shift
          real(dp) :: zlog, logRho, logT
          real(dp) :: alfa, beta, &
@@ -164,7 +164,7 @@
          logical :: clipped_logRho, clipped_logT
 
          include 'formats'
-
+         
          ierr = 0
          shift = 4*num_logRhos*num_logTs
 
@@ -191,7 +191,7 @@
          end if
 
          zlog = max(logzs(1),min(logzs(num_logzs),log10(max(1d-30,zbar))))
-
+         
          if (zlog <= logzs(1)) then ! use 1st
             call get1(1, logK, dlogK_dlogRho, dlogK_dlogT, ierr)
          else if (zlog >= logzs(num_logzs)) then ! use last
@@ -212,19 +212,19 @@
                write(*,*) 'confusion in do_electron_conduction'
                call mesa_error(__FILE__,__LINE__)
             end if
-
+            
             call get1(iz1, logK1, dlogK1_dlogRho, dlogK1_dlogT, ierr)
             if (ierr /= 0) then
                write(*,*) 'interp failed for iz1 in do_electron_conduction', iz1, logRho, logT
                call mesa_error(__FILE__,__LINE__)
             end if
-
+            
             call get1(iz2, logK2, dlogK2_dlogRho, dlogK2_dlogT, ierr)
             if (ierr /= 0) then
                write(*,*) 'interp failed for iz2 in do_electron_conduction', iz2, logRho, logT
                call mesa_error(__FILE__,__LINE__)
             end if
-
+            
             ! linear interpolation in zlog
             alfa = (zlog - logzs(iz1)) / (logzs(iz2) - logzs(iz1))
             beta = 1d0-alfa
@@ -246,14 +246,14 @@
          ! logkap = 3*logT - logRho - logK + log10(16*boltz_sigma/3)
 
          logkap = 3d0*logT_in - logRho_in - logK + log10(16d0 * boltz_sigma / 3d0)
-
+         
          kap = exp10(logkap)
          dlogkap_dlogRho = -1d0 - dlogK_dlogRho
          dlogkap_dlogT = 3d0 - dlogK_dlogT
 
          contains
-
-
+         
+         
          subroutine get1(iz, logK, dlogK_dlogRho, dlogK_dlogT, ierr)
             use kap_eval_support, only: Do_Kap_Interpolations
             integer, intent(in) :: iz
@@ -265,8 +265,8 @@
             integer :: i_logRho, j_logT, k
             include 'formats'
             ierr = 0
-            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift)
-
+            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift) 
+            
             if (logRho < logRhos(2)) then
                i_logRho = 1
             else
@@ -279,7 +279,7 @@
             end if
             logRho0 = logRhos(i_logRho)
             logRho1 = logRhos(i_logRho+1)
-
+            
             if (logT < logTs(2)) then
                j_logT = 1
             else
@@ -291,13 +291,13 @@
                end do
             end if
             logT0 = logTs(j_logT)
-            logT1 = logTs(j_logT+1)
-
+            logT1 = logTs(j_logT+1)            
+            
             call Do_Kap_Interpolations( &
                f1, num_logRhos, num_logTs, i_logRho, j_logT, logRho0, &
                logRho, logRho1, logT0, logT, logT1, logK, dlogK_dlogRho, dlogK_dlogT)
             if (ierr /= 0) return
-
+            
          end subroutine get1
 
 

--- a/kap/private/condint.f90
+++ b/kap/private/condint.f90
@@ -25,32 +25,32 @@
 
 
       module condint
-      
+
       use const_def, only: dp
       use math_lib
       use utils_lib, only: mesa_error
-      
+
       implicit none
 
 
       integer, parameter :: num_logTs=29, num_logRhos=71, num_logzs=15
       !!! NB: These parameters must be consistent with the table "condtabl.d"!
       logical :: initialized = .false.
-      
+
       real(dp) :: logTs(num_logTs), logRhos(num_logRhos), logzs(num_logzs)
       real(dp), target :: f_ary(4*num_logRhos*num_logTs*num_logzs) ! for bicubic splines
       real(dp), pointer :: f(:,:,:,:)
       integer :: ilinx(num_logzs), iliny(num_logzs)
-      
-      
+
+
       contains
-      
-      
+
+
       subroutine init_potekhin(ierr)
          use kap_def, only: kap_dir
          use interp_2d_lib_db, only: interp_mkbicub_db
          integer, intent(out) :: ierr
-         
+
          character (len=256) :: filename
          integer :: read_err, iz, it, ir, shift
          integer :: ibcxmin                   ! bc flag for x=xmin
@@ -63,15 +63,15 @@
          real(dp) :: bcymax(num_logRhos)               ! bc data vs. x at y=ymax
          real(dp) :: Z
          real(dp), pointer :: f1(:)
-         
+
          include 'formats'
-         
+
          ierr = 0
          if (initialized) return
-         
+
          shift = 4*num_logRhos*num_logTs
          f(1:4,1:num_logRhos,1:num_logTs,1:num_logzs) => f_ary(1:shift*num_logzs)
-                  
+
          filename = trim(kap_dir) // '/condtabl.data'
          open(1,file=trim(filename),status='OLD',iostat=ierr)
          if (ierr /= 0) then
@@ -123,7 +123,7 @@
          ibcymin = 3; bcymin(1:num_logRhos) = 0d0
          ibcymax = 3; bcymax(1:num_logRhos) = 0d0
          do iz = 1, num_logzs
-            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift) 
+            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift)
             call interp_mkbicub_db( &
                logRhos, num_logRhos, logTs, num_logTs, f1, num_logRhos, &
                ibcxmin, bcxmin, ibcxmax, bcxmax, &
@@ -143,8 +143,8 @@
          end do
          initialized = .true.
       end subroutine init_potekhin
-      
-      
+
+
       subroutine do_electron_conduction_potekhin( &
             zbar, logRho_in, logT_in, kap, dlogkap_dlogRho, dlogkap_dlogT, ierr)
 
@@ -152,7 +152,7 @@
          real(dp), intent(in) :: zbar, logRho_in, logT_in
          real(dp), intent(out) :: kap, dlogkap_dlogRho, dlogkap_dlogT
          integer, intent(out) :: ierr
-         
+
          integer :: iz, iz1, iz2, shift
          real(dp) :: zlog, logRho, logT
          real(dp) :: alfa, beta, &
@@ -164,7 +164,7 @@
          logical :: clipped_logRho, clipped_logT
 
          include 'formats'
-         
+
          ierr = 0
          shift = 4*num_logRhos*num_logTs
 
@@ -191,7 +191,7 @@
          end if
 
          zlog = max(logzs(1),min(logzs(num_logzs),log10(max(1d-30,zbar))))
-         
+
          if (zlog <= logzs(1)) then ! use 1st
             call get1(1, logK, dlogK_dlogRho, dlogK_dlogT, ierr)
          else if (zlog >= logzs(num_logzs)) then ! use last
@@ -212,19 +212,19 @@
                write(*,*) 'confusion in do_electron_conduction'
                call mesa_error(__FILE__,__LINE__)
             end if
-            
+
             call get1(iz1, logK1, dlogK1_dlogRho, dlogK1_dlogT, ierr)
             if (ierr /= 0) then
                write(*,*) 'interp failed for iz1 in do_electron_conduction', iz1, logRho, logT
                call mesa_error(__FILE__,__LINE__)
             end if
-            
+
             call get1(iz2, logK2, dlogK2_dlogRho, dlogK2_dlogT, ierr)
             if (ierr /= 0) then
                write(*,*) 'interp failed for iz2 in do_electron_conduction', iz2, logRho, logT
                call mesa_error(__FILE__,__LINE__)
             end if
-            
+
             ! linear interpolation in zlog
             alfa = (zlog - logzs(iz1)) / (logzs(iz2) - logzs(iz1))
             beta = 1d0-alfa
@@ -246,14 +246,14 @@
          ! logkap = 3*logT - logRho - logK + log10(16*boltz_sigma/3)
 
          logkap = 3d0*logT_in - logRho_in - logK + log10(16d0 * boltz_sigma / 3d0)
-         
+
          kap = exp10(logkap)
          dlogkap_dlogRho = -1d0 - dlogK_dlogRho
          dlogkap_dlogT = 3d0 - dlogK_dlogT
 
          contains
-         
-         
+
+
          subroutine get1(iz, logK, dlogK_dlogRho, dlogK_dlogT, ierr)
             use kap_eval_support, only: Do_Kap_Interpolations
             integer, intent(in) :: iz
@@ -265,8 +265,8 @@
             integer :: i_logRho, j_logT, k
             include 'formats'
             ierr = 0
-            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift) 
-            
+            f1(1:shift) => f_ary(1+(iz-1)*shift:iz*shift)
+
             if (logRho < logRhos(2)) then
                i_logRho = 1
             else
@@ -279,7 +279,7 @@
             end if
             logRho0 = logRhos(i_logRho)
             logRho1 = logRhos(i_logRho+1)
-            
+
             if (logT < logTs(2)) then
                j_logT = 1
             else
@@ -291,13 +291,13 @@
                end do
             end if
             logT0 = logTs(j_logT)
-            logT1 = logTs(j_logT+1)            
-            
+            logT1 = logTs(j_logT+1)
+
             call Do_Kap_Interpolations( &
                f1, num_logRhos, num_logTs, i_logRho, j_logT, logRho0, &
                logRho, logRho1, logT0, logT, logT1, logK, dlogK_dlogRho, dlogK_dlogT)
             if (ierr /= 0) return
-            
+
          end subroutine get1
 
 

--- a/kap/private/kap_eval.f90
+++ b/kap/private/kap_eval.f90
@@ -28,13 +28,13 @@
       use kap_def
       use const_def, only: dp, ln10, sige
       use math_lib
-      
+
       implicit none
-      
-            
+
+
       contains
-      
-      
+
+
       subroutine Get_kap_Results( &
            rq, zbar, X, Z, XC, XN, XO, XNe, logRho, logT, &
            lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT, &
@@ -67,7 +67,7 @@
          type(auto_diff_real_2var_order1) :: blend_logT, blend_logR, blend
 
          real(dp) :: frac_Type2, frac_highT, frac_lowT
-         
+
          logical :: dbg
 
          include 'formats'
@@ -221,13 +221,13 @@
          dlnkap_rad_dlnT = logkap_rad% d1val2
 
          call combine_rad_with_conduction( &
-            rq, Rho, logRho, T, logT, zbar, &
+            rq, logRho, logT, zbar, &
             kap_rad, dlnkap_rad_dlnRho, dlnkap_rad_dlnT, &
             kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
-         
+
       end subroutine Get_kap_Results
-      
-      
+
+
       subroutine Get_kap_Results_blend_T( &
            rq, X, Z, XC, XN, XO, XNe, logRho_in, logT_in, &
            frac_lowT, frac_highT, frac_Type2, kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
@@ -237,7 +237,7 @@
 
         ! INPUT
         type (Kap_General_Info), pointer :: rq
-        real(dp), intent(in) :: X, Z, XC, XN, XO, XNe ! composition    
+        real(dp), intent(in) :: X, Z, XC, XN, XO, XNe ! composition
         real(dp), intent(in) :: logRho_in ! density
         real(dp), intent(in) :: logT_in ! temperature
 
@@ -255,7 +255,7 @@
         real(dp) :: lowT_logT_max, logT_min
 
         logical :: clipped_Rho
-        
+
         logical :: dbg
 
         real(dp) :: alfa, beta, &
@@ -313,7 +313,7 @@
         case (kap_lowT_AESOPUS)
            lowT_logT_max = kA % max_logT
         case default
-           lowT_logT_max = kap_lowT_z_tables(rq% kap_lowT_option)% ar(1)% x_tables(1)% logT_max           
+           lowT_logT_max = kap_lowT_z_tables(rq% kap_lowT_option)% ar(1)% x_tables(1)% logT_max
         end select
 
 
@@ -347,7 +347,7 @@
         alfa0 = (logT - lower_bdy) / (upper_bdy - lower_bdy)
         d_alfa0_dlnT = 1d0/(upper_bdy - lower_bdy)/ln10
 
-        ! must smooth the transitions near alfa = 0.0 and 1.0  
+        ! must smooth the transitions near alfa = 0.0 and 1.0
         ! Rich Townsend's smoothing function for this
         alfa = -alfa0*alfa0*alfa0*(-10d0 + alfa0*(15d0 - 6d0*alfa0))
         d_alfa_dlnT = 30d0*(alfa0 - 1d0)*(alfa0 - 1d0)*alfa0*alfa0*d_alfa0_dlnT
@@ -398,7 +398,7 @@
 
         ! INPUT
         type (Kap_General_Info), pointer :: rq
-        real(dp), intent(in) :: X, Z, XC, XN, XO, XNe ! composition    
+        real(dp), intent(in) :: X, Z, XC, XN, XO, XNe ! composition
         real(dp), intent(in) :: logRho_in ! density
         real(dp), intent(in) :: logT_in ! temperature
         ! free_e := total combined number per nucleon of free electrons and positrons
@@ -455,7 +455,7 @@
            call AESOPUS_get(Zbase, X, XC, XN, XO, logRho, logT, &
                 kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
 
-           
+
         case default
            if (rq% kap_lowT_option == kap_lowT_test) then
               if (dbg) write(*,*) 'Calling test for lowT'
@@ -489,7 +489,7 @@
 
         ! INPUT
         type (Kap_General_Info), pointer :: rq
-        real(dp), intent(in) :: X, Z, XC_in, XN_in, XO_in, XNe_in ! composition    
+        real(dp), intent(in) :: X, Z, XC_in, XN_in, XO_in, XNe_in ! composition
         real(dp), intent(in) :: logRho_in ! density
         real(dp), intent(in) :: logT_in ! temperature
 
@@ -700,24 +700,24 @@
 
 
       subroutine combine_rad_with_conduction( &
-            rq, Rho, logRho, T, logT, zbar, &
+            rq, logRho, logT, zbar, &
             kap_rad, dlnkap_rad_dlnRho, dlnkap_rad_dlnT, &
             kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
 
          use condint, only: do_electron_conduction
          type (Kap_General_Info), pointer :: rq
-         real(dp), intent(in) :: Rho, logRho, T, logT, zbar
+         real(dp), intent(in) :: logRho, logT, zbar
          real(dp), intent(inout) :: kap_rad, dlnkap_rad_dlnRho, dlnkap_rad_dlnT
          real(dp), intent(out) :: kap, dlnkap_dlnRho, dlnkap_dlnT
          integer, intent(out) :: ierr ! 0 means AOK.
-      
+
          real(dp) :: kap_ec, dlnkap_ec_dlnRho, dlnkap_ec_dlnT
          logical, parameter :: dbg = .false.
-         
+
          include 'formats'
-         
+
          ierr = 0
-         
+
          if (.not. rq% include_electron_conduction) then
             kap = kap_rad
             dlnkap_dlnRho = dlnkap_rad_dlnRho
@@ -744,12 +744,12 @@
          if (dbg) write(*,1) 'dlnkap_ec_dlnRho', dlnkap_ec_dlnRho
          if (dbg) write(*,1) 'dlnkap_ec_dlnT', dlnkap_ec_dlnT
          if (dbg) write(*,*)
-         
+
          kap = 1d0 / (1d0/kap_rad + 1d0/kap_ec)
          if (dbg) write(*,1) 'kap_rad', kap_rad
          if (dbg) write(*,1) 'kap', kap
          if (dbg) write(*,1) 'log10(kap)', log10(kap)
-         
+
          if (is_bad(kap)) then
             ierr = -1; return
             write(*,1) 'kap', kap
@@ -769,9 +769,9 @@
             write(*,1) 'kap_ec', kap_ec
             call mesa_error(__FILE__,__LINE__,'combine_rad_with_conduction')
          end if
-         
+
          dlnkap_dlnT = (kap/kap_rad) * dlnkap_rad_dlnT + (kap/kap_ec) * dlnkap_ec_dlnT
-         
+
          if (is_bad(dlnkap_dlnT)) then
             ierr = -1; return
             write(*,1) 'dlnkap_dlnT', dlnkap_dlnT
@@ -787,8 +787,8 @@
          if (dbg) write(*,1) 'dlnkap_dlnRho', dlnkap_dlnRho
          if (dbg) write(*,1) 'dlnkap_dlnT', dlnkap_dlnT
          if (dbg) call mesa_error(__FILE__,__LINE__,'combine_rad_with_conduction')
-      
-      
+
+
       end subroutine combine_rad_with_conduction
 
 
@@ -810,7 +810,7 @@
          real(dp), intent(in) :: eta_in, d_eta_dlnRho, d_eta_dlnT
          real(dp), intent(out) :: kap, dlnkap_dlnRho, dlnkap_dlnT
          integer, intent(out) :: ierr
-         
+
          type(auto_diff_real_2var_order1) :: T, rho, free_e, eta, kap_auto
          type(auto_diff_real_2var_order1) :: zeta, f1, f2, f3, alpha, tbr, theta, tkev, mfp
 
@@ -828,15 +828,15 @@
             c22    = -0.0067d0, &
             c31    = -0.037d0, &
             c32    =  0.0031d0
-         
+
          include 'formats'
-         
+
          ierr = 0
 
          ! set up auto diff
          ! var1: Rho
          ! var2: T
-         
+
          Rho = Rho_in
          Rho% d1val1 = 1d0
          Rho% d1val2 = 0d0
@@ -871,9 +871,8 @@
          kap = kap_auto% val
          dlnkap_dlnRho = Rho% val * kap_auto% d1val1 / kap
          dlnkap_dlnT = T% val * kap_auto% d1val2 / kap
-         
+
       end subroutine Compton_Opacity
 
 
       end module kap_eval
-      

--- a/kap/public/kap_lib.f90
+++ b/kap/public/kap_lib.f90
@@ -773,7 +773,7 @@
       end subroutine call_compute_gamma_grid_mombarg
 
       subroutine call_compute_kappa_mombarg(handle, k,&
-        fk, T_cntr, Rho_cntr, logT_cntr, logRho_cntr,&
+        fk, logT_cntr, logRho_cntr,&
         zbar, lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT, &
         kap, dlnkap_dlnT, dlnkap_dlnRho, log_kap_rad_cell, ierr)
         use kap_eval, only: combine_rad_with_conduction
@@ -785,7 +785,7 @@
         integer, intent(in) :: handle ! from alloc_kap_handle
         integer, intent(in) :: k
         real(dp), intent(in) :: fk(:)
-        real(dp), intent(in) :: T_cntr, Rho_cntr, logT_cntr, logRho_cntr
+        real(dp), intent(in) :: logT_cntr, logRho_cntr
         real(dp), intent(in) :: zbar ! average ionic charge (for electron conduction)
         real(dp), intent(in) :: lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT
         integer, intent(inout) :: ierr
@@ -793,6 +793,7 @@
 
         integer ::  eid(17), ke
         real(dp) :: dlnkap_rad_dlnT, dlnkap_rad_dlnRho, kap_rad, delta, delta2!,fk(17),fk_norm_fac
+        real(dp) :: Rho_cntr, T_cntr
         type (Kap_General_Info), pointer :: rq
 
         ierr = 0
@@ -802,6 +803,9 @@
         endif
         call kap_ptr(handle,rq,ierr)
         if (ierr /= 0) return
+
+        Rho_cntr = 10**logRho_cntr
+        T_cntr = 10**logT_cntr
 
         eid = (/ ih1, ihe4, ic12, in14, io16, ine20, ina23, &
         img24, ial27, isi28, is32, iar40, ica40, icr52, imn55, ife56, ini58 /)

--- a/kap/public/kap_lib.f90
+++ b/kap/public/kap_lib.f90
@@ -411,7 +411,7 @@
          kap_rad = exp10(g1)
 
          call combine_rad_with_conduction( &
-            rq, rho, logRho, T, logT, zbar, &
+            rq, logRho, logT, zbar, &
             kap_rad, dlnkap_rad_dlnRho, dlnkap_rad_dlnT, &
             kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
 
@@ -793,7 +793,6 @@
 
         integer ::  eid(17), ke
         real(dp) :: dlnkap_rad_dlnT, dlnkap_rad_dlnRho, kap_rad, delta, delta2!,fk(17),fk_norm_fac
-        real(dp) :: Rho_cntr, T_cntr
         type (Kap_General_Info), pointer :: rq
 
         ierr = 0
@@ -804,8 +803,6 @@
         call kap_ptr(handle,rq,ierr)
         if (ierr /= 0) return
 
-        Rho_cntr = 10**logRho_cntr
-        T_cntr = 10**logT_cntr
 
         eid = (/ ih1, ihe4, ic12, in14, io16, ine20, ina23, &
         img24, ial27, isi28, is32, iar40, ica40, icr52, imn55, ife56, ini58 /)
@@ -855,7 +852,7 @@
         kap_rad = exp10(log_kap_rad_cell)
 
         call combine_rad_with_conduction( &
-             rq, Rho_cntr, logRho_cntr, T_cntr, logT_cntr, zbar, &
+             rq, logRho_cntr, logT_cntr, zbar, &
              kap_rad, dlnkap_rad_dlnRho, dlnkap_rad_dlnT, &
              kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
 

--- a/star/private/kap_support.f90
+++ b/star/private/kap_support.f90
@@ -457,7 +457,7 @@ contains
             end do
             fk = fk / sum(fk)
             call call_compute_kappa_mombarg(s% kap_handle, k, &
-                 fk, 10**logT, 10**logRho, logT, logRho, &
+                 fk, logT, logRho, &
                  zbar, lnfree_e, dlnfree_e_dlnRho, dlnfree_e_dlnT, &
                  kap_op, dlnkap_op_dlnT, dlnkap_op_dlnRho, log_kap_rad, ierr)
          endif

--- a/star/private/kap_support.f90
+++ b/star/private/kap_support.f90
@@ -141,7 +141,12 @@ contains
 
     type(auto_diff_real_2var_order1) :: frac
 
-    frac = frac_op_mono(s, s% lnd(k)/ln10, s% lnT(k)/ln10)
+    if (s% op_mono_method == 'mombarg' .and. k < 2) then
+       beta = 0d0 ! don't use 'mombarg' op mono method for atmospheres
+    else
+       frac = frac_op_mono(s, s% lnd(k)/ln10, s% lnT(k)/ln10)
+    end if
+    
     beta = frac% val
 
   end function fraction_of_op_mono
@@ -323,7 +328,12 @@ contains
        return
     end if
 
-    beta = frac_op_mono(s, logRho, logT)
+    if (s% op_mono_method == 'mombarg' .and. k < 2) then
+       beta = 0d0 ! don't use 'mombarg' op mono method for atmospheres
+    else
+       beta = frac_op_mono(s, logRho, logT)
+    end if
+    
     if (k > 0 .and. k <= s% nz) s% kap_frac_op_mono(k) = beta % val
 
     if (beta > 0d0) then
@@ -447,8 +457,8 @@ contains
             end do
             fk = fk / sum(fk)
             call call_compute_kappa_mombarg(s% kap_handle, k, &
-                 fk, s% T(k), s% rho(k), logT, logRho, &
-                 s% zbar(k), lnfree_e, dlnfree_e_dlnRho, dlnfree_e_dlnT, &
+                 fk, 10**logT, 10**logRho, logT, logRho, &
+                 zbar, lnfree_e, dlnfree_e_dlnRho, dlnfree_e_dlnT, &
                  kap_op, dlnkap_op_dlnT, dlnkap_op_dlnRho, log_kap_rad, ierr)
          endif
       else

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -149,7 +149,7 @@ contains
           end do
           fk = fk / sum(fk)
           delta = MAXVAL(ABS(fk - fk_pcg_old)/fk_pcg_old)
-          
+
           if (initiaze_kap_grid) then
              call call_load_op_master(s% emesh_data_for_op_mono_path, ierr)
              write(*,*) 'Computing kappa grid for initial mixture.'
@@ -165,7 +165,7 @@ contains
              fk_pcg_old = fk
           endif
        endif
-       
+
        if (s% use_other_opacity_factor) then
           call s% other_opacity_factor(s% id, ierr)
           if (ierr /= 0) return


### PR DESCRIPTION
This cleans up some of the behavior at the surface of models when `op_mono_method = 'mombarg'`.

This will fall back to the regular opacity routines for the atmosphere rather than OP Mono in this case, since the approximations from the `'mombarg'` routines seem to cause convergence issues in the atmosphere.

The original version of the `'mombarg'` routines actually did something similar to this by accident due to a bug that yielded `NaN` values in the atmosphere and forced falling back from OP Mono to regular opacities anyway. A fix to conductive opacities in #438 caused this behavior to go away and significantly slowed down the example MESA VI work directory as of release `r22.11.1`.

This PR yields a significant speedup for the MESA VI example work directory relative to `r22.11.1`, and is even somewhat faster than the original version of these routines before the conductive opacity bugfix.