### PR TITLE
Fix `ifort` build by renaming supposedly conflicting variable

### DIFF
--- a/binary/other/mod_other_binary_extras.f90
+++ b/binary/other/mod_other_binary_extras.f90
@@ -131,12 +131,12 @@
          
       end function null_how_many_extra_binary_history_columns
       
-      subroutine null_data_for_extra_binary_history_columns(binary_id, n, names, vals, ierr)
+      subroutine null_data_for_extra_binary_history_columns(binary_id, n, extra_names, vals, ierr)
          use binary_def, only : binary_info, binary_ptr, maxlen_binary_history_column_name
          use const_def
          integer, intent(in) :: binary_id
          integer, intent(in) :: n
-         character (len=maxlen_binary_history_column_name) :: names(n)
+         character (len=maxlen_binary_history_column_name) :: extra_names(n)
          real(dp) :: vals(n)
          integer, intent(out) :: ierr
          type (binary_info), pointer :: b
@@ -157,12 +157,12 @@
       end function null_how_many_extra_binary_history_header_items
 
       subroutine null_data_for_extra_binary_history_header_items( &
-           binary_id, n, names, vals, ierr)
+           binary_id, n, extra_names, vals, ierr)
          use binary_def, only : binary_info, binary_ptr, maxlen_binary_history_column_name
          use const_def
          type (binary_info), pointer :: b
          integer, intent(in) :: binary_id, n
-         character (len=maxlen_binary_history_column_name) :: names(n)
+         character (len=maxlen_binary_history_column_name) :: extra_names(n)
          real(dp) :: vals(n)
          integer, intent(out) :: ierr
          ierr = 0


### PR DESCRIPTION
@rjfarmer's perfectly [reasonable change](https://github.com/MESAHub/mesa/pull/550) of moving the `use` statements into the `other` procedures inexplicably broke the `ifort` build by introducing errors about the variable `names` being given conflicting attributes:
```
...
../other/mod_other_binary_extras.f90(135): error #6401: The attributes of this name conflict with those made accessible by a USE statement.   [NAMES]
         character (len=maxlen_binary_history_column_name) :: names(n)
--------------------------------------------------------------^
../other/mod_other_binary_extras.f90(130): warning #6717: This name has not been given an explicit type.   [NAMES]
      subroutine null_data_for_extra_binary_history_columns(binary_id, n, names, vals, ierr)
--------------------------------------------------------------------------^
../other/mod_other_binary_extras.f90(150): remark #6536: All symbols from this module are already visible due to another USE; the ONLY clause will have no effect. Rename clauses, if any, will be honored.   [BINARY_DEF]
         use binary_def
-------------^
COMPILE_CMD ../private/binary_history_specs.f90
../other/mod_other_binary_extras.f90(163): error #6401: The attributes of this name conflict with those made accessible by a USE statement.   [NAMES]
         character (len=maxlen_binary_history_column_name) :: names(n)
--------------------------------------------------------------^
../other/mod_other_binary_extras.f90(158): warning #6717: This name has not been given an explicit type.   [NAMES]
           binary_id, n, names, vals, ierr)
-------------------------^
../other/mod_other_binary_extras.f90(130): error #6404: This name does not have a type, and must have an explicit type.   [NAMES]
      subroutine null_data_for_extra_binary_history_columns(binary_id, n, names, vals, ierr)
--------------------------------------------------------------------------^
../other/mod_other_binary_extras.f90(158): error #6404: This name does not have a type, and must have an explicit type.   [NAMES]
           binary_id, n, names, vals, ierr)
-------------------------^
compilation aborted for ../other/mod_other_binary_extras.f90 (code 1)
make: *** [makefile_base:149: mod_other_binary_extras.o] Error 1
make: *** Waiting for unfinished jobs....
...
```
`names` doesn't seem to be defined anywhere, let alone somewhere it might conflict, but I couldn't find an obvious solution other than to concede defeat and rename the variables, which is what I've done here. I'll leave this up for a day or so in case anyone wants to discuss (or suggest a different variable name: I've replaced `names` with `extra_names`).

The test suite is [passing](https://testhub.mesastar.org/ifort-binary-names-fix/commits/e5d123c).