### PR TITLE
Reintroducing velocity drag for v flag

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -8136,10 +8136,24 @@
       ! ::
 
     use_dPrad_dm_form_of_T_gradient_eqn = .false.
-    use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = .false.
+    use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = .false.    
     
     
-    
+      ! drag_coefficient
+      ! ~~~~~~~~~~~~~~~~
+      ! min_q_for_drag
+      ! ~~~~~~~~~~~~~~
+
+      ! only when v_flag.  adjusts both v and energy transfer from kinetic to thermal.
+      ! only for v(k) when q(k) > min_q_for_drag.
+      ! kill off fraction of v = drag_coefficient (i.e. set to 1 to keep v near 0)
+      ! useful for preventing the development radial pulsations during advanced
+      ! burning in massive stars and AGB stars.
+
+      ! ::
+
+    drag_coefficient = 0d0
+    min_q_for_drag = 0d0
     
 
       ! for hydro comparison tests (e.g., Sedov)

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -985,6 +985,9 @@
                   action == do_copy_pointers_and_resize) &
                s% alpha_mlt(1:nz) = s% mixing_length_alpha
 
+            call do1(s% dvdt_drag, c% dvdt_drag)
+            if (failed('dvdt_drag')) exit
+
             call do1(s% vc, c% vc)
             if (failed('vc')) exit
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -350,6 +350,7 @@
     P_theta_for_velocity_time_centering, L_theta_for_velocity_time_centering, &
     steps_before_use_TDC, use_P_d_1_div_rho_form_of_work_when_time_centering_velocity, compare_TDC_to_MLT, &
     velocity_logT_lower_bound, max_dt_yrs_for_velocity_logT_lower_bound, velocity_q_upper_bound, &
+    drag_coefficient, min_q_for_drag, &
     retry_for_v_above_clight, &
 
     ! hydro solver
@@ -1855,6 +1856,9 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% RTI_log_max_boost = RTI_log_max_boost 
  s% RTI_m_full_boost = RTI_m_full_boost
  s% RTI_m_no_boost = RTI_m_no_boost
+
+ s% drag_coefficient = drag_coefficient
+ s% min_q_for_drag = min_q_for_drag
 
  s% velocity_logT_lower_bound = velocity_logT_lower_bound
  s% max_dt_yrs_for_velocity_logT_lower_bound = max_dt_yrs_for_velocity_logT_lower_bound
@@ -3519,6 +3523,10 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  RTI_log_max_boost = s% RTI_log_max_boost 
  RTI_m_full_boost = s% RTI_m_full_boost
  RTI_m_no_boost = s% RTI_m_no_boost
+
+
+ drag_coefficient = s% drag_coefficient
+ min_q_for_drag = s% min_q_for_drag
 
  velocity_logT_lower_bound = s% velocity_logT_lower_bound
  max_dt_yrs_for_velocity_logT_lower_bound = s% max_dt_yrs_for_velocity_logT_lower_bound

--- a/star/private/hydro_energy.f90
+++ b/star/private/hydro_energy.f90
@@ -224,7 +224,8 @@
             !use hydro_rsp2, only: compute_Eq_cell
             integer, intent(out) :: ierr
             type(auto_diff_real_star_order1) :: &
-               eps_nuc_ad, non_nuc_neu_ad, extra_heat_ad, Eq_ad, RTI_diffusion_ad
+               eps_nuc_ad, non_nuc_neu_ad, extra_heat_ad, Eq_ad, RTI_diffusion_ad, &
+               drag_force, drag_energy
             include 'formats'
             ierr = 0
          
@@ -272,7 +273,20 @@
             
             call setup_RTI_diffusion(RTI_diffusion_ad)
 
