### PR TITLE
add star_pointer initial_star_age to track when relaxation begins

### DIFF
--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -715,10 +715,11 @@
          x(1:num_pts) => rpar(1:num_pts)
          f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          f(1:4,1:num_pts) => f1(1:4*num_pts)
-         if s% doing_first_model_of_run then
+         if (s% doing_first_model_of_run) then
             rpar(lrpar) = 0
          else
             rpar(lrpar) = s% star_age
+         end if
     
 
          call store_rpar(num_pts, ierr)
@@ -970,10 +971,11 @@
          x(1:num_pts) => rpar(1:num_pts)
          f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          f(1:4,1:num_pts) => f1(1:4*num_pts)
-         if s% doing_first_model_of_run then
+         if (s% doing_first_model_of_run) then
             rpar(lrpar) = 0
          else
             rpar(lrpar) = s% star_age
+         end if
          call store_rpar(num_pts, ierr)
          if (ierr /= 0) return
          

--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -708,13 +708,18 @@
 
          ipar(1) = num_pts
          ipar(2) = s% max_model_number
-         lrpar = 5*num_pts
+         lrpar = 5*num_pts + 1
          allocate(rpar(lrpar), stat=ierr)
          if (ierr /= 0) return
 
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          f(1:4,1:num_pts) => f1(1:4*num_pts)
+         if s% doing_first_model_of_run then
+            rpar(lrpar) = 0
+         else
+            rpar(lrpar) = s% star_age
+    
 
          call store_rpar(num_pts, ierr)
          if (ierr /= 0) return
@@ -835,14 +840,14 @@
 
          ierr = 0
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          call adjust_entropy(num_pts, avg_err, ierr)
          if (ierr /= 0) relax_entropy_check_model = terminate
 
          if (mod(s% model_number, s% terminal_interval) == 0) &
             write(*,*) 'relax_entropy avg rel err, dt, model', avg_err, s% dt/secyer, s% model_number
 
-         if ((s% star_age - s% initial_star_age) >= s% job% timescale_for_relax_entropy*s% job% num_timescales_for_relax_entropy) then
+         if ((s% star_age - rpar(lrpar)) >= s% job% timescale_for_relax_entropy*s% job% num_timescales_for_relax_entropy) then
             relax_entropy_check_model = terminate
             s% termination_code = t_relax_finished_okay
             return
@@ -958,14 +963,17 @@
 
          ipar(1) = num_pts
          ipar(2) = s% max_model_number
-         lrpar = 5*num_pts
+         lrpar = 5*num_pts+1
          allocate(rpar(lrpar), stat=ierr)
          if (ierr /= 0) return
 
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          f(1:4,1:num_pts) => f1(1:4*num_pts)
-
+         if s% doing_first_model_of_run then
+            rpar(lrpar) = 0
+         else
+            rpar(lrpar) = s% star_age
          call store_rpar(num_pts, ierr)
          if (ierr /= 0) return
          
@@ -1088,14 +1096,14 @@
 
          ierr = 0
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          call adjust_angular_momentum(num_pts, avg_err, ierr)
          if (ierr /= 0) relax_angular_momentum_check_model = terminate
 
          if (mod(s% model_number, s% terminal_interval) == 0) &
             write(*,*) 'relax_angular_momentum avg rel err, dt, model', avg_err, s% dt/secyer, s% model_number
 
-         if ((s% star_age - s% initial_star_age) >= &
+         if ((s% star_age - rpar(lrpar)) >= &
             s% job% timescale_for_relax_angular_momentum*&
                s% job% num_timescales_for_relax_angular_momentum) then
             relax_angular_momentum_check_model = terminate
@@ -4007,13 +4015,10 @@
             s% num_retries = 0
             s% time = 0
             s% star_age = 0
-            s% initial_star_age = 0
             s% model_number_for_last_retry = 0
             s% photo_interval = 0
             s% profile_interval = 0
             s% priority_profile_interval = 0
-         else
-            s% initial_star_age = s% star_age
          end if
 
          if( s% job% pgstar_flag) then

--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -842,7 +842,7 @@
          if (mod(s% model_number, s% terminal_interval) == 0) &
             write(*,*) 'relax_entropy avg rel err, dt, model', avg_err, s% dt/secyer, s% model_number
 
-         if (s% star_age >= s% job% timescale_for_relax_entropy*s% job% num_timescales_for_relax_entropy) then
+         if ((s% star_age - s% initial_star_age) >= s% job% timescale_for_relax_entropy*s% job% num_timescales_for_relax_entropy) then
             relax_entropy_check_model = terminate
             s% termination_code = t_relax_finished_okay
             return
@@ -1095,7 +1095,7 @@
          if (mod(s% model_number, s% terminal_interval) == 0) &
             write(*,*) 'relax_angular_momentum avg rel err, dt, model', avg_err, s% dt/secyer, s% model_number
 
-         if (s% star_age >= &
+         if ((s% star_age - s% initial_star_age) >= &
             s% job% timescale_for_relax_angular_momentum*&
                s% job% num_timescales_for_relax_angular_momentum) then
             relax_angular_momentum_check_model = terminate
@@ -4007,10 +4007,13 @@
             s% num_retries = 0
             s% time = 0
             s% star_age = 0
+            s% initial_star_age = 0
             s% model_number_for_last_retry = 0
             s% photo_interval = 0
             s% profile_interval = 0
             s% priority_profile_interval = 0
+         else
+            s% initial_star_age = s% star_age
          end if
 
          if( s% job% pgstar_flag) then

--- a/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy
+++ b/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy
@@ -27,13 +27,22 @@
 
     relax_initial_angular_momentum = .true.
     relax_angular_momentum_filename = "angular_momentum.dat"
+    timescale_for_relax_angular_momentum = 1d-10
+    max_dt_for_relax_angular_momentum = 1d-9
+    num_timescales_for_relax_angular_momentum = 100
 
     relax_initial_entropy = .true.
     relax_entropy_filename = "entropy.dat"
+    timescale_for_relax_entropy = 1d-10
+    max_dt_for_relax_entropy = 1d-9
+    num_timescales_for_relax_entropy = 100
       
     save_model_when_terminate = .true.
     save_model_filename = 'relaxed.mod'
     required_termination_code_string = 'Values for Teff and L are within tolerance'
+
+    set_initial_age = .true.
+    initial_age = 1d8
 
 / ! end of star_job namelist
 

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -785,7 +785,7 @@
          ! nuclear timescale (years) -- proportional to mass divided by luminosity
 
       ! times in other units (just for convenience)
-      real(dp) :: star_age, initial_star_age, time_days, time_years ! time is in seconds
+      real(dp) :: star_age, time_days, time_years ! time is in seconds
       real(dp) :: time_step, dt_days, dt_years ! dt is in seconds
       
       real(dp) :: dt_start ! dt during first try for step

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -785,7 +785,7 @@
          ! nuclear timescale (years) -- proportional to mass divided by luminosity
 
       ! times in other units (just for convenience)
-      real(dp) :: star_age, time_days, time_years ! time is in seconds
+      real(dp) :: star_age, initial_star_age, time_days, time_years ! time is in seconds
       real(dp) :: time_step, dt_days, dt_years ! dt is in seconds
       
       real(dp) :: dt_start ! dt during first try for step


### PR DESCRIPTION
I gave a https://github.com/MESAHub/mesa/issues/534#issue-1702284534 a crack. Let me know if this looks correct? 
Line 845 might be too long? Didn't see any issues in the other relaxation routines. Will double check.
