### PR TITLE
Fix issues with entropy relaxtaion when star_age>0 (#536)

### DIFF
--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -838,7 +838,7 @@
 
          ierr = 0
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
          call adjust_entropy(num_pts, avg_err, ierr)
          if (ierr /= 0) relax_entropy_check_model = terminate
 
@@ -1094,7 +1094,7 @@
 
          ierr = 0
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
          call adjust_angular_momentum(num_pts, avg_err, ierr)
          if (ierr /= 0) relax_angular_momentum_check_model = terminate
 

--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -684,7 +684,7 @@
          integer, parameter ::  lipar=2
          integer :: lrpar, max_model_number
          real(dp), pointer :: rpar(:)
-         real(dp) :: starting_dt_next, mix_factor, dxdt_nuc_factor, max_years_for_timestep
+         real(dp) :: starting_dt_next, mix_factor, dxdt_nuc_factor, max_years_for_timestep, time
          logical :: do_element_diffusion, use_other_energy
          type (star_info), pointer :: s
          real(dp), pointer :: x(:), f1(:), f(:,:)
@@ -715,7 +715,7 @@
          x(1:num_pts) => rpar(1:num_pts)
          f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
          f(1:4,1:num_pts) => f1(1:4*num_pts)
-
+    
          call store_rpar(num_pts, ierr)
          if (ierr /= 0) return
          
@@ -738,6 +738,8 @@
          s% use_other_energy = .true.
          other_energy => s% other_energy
          s% other_energy => entropy_relax_other_energy
+         time = s% time
+         s% time = 0d0
 
          call do_internal_evolve( &
                id, before_evolve_relax_entropy, &
@@ -752,6 +754,7 @@
          s% max_years_for_timestep = max_years_for_timestep
          s% use_other_energy = use_other_energy
          s% other_energy => other_energy
+         s% time = time
 
          call error_check('relax entropy',ierr)
 
@@ -835,12 +838,13 @@
 
          ierr = 0
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          call adjust_entropy(num_pts, avg_err, ierr)
          if (ierr /= 0) relax_entropy_check_model = terminate
 
          if (mod(s% model_number, s% terminal_interval) == 0) &
             write(*,*) 'relax_entropy avg rel err, dt, model', avg_err, s% dt/secyer, s% model_number
+
 
          if (s% star_age >= s% job% timescale_for_relax_entropy*s% job% num_timescales_for_relax_entropy) then
             relax_entropy_check_model = terminate
@@ -934,7 +938,7 @@
          integer :: lrpar, max_model_number
          real(dp), pointer :: rpar(:)
          real(dp) :: starting_dt_next, mix_factor, dxdt_nuc_factor, max_timestep, &
-            am_D_mix_factor
+            am_D_mix_factor, time
          logical :: do_element_diffusion, use_other_torque
          type (star_info), pointer :: s
          real(dp), pointer :: x(:), f1(:), f(:,:)
@@ -965,7 +969,6 @@
          x(1:num_pts) => rpar(1:num_pts)
          f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
          f(1:4,1:num_pts) => f1(1:4*num_pts)
-
          call store_rpar(num_pts, ierr)
          if (ierr /= 0) return
          
@@ -990,6 +993,8 @@
          s% use_other_torque = .true.
          other_torque => s% other_torque
          s% other_torque => angular_momentum_relax_other_torque
+         time = s% time
+         s% time = 0d0
 
          call do_internal_evolve( &
                id, before_evolve_relax_angular_momentum, &
@@ -1005,6 +1010,7 @@
          s% max_timestep = max_timestep
          s% use_other_torque = use_other_torque
          s% other_torque => other_torque
+         s% time = time
 
          call error_check('relax angular momentum',ierr)
 
@@ -1088,14 +1094,14 @@
 
          ierr = 0
          x(1:num_pts) => rpar(1:num_pts)
-         f1(1:4*num_pts) => rpar(num_pts+1:lrpar)
+         f1(1:4*num_pts) => rpar(num_pts+1:lrpar-1)
          call adjust_angular_momentum(num_pts, avg_err, ierr)
          if (ierr /= 0) relax_angular_momentum_check_model = terminate
 
          if (mod(s% model_number, s% terminal_interval) == 0) &
             write(*,*) 'relax_angular_momentum avg rel err, dt, model', avg_err, s% dt/secyer, s% model_number
 
-         if (s% star_age >= &
+         if (s% star_age  >= &
             s% job% timescale_for_relax_angular_momentum*&
                s% job% num_timescales_for_relax_angular_momentum) then
             relax_angular_momentum_check_model = terminate

--- a/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy
+++ b/star/test_suite/relax_composition_j_entropy/inlist_start_relax_composition_j_entropy
@@ -27,13 +27,22 @@
 
     relax_initial_angular_momentum = .true.
     relax_angular_momentum_filename = "angular_momentum.dat"
+    timescale_for_relax_angular_momentum = 1d-10
+    max_dt_for_relax_angular_momentum = 1d-9
+    num_timescales_for_relax_angular_momentum = 100
 
     relax_initial_entropy = .true.
     relax_entropy_filename = "entropy.dat"
+    timescale_for_relax_entropy = 1d-10
+    max_dt_for_relax_entropy = 1d-9
+    num_timescales_for_relax_entropy = 100
       
     save_model_when_terminate = .true.
     save_model_filename = 'relaxed.mod'
     required_termination_code_string = 'Values for Teff and L are within tolerance'
+
+    set_initial_age = .true.
+    initial_age = 1d8
 
 / ! end of star_job namelist
 


### PR DESCRIPTION
The problem with the relax routines is that they assume the star_age is 0, so this fixes things by forcing that to be true and then restoring the star_age afterwards. Note we don't want to do any subtracting of an initial age as there can be precision loss when star_age is large as the entropy and angular momentum routines assume dt << 1s.
