### PR TITLE
Stop trying to convert history values to ints

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,13 @@ thus the variable ``s% extra_pressure`` is now an ``auto_diff``
 and allows for the setting of the partial derivatives the
 pressure with respect to other variables.
 
+run_star_extras
+---------------
+
+Previously we had logic to determine if a extra history value should be saved 
+as an int or a float (users can only provide data as a float). This was error
+prone, so now we save extra history values as floats.
+
 
 
 Changes in r23.05.1

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -484,17 +484,7 @@ contains
          else if (pass == 2) then
             call do_name(j + col_offset, extra_col_names(j))
          else if (pass == 3) then
-            if (abs(extra_col_vals(j)) < huge(int_val))then
-               int_val = int(extra_col_vals(j))
-               if (abs(extra_col_vals(j) - dble(int_val)) < &
-                  1d-10 * max(1d-10, abs(extra_col_vals(j)))) then
-                  call do_int_val(j + col_offset, int_val)
-               else
-                  call do_val(j + col_offset, extra_col_vals(j))
-               end if
-            else
-               call do_val(j + col_offset, extra_col_vals(j))
-            end if
+            call do_val(j + col_offset, extra_col_vals(j))
          end if
       end subroutine do_extra_col
 


### PR DESCRIPTION
We would attempt to detect whether a extra history value was meant to be an int or a float. But this was error prone with very large values. Instead just treat everything as a float (given users can only provide values in floats anyway this should not change peoples results).

Closes #354