-            sources_ad = eps_nuc_ad - non_nuc_neu_ad + extra_heat_ad + Eq_ad + RTI_diffusion_ad
+            if (s% q(k) > s% min_q_for_drag .and. s% drag_coefficient > 0) then
+               v_00 = wrap_v_00(s,k)
+               drag_force = s% drag_coefficient*v_00/s% dt
+               drag_energy = 0.5d0*v_00*drag_force
+            ! drag energy for outer half-cell.   the 0.5d0 is for dm/2
+            end if
+            if (s% q(k+1) > s% min_q_for_drag .and. s% drag_coefficient > 0) then
+               v_p1 = wrap_v_p1(s,k)
+               drag_force = s% drag_coefficient*v_p1/s% dt
+               drag_energy = drag_energy + 0.5d0*v_p1*drag_force
+            ! drag energy for inner half-cell.   the 0.5d0 is for dm/2
+            end if
+
+            sources_ad = eps_nuc_ad - non_nuc_neu_ad + extra_heat_ad + Eq_ad + RTI_diffusion_ad + drag_energy
 
             sources_ad%val = sources_ad%val + s% irradiation_heat(k)
             

--- a/star/private/hydro_momentum.f90
+++ b/star/private/hydro_momentum.f90
@@ -387,7 +387,8 @@
             other_ad, accel_ad,Uq_ad
          real(dp), intent(out) :: other
          integer, intent(out) :: ierr
-         type(auto_diff_real_star_order1) :: extra_ad, v_00
+         type(auto_diff_real_star_order1) :: extra_ad, v_00, &
+            drag
          real(dp) :: accel, d_accel_dv, fraction_on
          logical :: test_partials, local_v_flag
 
@@ -423,6 +424,13 @@
             end if
             accel_ad%val = accel
             accel_ad%d1Array(i_v_00) = d_accel_dv
+
+            s% dvdt_drag(k) = 0
+            if (s% q(k) > s% min_q_for_drag .and. s% drag_coefficient > 0) then
+               v_00 = wrap_v_00(s,k)
+               drag = -s% drag_coefficient*v_00/s% dt
+               s% dvdt_drag(k) = drag%val
+            end if
          
          end if ! v_flag
 
@@ -432,7 +440,7 @@
             if (ierr /= 0) return
          end if
          
-         other_ad = extra_ad - accel_ad + Uq_ad
+         other_ad = extra_ad - accel_ad + drag + Uq_ad
          other = other_ad%val
          
          !test_partials = (k == s% solver_test_partials_k)


### PR DESCRIPTION
In a previous version of mesa (r15140), there existed controls to apply a velocity drag to the outer envelope of a model. This drag functions by converting kinetic energy into heat. This control was useful for preventing instabilities in the envelope from accelerating material at glorious speeds, and is also useful in the preventing radial pulsations and other instabilities that developed near the surface of a model. I've found this control particularly useful for getting 1-7 Msun stars through the thermal-pulsing AGB, and for generating smooth hr tracks in Massive stars from Carbon burning on. I've had success taking massive stars from 15-150 Msun to cc (infall ~ 300 km/s) with this this control.

It should be noted that if you run the drag factor 'drag_coefficient = ' at 1d0 too long, you risk heating the surface up too much and generating a 90 degree kink in the rho-T plane, which can cause some issues. Therefore I reccomend, if  a user is going to turn on this control to be weary. I have found that 'drag_coefficient = ' 0.5d0 or 0.8d0 to be enough for most cases.

Another caveat is that by preventing large accelerations from developing in the envelope, you are preventing surface from being accelerated as much, and therefore your corresponding stellar radius will be affected to some extent.

This control was removed between r15140 and r21.12.1, which I imagine was part of the large amount of internal clean up of the code. I'm hoping it is alright to reintroduce, but let me know what your thoughts are? 

Eventually, it would be nice if we could modify the test_suite "20M_pre_ms_to_core_collapse" to remove
-----
      relax_to_this_tau_factor = 1.5d6
      dlogtau_factor = 0.1d0
      relax_initial_tau_factor = .true.
-----
and replace with something like 







