### PR TITLE
Fix ideal neutral energy

### DIFF
--- a/docs/source/eos/overview.rst
+++ b/docs/source/eos/overview.rst
@@ -159,11 +159,6 @@ thermodynamic consistency.  The composition is accounted for via
 :math:`\overline{{\rm A}}` (the mass-averaged atomic weight), and
 :math:`\overline{\rm Z}` (the mass-averaged atomic charge).
 
-.. note::
-
-  HELM serves as a "backstop" EOS for MESA.  When applied at low
-  temperatures, it falls back into an ideal gas mode.
-
 
 PC
 --
@@ -190,6 +185,17 @@ defining feature of this equation of state is that it uses analytic
 free energy terms and provides thermodynamic quantities using
 automatic differentiation machinery.
 
+ideal
+-----
+
+.. warning::
+
+   This EOS is used as a very simple backstop.
+   It currently assumes fully neutral matter, even at high temperatures.
+
+This EOS is a backstop derived from the ideal ion portion of Skye.
+It assumes no free electrons, so the only EOS contributions are from
+ideal ions and radiation.
 
 CMS
 ---

--- a/eos/private/ideal.f90
+++ b/eos/private/ideal.f90
@@ -169,7 +169,9 @@ module ideal
 
       ! Ideal ion free energy, only depends on abar
       F_ideal_ion = compute_F_ideal_ion(temp, den, abar, relevant_species, ACMI, ya)
-      F_ideal_ion = F_ideal_ion + compute_ion_offset(species, xa, chem_id) ! Offset so ion ground state energy is zero.
+      if(temp > 1d4) then ! only add ionization energy for hot matter
+         F_ideal_ion = F_ideal_ion + compute_ion_offset(species, xa, chem_id) ! Offset so ion ground state energy is zero.
+      end if
 
       ! Radiation free energy, independent of composition
       F_rad = compute_F_rad(temp, den)

--- a/eos/private/ideal.f90
+++ b/eos/private/ideal.f90
@@ -169,9 +169,11 @@ module ideal
 
       ! Ideal ion free energy, only depends on abar
       F_ideal_ion = compute_F_ideal_ion(temp, den, abar, relevant_species, ACMI, ya)
-      if(temp > 1d4) then ! only add ionization energy for hot matter
-         F_ideal_ion = F_ideal_ion + compute_ion_offset(species, xa, chem_id) ! Offset so ion ground state energy is zero.
-      end if
+
+      ! The compute_ion_offset correction should only be applied to ionized matter.
+      ! Right now, ideal always assumes neutral, so leave this off unless/until we consider
+      ! adding assumption of full ionizatino for high T regions on ideal gas.
+      !F_ideal_ion = F_ideal_ion + compute_ion_offset(species, xa, chem_id) ! Offset so ion ground state energy is zero.
 
       ! Radiation free energy, independent of composition
       F_rad = compute_F_rad(temp, den)


### PR DESCRIPTION
Ideal EOS is currently including the full ionization energy as part of the internal energy, which is inconsistent with its assumption that the matter is fully neutral. I suspect this is just an artifact of porting ideal over from skye_ideal, which does assume full ionization.