### PR TITLE
Delete unused libraries from GitHub runner

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,6 @@
 name: Build on Linux with SDK
 
-on: [pull_request, release]
+on: [push, pull_request, release]
 
 jobs:
   build:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Delete unused packages
         run: |
-	  # commands lifted from https://github.com/jlumbroso/free-disk-space
+          # commands lifted from https://github.com/jlumbroso/free-disk-space
           sudo rm -rf /usr/local/lib/android
           sudo apt-get remove -y '^dotnet-.*' # 990 MB
           sudo apt-get remove -y '^llvm-.*' # 1052 MB

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,6 @@
 name: Build on Linux with SDK
 
-on: [push, pull_request, release]
+on: [pull_request, release]
 
 jobs:
   build:
@@ -12,18 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - name: Free Disk Space (Ubuntu)
-      #   uses: jlumbroso/free-disk-space@main
       - name: Delete unused packages
         run: |
+	  # commands lifted from https://github.com/jlumbroso/free-disk-space
           sudo rm -rf /usr/local/lib/android
-          sudo apt-get remove -y '^dotnet-.*'
-          sudo apt-get remove -y '^llvm-.*'
-          sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y '^mongodb-.*'
-          sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          sudo apt-get autoremove -y
+          sudo apt-get remove -y '^dotnet-.*' # 990 MB
+          sudo apt-get remove -y '^llvm-.*' # 1052 MB
+          # sudo apt-get remove -y 'php.*' # 56.6 MB
+          # sudo apt-get remove -y '^mysql-.*' # 209 MB
+          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri # 2274 MB
+          sudo apt-get autoremove -y # 771 MB
           sudo apt-get clean
 
       - name: Checkout

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -95,6 +95,9 @@ jobs:
           export "MESA_DIR=$(readlink -f ./)"
           # Everything is run as root so we need to disable the root check in the install script
           sed -i 's/\${EUID:-\$(id -u)}/1/' install
+          # Turn off caching during build to save more space
+          sed -i 's/use_cache_for_eos = .true./use_cache_for_eos = .false./' $MESA_DIR/eos/public/eos_def.f90
+          sed -i 's/use_cache = .true./use_cache = .false./' $MESA_DIR/star/private/star_private_def.f90
           ./install
           if [ ! -f lib/libbinary.a ]; then
             exit 1

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+
       - name: Checkout
         uses: actions/checkout@v3.0.0
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,8 +12,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+      # - name: Free Disk Space (Ubuntu)
+      #   uses: jlumbroso/free-disk-space@main
+      - name: Delete unused packages
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo apt-get remove -y '^dotnet-.*'
+          sudo apt-get remove -y '^llvm-.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y '^mongodb-.*'
+          sudo apt-get remove -y '^mysql-.*'
+          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get autoremove -y
+          sudo apt-get clean
 
       - name: Checkout
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -96,8 +96,8 @@ jobs:
           # Everything is run as root so we need to disable the root check in the install script
           sed -i 's/\${EUID:-\$(id -u)}/1/' install
           # Turn off caching during build to save more space
-          sed -i 's/use_cache_for_eos = .true./use_cache_for_eos = .false./' $MESA_DIR/eos/public/eos_def.f90
-          sed -i 's/use_cache = .true./use_cache = .false./' $MESA_DIR/star/private/star_private_def.f90
+          sed -i 's/use_cache_for_eos = .true./use_cache_for_eos = .false./g' $MESA_DIR/eos/public/eos_def.f90
+          sed -i 's/use_cache = .true./use_cache = .false./g' $MESA_DIR/star/private/star_private_def.f90
           ./install
           if [ ! -f lib/libbinary.a ]; then
             exit 1


### PR DESCRIPTION
The CI has started failing because it runs out of space before the build can complete. This appears to be a common enough issue that a common workaround, compiled into [this action](https://github.com/marketplace/actions/free-disk-space-ubuntu) (for example), is to delete/uninstall a bunch of unused software that's included on the GitHub runner.