### PR TITLE
add documentation to change and relax z_fracs routine for initial_zfracs

### DIFF
--- a/star/defaults/star_job.defaults
+++ b/star/defaults/star_job.defaults
@@ -948,6 +948,8 @@
       ! ``relax_Z = .true.`` gradually changes average Z, reconverging at each step.
       ! ``change_Z = .true.`` simply changes abundances; doesn't reconverge the model.
       ! note: ``relax_dlnZ`` in the controls inlist determines the rate of change
+      ! note: ``initial_zfracs`` are not adjusted when using these controls, 
+      ! except if ``set_uniform_initial_composition = .true.``, and manually setting abundances.
 
       ! ::
 


### PR DESCRIPTION
Added documentation to the relax_zfracs and change_zfracs routines to let users know that it does not adjust the initial_zfracs of the model. see https://github.com/MESAHub/mesa/issues/578