### PR TITLE
Add `-std=f2008` flag when compiling `work` folders

### DIFF
--- a/astero/test_suite/astero_adipls/src/run_star_extras.f90
+++ b/astero/test_suite/astero_adipls/src/run_star_extras.f90
@@ -103,8 +103,8 @@
             l, order, freq, inertia, x, y, aa, data, nn, iy, iaa, ispcpr, ierr)
          integer, intent(in) :: l, order
          real(dp), intent(in) :: freq, inertia
-         real(dp), intent(in) :: x(1:nn), y(1:iy,1:nn), aa(1:iaa,1:nn), data(8)
          integer, intent(in) :: nn, iy, iaa, ispcpr
+         real(dp), intent(in) :: x(1:nn), y(1:iy,1:nn), aa(1:iaa,1:nn), data(8)
          integer, intent(out) :: ierr
          ierr = 0
          write(*,*) 'astero called my_other_adipls_mode_info'

--- a/star/test_suite/carbon_kh/src/run_star_extras.f90
+++ b/star/test_suite/carbon_kh/src/run_star_extras.f90
@@ -215,11 +215,11 @@
          do k = 1, nz
             vals(k,1) = s% eos_frac_HELM(k)
             vals(k,2) = s% eos_frac_FreeEOS(k)
-            vals(k,3) = ((s% energy(k) - s% energy_start(k)) + &
-               -0.5d0 * (s% T_start(k)*s% cv_start(k) + s% T(k)*s% cv(k)) * s% dxh_lnT(k) + &
+            vals(k,3) = ((s% energy(k) - s% energy_start(k)) &
+               -0.5d0 * (s% T_start(k)*s% cv_start(k) + s% T(k)*s% cv(k)) * s% dxh_lnT(k) &
                -0.5d0 * (s% Rho_start(k)*s% dE_dRho_start(k) + s% Rho(k)*s% dE_dRho(k)) * s% dxh_lnd(k)) * s% dt
             vals(k,4) = (&
-               -0.5d0 * (s% T_start(k)*s% cv_start(k) + s% T(k)*s% cv(k)) * s% dxh_lnT(k) + &
+               -0.5d0 * (s% T_start(k)*s% cv_start(k) + s% T(k)*s% cv(k)) * s% dxh_lnT(k) &
                -0.5d0 * (s% Rho_start(k)*s% dE_dRho_start(k) + s% Rho(k)*s% dE_dRho(k)) * s% dxh_lnd(k)) * s% dt
          end do
 
@@ -247,8 +247,8 @@
          e_eos_err_step_blend = 0
          do k = 1, nz
             e_eos_err_cell = s% dm(k) * &
-               ((s% energy(k) - s% energy_start(k)) + &
-               -0.5d0 * (s% T_start(k)*s% cv_start(k) + s% T(k)*s% cv(k)) * s% dxh_lnT(k) + &
+               ((s% energy(k) - s% energy_start(k)) &
+               -0.5d0 * (s% T_start(k)*s% cv_start(k) + s% T(k)*s% cv(k)) * s% dxh_lnT(k) &
                -0.5d0 * (s% Rho_start(k)*s% dE_dRho_start(k) + s% Rho(k)*s% dE_dRho(k)) * s% dxh_lnd(k))
             e_eos_err_step = e_eos_err_step + e_eos_err_cell
             if (in_eos_blend(s,k)) e_eos_err_step_blend = e_eos_err_step_blend + e_eos_err_cell

--- a/utils/makefile_header
+++ b/utils/makefile_header
@@ -233,7 +233,7 @@ COMPILE_DEVEL     = $(COMPILE_NO_OPT)
 # some definitions used in the test makefiles and client makefiles
 
 WORK_COMPILE = \
-   $(FC) $(FCbasic) $(FCopenmp) $(FCchecks) $(FCdebug) $(FCfree) \
+   $(FC) $(FCbasic) $(FCopenmp) $(FCchecks) $(FCdebug) $(FCfree) $(FCstandard) \
    -I$(MESA_INCLUDE_DIR) -I$(WORK_SRC_DIR) -c
 
 ifeq ($(USE_PGPLOT),YES)

--- a/utils/makefile_header_non_mesasdk
+++ b/utils/makefile_header_non_mesasdk
@@ -330,7 +330,7 @@ COMPILE_DEVEL     = $(COMPILE_NO_OPT)
 # some definitions used in the test makefiles and client makefiles
 
 WORK_COMPILE = \
-   $(FC) $(FCbasic) $(FCopenmp) -O0 $(FCchecks) $(FCdebug) $(FCfree) $(FCstandard) \
+   $(FC) $(FCbasic) $(FCopenmp) -O0 $(FCchecks) $(FCdebug) $(FCfree) \
    $(FC_free_preprocess) -I$(MESA_INCLUDE_DIR) $(INCLUDE_HDF5) -c
  
 ifeq ($(USE_PGPLOT),YES)

--- a/utils/makefile_header_non_mesasdk
+++ b/utils/makefile_header_non_mesasdk
@@ -330,7 +330,7 @@ COMPILE_DEVEL     = $(COMPILE_NO_OPT)
 # some definitions used in the test makefiles and client makefiles
 
 WORK_COMPILE = \
-   $(FC) $(FCbasic) $(FCopenmp) -O0 $(FCchecks) $(FCdebug) $(FCfree) \
+   $(FC) $(FCbasic) $(FCopenmp) -O0 $(FCchecks) $(FCdebug) $(FCfree) $(FCstandard) \
    $(FC_free_preprocess) -I$(MESA_INCLUDE_DIR) $(INCLUDE_HDF5) -c
  
 ifeq ($(USE_PGPLOT),YES)


### PR DESCRIPTION
Fixes #537, where @mjoyceGR showed that a bad namelist item after an array leads to an error message that points to the array item, rather than the bad namelist item. Following up on the [associated GCC bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109897), using the `-std=f2008` flag seems to fix this behaviour. This PR just adds that flag in a place that fixes the error. There are still parts of `star` that are compiled without the flag but that doesn't seem to matter.

This led to small changes in `carbon_kh` and `astero_adipls`, which apparently didn't already conform the the Fortran 2008 standard and [failed to compile](https://testhub.mesastar.org/whb%2Fstar-work-std-f2008/commits/e0e56f4).

The test suite is now [passing](https://testhub.mesastar.org/whb%2Fstar-work-std-f2008/commits/dfd53d7).