### PR TITLE
Reformatting of pgstar documentation

### DIFF
--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -205,13 +205,6 @@
     pgstar_age_coord = -0.04
     pgstar_age_fjust = 0.0
 
-      ! ### axes line weight
-
-      ! ::
-
-    pgstar_box_lw = 3
-
-
       ! titles
       ! ~~~~~~
 
@@ -272,6 +265,13 @@
 
     pgstar_num_scale = 1.2
 
+
+      ! line width for axes
+      ! ~~~~~~~~~~~~~~~~~~~
+
+      ! ::
+
+    pgstar_box_lw = 3
 
       ! line width for data
       ! ~~~~~~~~~~~~~~~~~~~

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -81,7 +81,7 @@
     win_white_on_black_flag = .true.
 
 
-   ! file output
+   ! File output
    ! -----------
 
 
@@ -304,12 +304,15 @@
 
     TRho_Profile_win_flag = .false.
 
-      ! **Window Sizing**
+      ! **Window sizing**
 
       ! ::
 
     TRho_Profile_win_width = 6
     TRho_Profile_win_aspect_ratio = 0.75
+
+      ! :: 
+
     TRho_Profile_xleft = 0.15
     TRho_Profile_xright = 0.85
     TRho_Profile_ybot = 0.15
@@ -388,7 +391,7 @@
 
     TRho_Profile_fname = ''
 
-      ! ``TRho_Profile_use_decorator`` enables calling a subroutine to add extra information to a plot
+      ! ``TRho_Profile_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
@@ -396,7 +399,7 @@
     TRho_Profile_use_decorator = .false.
 
 
-      ! **file output**
+      ! **File output**
 
       ! ::
 
@@ -415,14 +418,14 @@
 
     show_TRho_Profile_mass_locs = .false.
 
-      ! **Setting Colors**
+      ! **Setting colors**
 
       ! ``profile_mass_point_color_index`` and ``profile_mass_point_str_clr`` 
       ! set the color of the mass location's symbol and corresponding string, respectively, 
       ! with 1 = foreground color, 2 = Red, 3 = Green, 4 = Blue, etc.
       ! The full range of available indicies is defined in Set_Colours in pgstar.support.f.
       
-      ! **Setting Symbols and Text**
+      ! **Setting symbols and text**
 
       ! ``profile_mass_point_symbol`` sets the symbol to be drawn for a given marker.
       ! A selection of code numbers used to define the mass point symbol can be found in the table below.
@@ -497,6 +500,9 @@
 
     Abundance_win_width = 6
     Abundance_win_aspect_ratio = 0.75
+
+      ! ::
+
     Abundance_xleft = 0.15
     Abundance_xright = 0.85
     Abundance_ybot = 0.15
@@ -504,7 +510,7 @@
     Abundance_txt_scale = 1.0
     Abundance_title = 'Abundance'
 
-      ! **Axis Limits and labels**
+      ! **Axis limits and labels**
 
       ! X-axis limits are set by ``Abundance_xmin`` and ``Abundance_xmax``. 
       ! Y-axis limits are set by ``Abundance_log_mass_frac_min`` and ``Abundance_log_mass_frac_max``
@@ -515,8 +521,11 @@
     Abundance_xmax = -101d0
     Abundance_log_mass_frac_min = 101
     Abundance_log_mass_frac_max = 0.3
-    Abundance_xaxis_reversed = .false.
+
+      ! ::
+    
     Abundance_xaxis_name = 'mass'
+    Abundance_xaxis_reversed = .false.
 
       ! **Legend**
       
@@ -549,14 +558,14 @@
 
     Abundance_show_photosphere_location = .false.
 
-      ! ''Abundance_use_decorator`` enables calling a subroutine to add extra information to a plot
+      ! ''Abundance_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Abundance_use_decorator = .false.
 
-      ! **file output**
+      ! **File output**
 
       ! ::
 
@@ -576,6 +585,7 @@
 
     Power_win_flag = .false.
 
+      ! **Window Sizing**
       ! ::
 
     Power_win_width = 6
@@ -590,38 +600,37 @@
     Power_txt_scale = 1.0
     Power_title = 'Power'
 
+      ! **Axis limits and labels**
+
+      ! ::
+
+    Power_xmin = -101d0
+    Power_xmax = -101d0
+    Power_ymin = -101d0
+    Power_ymax = -101d0
+    
       ! ::
 
     Power_xaxis_name = 'mass'
     Power_xaxis_reversed = .false.
+
+      ! **Legend**
 
       ! ::
 
     Power_legend_max_cnt = 16
     Power_legend_txt_scale_factor = 0.7
 
-      ! power xaxis limits -- to override system default selections
+      ! **Decorators**
 
-      ! ::
-
-    Power_xmin = -101d0
-    Power_xmax = -101d0
-
-      ! power yaxis limits -- to override system default selections
-
-      ! ::
-
-    Power_ymin = -101d0
-    Power_ymax = -101d0
-
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``Power_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Power_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -635,11 +644,13 @@
 ! Mixing window
 ! =============
 
-      ! current model profile of mixing diffusion coefficients
+      ! Display current model profile of mixing diffusion coefficients
 
       ! ::
 
     Mixing_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -655,9 +666,29 @@
     Mixing_txt_scale = 1.0
     Mixing_title = 'Mixing'
 
+      ! **Axis limits and labels**
+
       ! ::
 
+    Mixing_xmin = -101d0
+    Mixing_xmax = -101d0
+    Mixing_ymin = -101d0
+    Mixing_ymax = -101d0
+    Mixing_dymin = -101d0
+
+      ! ::
+
+    Mixing_xaxis_name = 'mass'
+    Mixing_xaxis_reversed = .false.
+
+
+      ! **Legend**
+
+      ! ::
+    
     Mixing_legend_txt_scale_factor = 1
+
+      ! **Decorators**
 
       ! ::
 
@@ -669,30 +700,14 @@
 
     Mixing_show_rotation_details = .true.
 
-      ! ::
-
-    Mixing_xaxis_name = 'mass'
-    Mixing_xaxis_reversed = .false.
-
-      ! ::
-
-    Mixing_xmin = -101d0
-    Mixing_xmax = -101d0
-
-      ! ::
-
-    Mixing_ymin = -101d0
-    Mixing_ymax = -101d0
-    Mixing_dymin = -101d0
-
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``Mixing_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Mixing_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -706,11 +721,13 @@
 ! Dynamo window
 ! =============
 
-      ! current model dynamo info
+      ! Display current model dynamo info
 
       ! ::
 
     Dynamo_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -726,22 +743,12 @@
     Dynamo_txt_scale = 1.0
     Dynamo_title = 'Dynamo'
 
-      ! ::
-
-    Dynamo_legend_txt_scale_factor = 0.7
+      ! **Axis limits and labels**
 
       ! ::
 
-    show_Dynamo_annotation1 = .false.
-    show_Dynamo_annotation2 = .false.
-    show_Dynamo_annotation3 = .false.
-
-      ! ::
-
-    Dynamo_xaxis_name = 'mass'
     Dynamo_xmin = -101d0
     Dynamo_xmax = -101d0
-    Dynamo_xaxis_reversed = .false.
 
       ! ::
 
@@ -755,14 +762,33 @@
     Dynamo_ymax_right = -101d0
     Dynamo_dymin_right = -101d0
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ::
+
+    Dynamo_xaxis_name = 'mass'
+    Dynamo_xaxis_reversed = .false.
+
+      ! **Legend**
+
+      ! ::
+
+    Dynamo_legend_txt_scale_factor = 0.7
+
+      ! **Decorators**
+
+      ! ::
+
+    show_Dynamo_annotation1 = .false.
+    show_Dynamo_annotation2 = .false.
+    show_Dynamo_annotation3 = .false.
+
+      ! ``Dynamo_use_decorator`` enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Dynamo_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -782,6 +808,8 @@
 
     Mode_Prop_win_flag = .false.
 
+      ! **Window sizing**
+
       ! ::
 
     Mode_Prop_win_width = 6
@@ -796,37 +824,37 @@
     Mode_Prop_txt_scale = 1.0
     Mode_Prop_title = 'Mode_Prop'
 
+      ! **Axis limits and labels**
+
       ! ::
 
-    Mode_Prop_nu_max_obs = -999
+    Mode_Prop_xmin = -101d0
+    Mode_Prop_xmax = -101d0
+    Mode_Prop_ymin = -101d0
+    Mode_Prop_ymax = -101d0
 
       ! ::
 
     Mode_Prop_xaxis_name = 'mass'
     Mode_Prop_xaxis_reversed = .false.
 
-      ! xaxis limits -- to override system default selections
+      ! **Decorators**
+
+      ! ``Mode_Prop_nu_max_obs`` sets the observed nu max that is plotted for comparison 
+      ! and can be ignored by setting the value to -999
 
       ! ::
 
-    Mode_Prop_xmin = -101d0
-    Mode_Prop_xmax = -101d0
+    Mode_Prop_nu_max_obs = -999
 
-      ! yaxis limits -- to override system default selections
-
-      ! ::
-
-    Mode_Prop_ymin = -101d0
-    Mode_Prop_ymax = -101d0
-
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``Mode_Prop_use_decorator`` enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Mode_Prop_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -840,9 +868,13 @@
 ! Summary Burn window
 ! ===================
 
+      ! Display summary of burn
+
       ! ::
 
     Summary_Burn_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -859,24 +891,28 @@
     Summary_Burn_title = 'Summary_Burn'
     Summary_Burn_title_shift = 2.5
 
-      ! ::
-
-    Summary_Burn_xaxis_name = 'mass'
-    Summary_Burn_xaxis_reversed = .false.
+      ! **Axis limits and labels**
 
       ! ::
 
     Summary_Burn_xmin = -101d0
     Summary_Burn_xmax = -101d0
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ::
+
+    Summary_Burn_xaxis_name = 'mass'
+    Summary_Burn_xaxis_reversed = .false.
+
+      ! **Decorators**
+
+      ! ``Summary_Burn_use_decorator`` enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Summary_Burn_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -890,9 +926,13 @@
 ! Summary Profile window
 ! ======================
 
+      ! Display summary of profile
+
       ! ::
 
     Summary_Profile_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -908,10 +948,7 @@
     Summary_Profile_txt_scale = 1.0
     Summary_Profile_title = 'Summary_Profile'
 
-      ! ::
-
-    Summary_Profile_xaxis_name = 'mass'
-    Summary_Profile_xaxis_reversed = .false.
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -920,19 +957,30 @@
 
       ! ::
 
-    Summary_Profile_name(:) = ''
+    Summary_Profile_xaxis_name = 'mass'
+    Summary_Profile_xaxis_reversed = .false.
 
-      ! if name len=0, then skip this one
+
+      ! **Syntax**
+
+      ! To set defaults for all entries:
+
+      ! If ``Summary_Profile_name(N)=''``, then skip it.
 
       ! ::
 
+    Summary_Profile_name(:) = ''
     Summary_Profile_legend(:) = ''
-    Summary_Profile_scaled_value(:) = .true.
 
-      ! if true, show values scaled max to 1.0 and min to 0.0
-      ! if false, show the unmapped values (which should be in range 0.0 to 1.0)
+      ! If ``Summary_Profile_scaled_value = .true.``, show values scaled max to 1.0 and min to 0.0. 
+      ! If ``Summary_Profile_scaled_value = .false.``, show the unmapped values (which should be in range 0.0 to 1.0)
       ! typically set .false. for mass fractions; .true. for everything else.
 
+      ! ::
+
+    Summary_Profile_scaled_value(:) = .true.
+
+      ! To then set individual qualities of any given ``Summary_Profile_name(N)``:
       ! ::
 
     Summary_Profile_num_lines = 11
@@ -994,6 +1042,8 @@
     Summary_Profile_name(11) = 'temperature'
     Summary_Profile_legend(11) = 'T rel'
 
+      ! **Decorators**
+
       ! Enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
@@ -1001,7 +1051,7 @@
 
     Summary_Profile_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1015,9 +1065,13 @@
 ! Summary History window
 ! ======================
 
+      ! Display history summary
+
       ! ::
 
     Summary_History_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1033,27 +1087,34 @@
     Summary_History_txt_scale = 1.0
     Summary_History_title = 'Summary_History'
 
+      ! **Axis limits and labels**
+
       ! ::
 
     Summary_History_xmax = -1
     Summary_History_xmin = -1
     Summary_History_max_width = -1
 
+      ! **Syntax**
+
+      ! To set defaults for all entries:
+
+      ! If ``Summary_History_name(N)=''``, then skip it.
+
       ! ::
 
     Summary_History_name(:) = ''
+    Summary_History_legend(:) = ''
 
-      ! if name len=0, then skip this one
+      ! if ``Summary_History_scaled_value = .true.``, show values scaled max to 1.0 and min to 0.0
+      ! if ``Summary_History_scaled_value = .false.``, show the unmapped values (which should be in range 0.0 to 1.0)
+      ! typically set .false. for mass fractions; .true. for everything else.
 
       ! ::
 
-    Summary_History_legend(:) = ''
     Summary_History_scaled_value(:) = .true.
 
-      ! if true, show values scaled max to 1.0 and min to 0.0
-      ! if false, show the unmapped values (which should be in range 0.0 to 1.0)
-      ! typically set .false. for mass fractions; .true. for everything else.
-
+      ! To then set individual qualities of any given ``Summary_History_name(N)``:
       ! ::
 
     Summary_History_num_lines = 7
@@ -1095,6 +1156,8 @@
     Summary_History_legend(7) = 'he4\dc\u'
     Summary_History_scaled_value(7) = .false.
 
+      ! **Decorators**
+
       ! Enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
@@ -1102,7 +1165,7 @@
 
     Summary_History_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1131,9 +1194,13 @@
       !     if you want to show mass boundaries, then include some or all of
       !            he_core_mass, co_core_mass, fe_core_mass
 
+      ! Display Kippenhahn window
+
       ! ::
 
     Kipp_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1149,27 +1216,25 @@
     Kipp_txt_scale = 1.0
     Kipp_title = 'Kipp'
 
-      ! Set xaxis
+      ! **Axis limits and labels**
+
+      ! The options for ``Kipp_xaxis_name`` are ``model_number`` and ``star_age``
 
       ! ::
 
     Kipp_step_xmin = -1
     Kipp_step_xmax = -1
+    Kipp_xaxis_name = 'model_number'
 
-      ! These can be combined with Kipp_{xmin,xmax} options
-
+      ! If ``Kipp_max_width`` is negative, then all steps will be shown, thereby overriding ``Kipp_step_xmin``
+      
       ! ::
 
     Kipp_max_width = -1
 
-      ! Negative implies show all steps. This overrides ``Kipp_step_xmin``
-
-      ! ::
-
-    Kipp_xaxis_name = 'model_number'
-
-      ! are ``model_number`` or ``star_age``
-
+      ! Changes to ``Kipp_xaxis_log``, ``Kipp_xmin``, ``Kipp_xmax``, ``Kipp_xmargin``, 
+      ! ``Kipp_xaxis_reversed``, ``Kipp_xaxis_in_seconds``, ``Kipp_xaxis_in_Myr``, and 
+      ! ``Kipp_xaxis_time_from_present`` all require ``Kipp_xaxis_name = star_age``
       ! ::
 
     Kipp_xaxis_log = .false.
@@ -1178,23 +1243,15 @@
     Kipp_xmargin = 0.0
     Kipp_xaxis_reversed = .false.
     Kipp_xaxis_in_seconds = .false.
-
-      ! Requires ``Kipp_xaxis_name='star_age'``
-
-      ! ::
-
     Kipp_xaxis_in_Myr = .false.
 
-      ! Requires ``Kipp_xaxis_name='star_age'``
+      ! ``Kipp_xaxis_time_from_present`` plots star_age - max(star_age)
 
       ! ::
 
     Kipp_xaxis_time_from_present = .false.
 
-      ! plots ``star_age-max(star_age)``
-      ! Requires ``Kipp_xaxis_name='star_age'``
-
-      ! bounds for mass yaxis
+      ! Bounds for mass Y-axis:
 
       ! ::
 
@@ -1202,7 +1259,7 @@
     Kipp_mass_min = -1
     Kipp_mass_margin = 0.01
 
-      ! bounds for luminosity yaxis
+      ! Bounds for luminosity Y-axis:
 
       ! ::
 
@@ -1210,52 +1267,40 @@
     Kipp_lgL_min = -101d0
     Kipp_lgL_margin = 0.1
 
+      ! **Decorators**
+
+      ! ``Kipp_show_mixing`` uses the ``mixing_regions`` specified in your ``history_columns.list``.
+      ! ``Kipp_mix_interval`` sets the model number step in between updates of the displayed mixing data
+
       ! ::
 
     Kipp_show_mixing = .true.
+    Kipp_mix_line_weight = 10
+    Kipp_mix_interval = 4
 
-      ! this uses the ``mixing_regions`` specified in your ``history_columns.list``
-
+      ! ``Kipp_show_burn`` uses the ``burning_regions`` specified in your ``history_columns.list``.
+      ! Burn lines are shown only where abs(log(eps)) > ``Kipp_burn_type_cutoff``.
       ! ::
+
 
     Kipp_show_burn = .true.
+    Kipp_burn_line_weight = 14
+    Kipp_burn_type_cutoff = 0d0
 
-      ! this uses the ``burning_regions`` specified in your ``history_columns.list``
-
-      ! ::
-
-    Kipp_show_luminosities = .false.
-
-      ! to use this option, include the following in your ``history_columns.list``
+      ! To use ``Kipp_show_luminosities``, include the following in your ``history_columns.list``
       ! ``log_L``, ``log_Lneu``, ``log_LH``, ``log_LHe``
 
       ! ::
 
-    Kipp_show_mass_boundaries = .true.
+    Kipp_show_luminosities = .false.
+    Kipp_luminosities_line_weight = 8
 
-      ! to use this option, include the following in your ``history_columns.list``
+      ! To use ``Kipp_show_mass_boundaries``, include the following in your ``history_columns.list``
       ! ``he_core_mass``, ``co_core_mass``, ``fe_core_mass``
 
       ! ::
 
-    Kipp_mix_line_weight = 10
-    Kipp_mix_interval = 4
-
-      ! show mixing for steps with ``mod(model_number, Kipp_mix_interval) = 0.``
-
-      ! ::
-
-    Kipp_burn_line_weight = 14
-
-      ! ::
-
-    Kipp_burn_type_cutoff = 0d0
-
-      ! show burn lines only for abs(log(eps)) > Kipp_burn_type_cutoff
-
-      ! ::
-
-    Kipp_luminosities_line_weight = 8
+    Kipp_show_mass_boundaries = .true.
     Kipp_masses_line_weight = 8
 
       ! ::
@@ -1264,14 +1309,14 @@
     show_Kipp_annotation2 = .false.
     show_Kipp_annotation3 = .false.
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``Kipp_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Kipp_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1295,10 +1340,13 @@
       !     and if you have set M_center > 0, then also include
       !            log_xmstar
 
+      ! Display history of Rayleigh-Taylor Instability
+
       ! ::
 
     rti_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     rti_win_width = 7
@@ -1313,26 +1361,26 @@
     rti_txt_scale = 1.0
     rti_title = 'Rayleigh Taylor Instability'
 
-      ! Set xaxis
+      ! **Axis limits and Labels**
+
+      ! The options for ``rti_xaxis_name`` are ``model_number`` or ``star_age``
 
       ! ::
 
     rti_step_xmin = -1
     rti_step_xmax = -1
+    rti_xaxis_name = 'model_number'
 
-      ! These can be combined with ``rti_{xmin,xmax}`` options
+      ! If ``rti_max_width`` is negative, then all steps will be shown, 
+      ! thereby overriding ``rti_step_xmin``
 
       ! ::
 
     rti_max_width = -1
 
-      ! Negative implies show all steps. This overrides ``rti_step_xmin``
-
-      ! ::
-
-    rti_xaxis_name = 'model_number'
-
-      ! are ``model_number`` or ``star_age``
+      ! Changes to ``rti_xaxis_log``, ``rti_xmin``, ``rti_xmax``, ``rti_xmargin``, 
+      ! ``rti_xaxis_reversed``, ``rti_xaxis_in_seconds``, ``rti_xaxis_in_Myr``, 
+      ! and ``rti_xaxis_time_from_present`` all require ``rti_xaxis_name = star_age``
 
       ! ::
 
@@ -1342,23 +1390,15 @@
     rti_xmargin = 0.0
     rti_xaxis_reversed = .false.
     rti_xaxis_in_seconds = .false.
-
-      ! Requires ``rti_xaxis_name='star_age'``
-
-      ! ::
-
     rti_xaxis_in_Myr = .false.
 
-      ! Requires ``rti_xaxis_name='star_age'``
+      ! ``rti_xaxis_time_from_present`` plots star_age - max(star_age)
 
       ! ::
 
     rti_xaxis_time_from_present = .false.
 
-      ! plots ``star_age-max(star_age)``
-      ! Requires ``rti_xaxis_name='star_age'``
-
-      ! bounds for mass yaxis
+      ! Bounds for mass Y-axis
 
       ! ::
 
@@ -1366,12 +1406,14 @@
     rti_mass_min = -1
     rti_mass_margin = 0.01
 
+      ! **Decorators**
+      
+      ! ``rti_interval`` sets the model number step in between 
+      ! updates of the displayed rti data
       ! ::
 
     rti_line_weight = 10
     rti_interval = 4
-
-      ! show rti for steps with ``mod(model_number, rti_interval) = 0.``
 
       ! ::
 
@@ -1379,14 +1421,14 @@
     show_rti_annotation2 = .false.
     show_rti_annotation3 = .false.
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``rti_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     rti_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1400,11 +1442,13 @@
 ! TRho window
 ! ===========
 
-      ! history of central temperature vs. density
+      ! Display history of central temperature vs. density
 
       ! ::
 
     TRho_win_flag = .false.
+
+      ! **Window Sizing**
 
       ! ::
 
@@ -1420,7 +1464,7 @@
     TRho_txt_scale = 1.0
     TRho_title = 'TRho'
 
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1441,6 +1485,8 @@
     TRho_step_min = -1
     TRho_step_max = -1
 
+      ! **Decorators**
+
       ! ::
 
     show_TRho_degeneracy_line = .true.
@@ -1455,14 +1501,14 @@
 
     TRho_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``TRho_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     TRho_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1476,12 +1522,13 @@
 ! TmaxRho window
 ! ==============
 
-      ! history of central temperature vs. density
+      ! Display history of central temperature vs. density
 
       ! ::
 
     TmaxRho_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     TmaxRho_win_width = 6
@@ -1496,7 +1543,7 @@
     TmaxRho_txt_scale = 1.0
     TmaxRho_title = 'TmaxRho'
 
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1517,6 +1564,8 @@
     TmaxRho_step_min = -1
     TmaxRho_step_max = -1
 
+      ! **Decorators**
+
       ! ::
 
     show_TmaxRho_degeneracy_line = .true.
@@ -1531,7 +1580,7 @@
 
     TmaxRho_fname = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1545,11 +1594,13 @@
 ! HR window
 ! =========
 
-      ! history of ``lg_L`` vs. ``lg_Teff``
+      ! Display history of ``lg_L`` vs. ``lg_Teff``
 
       ! ::
 
     HR_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1565,7 +1616,7 @@
     HR_txt_scale = 1.0
     HR_title = 'HR'
 
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1585,6 +1636,8 @@
 
     HR_step_min = -1
     HR_step_max = -1
+
+      ! **Decorators**
 
       ! ::
 
@@ -1611,14 +1664,14 @@
 
     HR_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``HR_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     HR_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1632,11 +1685,13 @@
 ! logL_Teff window
 ! ================
 
-      ! history of logL vs. Teff
+      ! Display history of logL vs. Teff
 
       ! ::
 
     logL_Teff_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1652,16 +1707,7 @@
     logL_Teff_txt_scale = 1.0
     logL_Teff_title = 'logL_Teff'
 
-      ! ::
-
-    show_logL_Teff_target_box = .false.
-    logL_Teff_target_n_sigma = -3
-    logL_Teff_target_logL = 4.00d0
-    logL_Teff_target_logL_sigma = 0.06d0
-    logL_Teff_target_Teff = 6095d0
-    logL_Teff_target_Teff_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1682,6 +1728,18 @@
     logL_Teff_step_min = -1
     logL_Teff_step_max = -1
 
+      ! **Decorators**
+      
+      ! ::
+
+    show_logL_Teff_target_box = .false.
+    logL_Teff_target_n_sigma = -3
+    logL_Teff_target_logL = 4.00d0
+    logL_Teff_target_logL_sigma = 0.06d0
+    logL_Teff_target_Teff = 6095d0
+    logL_Teff_target_Teff_sigma = 65
+
+
       ! ::
 
     show_logL_Teff_annotation1 = .false.
@@ -1692,14 +1750,14 @@
 
     logL_Teff_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``logL_Teff_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     logL_Teff_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1713,11 +1771,13 @@
 ! logL_R window
 ! =============
 
-      ! history of logL vs. R
+      ! Display history of logL vs. R
 
       ! ::
 
     logL_R_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1733,20 +1793,7 @@
     logL_R_txt_scale = 1.0
     logL_R_title = 'logL_R'
 
-      ! ::
-
-    show_logL_photosphere_r = .false.
-
-      ! ::
-
-    show_logL_R_target_box = .false.
-    logL_R_target_n_sigma = -3
-    logL_R_target_logL = 4.00d0
-    logL_R_target_logL_sigma = 0.06d0
-    logL_R_target_R = 6095d0
-    logL_R_target_R_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1767,6 +1814,21 @@
     logL_R_step_min = -1
     logL_R_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_logL_photosphere_r = .false.
+
+      ! ::
+
+    show_logL_R_target_box = .false.
+    logL_R_target_n_sigma = -3
+    logL_R_target_logL = 4.00d0
+    logL_R_target_logL_sigma = 0.06d0
+    logL_R_target_R = 6095d0
+    logL_R_target_R_sigma = 65
+
       ! ::
 
     show_logL_R_annotation1 = .false.
@@ -1777,14 +1839,14 @@
 
     logL_R_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``logL_R_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     logL_R_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1798,11 +1860,13 @@
 ! logL_v window
 ! =============
 
-      ! history of logL vs. v surface or photosphere
+      ! Display history of logL vs. v surface or photosphere
 
       ! ::
 
     logL_v_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1818,20 +1882,7 @@
     logL_v_txt_scale = 1.0
     logL_v_title = 'logL_v'
 
-      ! ::
-
-    show_logL_photosphere_v = .false.
-
-      ! ::
-
-    show_logL_v_target_box = .false.
-    logL_v_target_n_sigma = -3
-    logL_v_target_logL = 4.00d0
-    logL_v_target_logL_sigma = 0.06d0
-    logL_v_target_v = 6095d0
-    logL_v_target_v_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1852,6 +1903,21 @@
     logL_v_step_min = -1
     logL_v_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_logL_photosphere_v = .false.
+
+      ! ::
+
+    show_logL_v_target_box = .false.
+    logL_v_target_n_sigma = -3
+    logL_v_target_logL = 4.00d0
+    logL_v_target_logL_sigma = 0.06d0
+    logL_v_target_v = 6095d0
+    logL_v_target_v_sigma = 65
+
       ! ::
 
     show_logL_v_annotation1 = .false.
@@ -1862,14 +1928,14 @@
 
     logL_v_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``logl_v_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     logl_v_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1883,11 +1949,13 @@
 ! L_Teff window
 ! =============
 
-      ! history of L vs. Teff
+      ! Display history of L vs. Teff
 
       ! ::
 
     L_Teff_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1903,16 +1971,7 @@
     L_Teff_txt_scale = 1.0
     L_Teff_title = 'L_Teff'
 
-      ! ::
-
-    show_L_Teff_target_box = .false.
-    L_Teff_target_n_sigma = -3
-    L_Teff_target_L = 4.00d0
-    L_Teff_target_L_sigma = 0.06d0
-    L_Teff_target_Teff = 6095d0
-    L_Teff_target_Teff_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -1933,6 +1992,17 @@
     L_Teff_step_min = -1
     L_Teff_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_L_Teff_target_box = .false.
+    L_Teff_target_n_sigma = -3
+    L_Teff_target_L = 4.00d0
+    L_Teff_target_L_sigma = 0.06d0
+    L_Teff_target_Teff = 6095d0
+    L_Teff_target_Teff_sigma = 65
+
       ! ::
 
     show_L_Teff_annotation1 = .false.
@@ -1943,14 +2013,14 @@
 
     L_Teff_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``L_Teff_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     L_Teff_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -1964,11 +2034,13 @@
 ! L_v window
 ! ==========
 
-      ! history of L vs. surface velocity
+      ! Display history of L vs. surface velocity
 
       ! ::
 
     L_v_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -1984,16 +2056,7 @@
     L_v_txt_scale = 1.0
     L_v_title = 'L_v'
 
-      ! ::
-
-    show_L_v_target_box = .false.
-    L_v_target_n_sigma = -3
-    L_v_target_L = 4.00d0
-    L_v_target_L_sigma = 0.06d0
-    L_v_target_v = 6095d0
-    L_v_target_v_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2014,6 +2077,17 @@
     L_v_step_min = -1
     L_v_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_L_v_target_box = .false.
+    L_v_target_n_sigma = -3
+    L_v_target_L = 4.00d0
+    L_v_target_L_sigma = 0.06d0
+    L_v_target_v = 6095d0
+    L_v_target_v_sigma = 65
+
       ! ::
 
     show_L_v_annotation1 = .false.
@@ -2024,14 +2098,14 @@
 
     L_v_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``L_v_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     L_v_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2045,11 +2119,13 @@
 ! L_R window
 ! ==========
 
-      ! history of L vs. R
+      ! Display history of L vs. R
 
       ! ::
 
     L_R_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -2065,16 +2141,7 @@
     L_R_txt_scale = 1.0
     L_R_title = 'L_R'
 
-      ! ::
-
-    show_L_R_target_box = .false.
-    L_R_target_n_sigma = -3
-    L_R_target_L = 4.00d0
-    L_R_target_L_sigma = 0.06d0
-    L_R_target_R = 6095d0
-    L_R_target_R_sigma = 65
-
-      ! axis limits -- to oRerride system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2095,6 +2162,17 @@
     L_R_step_min = -1
     L_R_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_L_R_target_box = .false.
+    L_R_target_n_sigma = -3
+    L_R_target_L = 4.00d0
+    L_R_target_L_sigma = 0.06d0
+    L_R_target_R = 6095d0
+    L_R_target_R_sigma = 65
+
       ! ::
 
     show_L_R_annotation1 = .false.
@@ -2105,14 +2183,14 @@
 
     L_R_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``L_R_use_decorator`` Enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     L_R_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2126,11 +2204,13 @@
 ! R_Teff window
 ! =============
 
-      ! history of R vs. Teff
+      ! Display history of R vs. Teff
 
       ! ::
 
     R_Teff_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -2146,16 +2226,7 @@
     R_Teff_txt_scale = 1.0
     R_Teff_title = 'R_Teff'
 
-      ! ::
-
-    show_R_Teff_target_box = .false.
-    R_Teff_target_n_sigma = -3
-    R_Teff_target_R = 4.00d0
-    R_Teff_target_R_sigma = 0.06d0
-    R_Teff_target_Teff = 6095d0
-    R_Teff_target_Teff_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2176,6 +2247,17 @@
     R_Teff_step_min = -1
     R_Teff_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_R_Teff_target_box = .false.
+    R_Teff_target_n_sigma = -3
+    R_Teff_target_R = 4.00d0
+    R_Teff_target_R_sigma = 0.06d0
+    R_Teff_target_Teff = 6095d0
+    R_Teff_target_Teff_sigma = 65
+
       ! ::
 
     show_R_Teff_annotation1 = .false.
@@ -2186,14 +2268,14 @@
 
     R_Teff_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``R_Teff_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     R_Teff_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2207,11 +2289,13 @@
 ! R_L window
 ! ==========
 
-      ! history of R vs. L
+      ! Display history of R vs. L
 
       ! ::
 
     R_L_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -2227,16 +2311,7 @@
     R_L_txt_scale = 1.0
     R_L_title = 'R_L'
 
-      ! ::
-
-    show_R_L_target_box = .false.
-    R_L_target_n_sigma = -3
-    R_L_target_R = 4.00d0
-    R_L_target_R_sigma = 0.06d0
-    R_L_target_L = 6095d0
-    R_L_target_L_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2257,6 +2332,17 @@
     R_L_step_min = -1
     R_L_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_R_L_target_box = .false.
+    R_L_target_n_sigma = -3
+    R_L_target_R = 4.00d0
+    R_L_target_R_sigma = 0.06d0
+    R_L_target_L = 6095d0
+    R_L_target_L_sigma = 65
+
       ! ::
 
     show_R_L_annotation1 = .false.
@@ -2267,14 +2353,14 @@
 
     R_L_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``R_L_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     R_L_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2288,11 +2374,13 @@
 ! logg_Teff window
 ! ================
 
-      ! history of logg vs. Teff
+      ! Display history of logg vs. Teff
 
       ! ::
 
     logg_Teff_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -2308,16 +2396,7 @@
     logg_Teff_txt_scale = 1.0
     logg_Teff_title = 'logg_Teff'
 
-      ! ::
-
-    show_logg_Teff_target_box = .false.
-    logg_Teff_target_n_sigma = -3
-    logg_Teff_target_logg = 4.00d0
-    logg_Teff_target_logg_sigma = 0.06d0
-    logg_Teff_target_Teff = 6095d0
-    logg_Teff_target_Teff_sigma = 65
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2338,6 +2417,17 @@
     logg_Teff_step_min = -1
     logg_Teff_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_logg_Teff_target_box = .false.
+    logg_Teff_target_n_sigma = -3
+    logg_Teff_target_logg = 4.00d0
+    logg_Teff_target_logg_sigma = 0.06d0
+    logg_Teff_target_Teff = 6095d0
+    logg_Teff_target_Teff_sigma = 65
+
       ! ::
 
     show_logg_Teff_annotation1 = .false.
@@ -2348,14 +2438,14 @@
 
     logg_Teff_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``logg_Teff_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     logg_Teff_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2369,11 +2459,13 @@
 ! logg_logT window
 ! ================
 
-      ! history of logg vs. log Teff
+      ! Display history of logg vs. log Teff
 
       ! ::
 
     logg_logT_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -2389,16 +2481,7 @@
     logg_logT_txt_scale = 1.0
     logg_logT_title = 'logg_logT'
 
-      ! ::
-
-    show_logg_logT_target_box = .false.
-    logg_logT_target_n_sigma = -3
-    logg_logT_target_logg = 4.00d0
-    logg_logT_target_logg_sigma = 0.06d0
-    logg_logT_target_logT = 3.785d0
-    logg_logT_target_logT_sigma = 0.00461d0
-
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2419,6 +2502,17 @@
     logg_logT_step_min = -1
     logg_logT_step_max = -1
 
+      ! **Decorators**
+
+      ! ::
+
+    show_logg_logT_target_box = .false.
+    logg_logT_target_n_sigma = -3
+    logg_logT_target_logg = 4.00d0
+    logg_logT_target_logg_sigma = 0.06d0
+    logg_logT_target_logT = 3.785d0
+    logg_logT_target_logT_sigma = 0.00461d0
+
       ! ::
 
     show_logg_logT_annotation1 = .false.
@@ -2429,14 +2523,14 @@
 
     logg_logT_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``logg_logT_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     logg_logT_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2450,11 +2544,13 @@
 ! dPg_dnu window
 ! ==============
 
-      ! ``delta_Pg`` vs. ``delta_nu`` (for asteroseismology)
+      ! Display ``delta_Pg`` vs. ``delta_nu`` (for asteroseismology)
 
       ! ::
 
     dPg_dnu_win_flag = .false.
+
+      ! **Window sizing**
 
       ! ::
 
@@ -2470,7 +2566,7 @@
     dPg_dnu_txt_scale = 1.0
     dPg_dnu_title = 'dPg_dnu'
 
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2491,6 +2587,8 @@
     dPg_dnu_step_min = -1
     dPg_dnu_step_max = -1
 
+      ! **Decorators**
+
       ! ::
 
     show_dPg_dnu_annotation1 = .false.
@@ -2501,14 +2599,14 @@
 
     dPg_dnu_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``dPg_dnu_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     dPg_dnu_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2528,6 +2626,8 @@
 
     Network_win_flag = .false.
 
+      ! **Window sizing**
+
       ! ::
 
     Network_win_width = 6
@@ -2542,7 +2642,7 @@
     Network_txt_scale = 1.0
     Network_title = 'Network'
 
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2551,39 +2651,33 @@
     Network_zmin = -101d0
     Network_zmax = -101d0
 
-      ! Show mass fraction as a coloured square
+      ! **Decorators**
+
+      ! If ``Network_show_mass_fraction = .true.``, then show mass fraction as a coloured square. 
+      ! The mass fractions shown are limited by ``Network_log_mass_frac_min`` and ``Network_log_mass_frac_max``.
 
       ! ::
 
     Network_show_mass_fraction = .true.
-
-      ! Limits on mass fractions to show
-
-      ! ::
-
     Network_log_mass_frac_min = -5.0d0
     Network_log_mass_frac_max = 0.0d0
 
-      ! Label Y axis with element name
+      ! Use ``Network_show_element_names`` to label Y-axis with element name and 
+      ! ``Network_show_colorbar`` to add a color bar.
 
       ! ::
 
     Network_show_element_names = .true.
+    Network_show_colorbar = .true.
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``Network_use_decorator`` enables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Network_use_decorator = .false.
 
-      ! Add colorbar
-
-      ! ::
-
-    Network_show_colorbar = .true.
-
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2603,6 +2697,8 @@
 
     Production_win_flag = .false.
 
+      ! **Window sizing**
+
       ! ::
 
     Production_win_width = 6
@@ -2617,7 +2713,7 @@
     Production_txt_scale = 1.0
     Production_title = 'Production'
 
-      ! axis limits -- to override system default selections
+      ! **Axis limits and labels**
 
       ! ::
 
@@ -2639,20 +2735,22 @@
 
     Production_min_mass_frac = -5.0d0
 
+      ! **Decorators**
+
       ! Add labels with element names
 
       ! ::
 
     Production_show_element_names = .true.
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``Production_use_decorator`` nables calling a subroutine to add extra information to a plot,
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Production_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2690,6 +2788,7 @@
 
     Profile_Panels1_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels1_win_width = 6
@@ -2760,7 +2859,7 @@
 
     Profile_Panels1_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2779,6 +2878,7 @@
 
     Profile_Panels2_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels2_win_width = 6
@@ -2864,7 +2964,7 @@
 
     Profile_Panels2_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2883,6 +2983,7 @@
 
     Profile_Panels3_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels3_win_width = 6
@@ -2969,7 +3070,7 @@
 
     Profile_Panels3_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -2988,6 +3089,7 @@
 
     Profile_Panels4_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels4_win_width = 6
@@ -3071,7 +3173,7 @@
 
     Profile_Panels4_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3090,6 +3192,7 @@
 
     Profile_Panels5_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels5_win_width = 5
@@ -3176,7 +3279,7 @@
 
     Profile_Panels5_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3195,6 +3298,7 @@
 
     Profile_Panels6_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels6_win_width = 6
@@ -3259,7 +3363,7 @@
 
     Profile_Panels6_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3278,6 +3382,7 @@
 
     Profile_Panels7_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels7_win_width = 6
@@ -3342,7 +3447,7 @@
 
     Profile_Panels7_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3361,6 +3466,7 @@
 
     Profile_Panels8_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels8_win_width = 6
@@ -3425,7 +3531,7 @@
 
     Profile_Panels8_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3444,6 +3550,7 @@
 
     Profile_Panels9_win_flag = .false.
 
+      ! **Window sizing**
       ! ::
 
     Profile_Panels9_win_width = 6
@@ -3508,7 +3615,7 @@
 
     Profile_Panels9_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3599,7 +3706,7 @@
 
     History_Track1_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3685,7 +3792,7 @@
 
     History_Track2_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3771,7 +3878,7 @@
 
     History_Track3_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3857,7 +3964,7 @@
 
     History_Track4_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -3943,7 +4050,7 @@
 
     History_Track5_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4029,7 +4136,7 @@
 
     History_Track6_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4115,7 +4222,7 @@
 
     History_Track7_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4201,7 +4308,7 @@
 
     History_Track8_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4287,7 +4394,7 @@
 
     History_Track9_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4424,7 +4531,7 @@
 
     History_Panels1_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4508,7 +4615,7 @@
 
     History_Panels2_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4592,7 +4699,7 @@
 
     History_Panels3_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4676,7 +4783,7 @@
 
     History_Panels4_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4768,7 +4875,7 @@
 
     History_Panels5_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4850,7 +4957,7 @@
 
     History_Panels6_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -4934,7 +5041,7 @@
 
     History_Panels7_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5018,7 +5125,7 @@
 
     History_Panels8_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5110,7 +5217,7 @@
 
     History_Panels9_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5262,7 +5369,7 @@
 
     Color_magnitude1_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5386,7 +5493,7 @@
 
     Color_magnitude2_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5510,7 +5617,7 @@
 
     Color_magnitude3_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5634,7 +5741,7 @@
 
     Color_magnitude4_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5758,7 +5865,7 @@
 
     Color_magnitude5_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -5882,7 +5989,7 @@
 
     Color_magnitude6_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6006,7 +6113,7 @@
 
     Color_magnitude7_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6130,7 +6237,7 @@
 
     Color_magnitude8_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6254,7 +6361,7 @@
 
     Color_magnitude9_use_decorator = .false.
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6340,7 +6447,7 @@
     Text_Summary1_name(7,4) = 'num_retries'
     Text_Summary1_name(8,4) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6377,7 +6484,7 @@
     Text_Summary2_num_cols = 0
     Text_Summary2_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6414,7 +6521,7 @@
     Text_Summary3_num_cols = 0
     Text_Summary3_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6451,7 +6558,7 @@
     Text_Summary4_num_cols = 0
     Text_Summary4_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6488,7 +6595,7 @@
     Text_Summary5_num_cols = 0
     Text_Summary5_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6525,7 +6632,7 @@
     Text_Summary6_num_cols = 0
     Text_Summary6_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6562,7 +6669,7 @@
     Text_Summary7_num_cols = 0
     Text_Summary7_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6599,7 +6706,7 @@
     Text_Summary8_num_cols = 0
     Text_Summary8_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6636,7 +6743,7 @@
     Text_Summary9_num_cols = 0
     Text_Summary9_name(:,:) = ''
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6744,7 +6851,7 @@
     Grid1_plot_pad_bot(4) = -0.05
     Grid1_txt_scale_factor(4) = 0.2
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6867,7 +6974,7 @@
     Grid2_plot_pad_bot(5) = 0.0
     Grid2_txt_scale_factor(5) = 0.65
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -6965,7 +7072,7 @@
     Grid3_plot_pad_bot(3) = 0.07
     Grid3_txt_scale_factor(3) = 0.7
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -7096,7 +7203,7 @@
     Grid4_plot_pad_bot(6) = 0.0
     Grid4_txt_scale_factor(6) = 0.17
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -7214,7 +7321,7 @@
     Grid5_plot_pad_bot(5) = 0.06
     Grid5_txt_scale_factor(5) = 0.7
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -7338,7 +7445,7 @@
     Grid6_plot_pad_bot(5) = 0.00
     Grid6_txt_scale_factor(5) = 0.21
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -7436,7 +7543,7 @@
     Grid7_plot_pad_bot(3) = 0.0
     Grid7_txt_scale_factor(3) = 0.16
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -7573,7 +7680,7 @@
     Grid8_plot_pad_bot(6) = 0.0
     Grid8_txt_scale_factor(6) = 0.16
 
-      ! file output
+      ! **File output**
 
       ! ::
 
@@ -7697,7 +7804,7 @@
     Grid9_plot_pad_bot(5) = 0.0
     Grid9_txt_scale_factor(5) = 0.14
 
-      ! file output
+      ! **File output**
 
       ! ::
 

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -281,11 +281,16 @@
     pgstar_lw = 8
 
 
-      ! pgstar_profile_line_style for profile panels plot (the left side one, not the "other" one on the right)
-      ! pgstar_history_line_style for history panels plot (the left side one, not the "other" one on the right)
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! pgstar_profile_line_style for profile panels plot
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! pgstar_history_line_style for history panels plot 
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! :: 1 (full line), 2 (dashed), 3 (dot-dash-dot-dash), 4 (dotted), 5 (dash-dot-dot-dot)
+      ! Referring to the the left side plot, not the "other" one on the right
+      !
+      ! 1 (full line), 2 (dashed), 3 (dot-dash-dot-dash), 4 (dotted), 5 (dash-dot-dot-dot)
+
+      ! :: 
 
     pgstar_profile_line_style = 1 
     pgstar_history_line_style = 1

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -298,19 +298,19 @@
 ! TRho Profile window
 ! ===================
 
-      ! current model in T-Rho plane
+      ! Display current model in T-Rho plane
 
       ! ::
 
     TRho_Profile_win_flag = .false.
 
+      ! Window Sizing
+      ! -------------
+
       ! ::
 
     TRho_Profile_win_width = 6
     TRho_Profile_win_aspect_ratio = 0.75
-
-      ! ::
-
     TRho_Profile_xleft = 0.15
     TRho_Profile_xright = 0.85
     TRho_Profile_ybot = 0.15
@@ -318,17 +318,27 @@
     TRho_Profile_txt_scale = 1.0
     TRho_Profile_title = 'TRho_Profile'
 
+      ! Axis limits
+      ! -----------
+
+      ! ::
+
+    TRho_Profile_xmin = -11.1
+    TRho_Profile_xmax = 10.2
+    TRho_Profile_ymin = 2.6
+    TRho_Profile_ymax = 10.2
+
+
+      ! If ``TRho_switch_to_Column_Depth = .true.``, replace logRho for xaxis by log column depth (g/cm^2). 
+      ! If ``TRho_switch_to_mass = .true.``, replace logRho for xaxis by log mass coordinate M-m(k) |Msun|.
+
       ! ::
 
     TRho_switch_to_Column_Depth = .false.
-
-      ! if true, replace logRho for xaxis by log column depth (g/cm^2)
-
-      ! ::
-
     TRho_switch_to_mass = .false.
 
-      ! if true, replaces logRho for xaxis by log mass coordinate M-m(k) (Msun)
+      ! Legend 
+      ! ------
 
       ! ::
 
@@ -347,25 +357,30 @@
     TRho_Profile_text_info_yfac = 0.6
     TRho_Profile_text_info_dyfac = -0.04
 
+      ! Decorators
+      ! ----------
+
+      ! If ``show_TRho_accretion_mesh_borders = .true.``, plots the borders of the mesh and newly accreted material in the appropriate xcoord
+
       ! ::
 
-    show_TRho_Profile_mass_locs = .false.
     show_TRho_accretion_mesh_borders = .false.
 
-      ! If true, plots the borders of the mesh and newly accreted material in the appropriate xcoord
+      ! The regions shown by ``show_TRho_Profile_kap_regions`` and ``show_TRho_Profile_eos_regions`` may **not** correspond exactly to those used in the model as 
+      ! they are **not** updated to reflect changes made in a inlist that change the boundaries between eos or kap regions. 
 
       ! ::
 
     show_TRho_Profile_kap_regions = .false.
     show_TRho_Profile_eos_regions = .false.
+
+      ! ::
+
     show_TRho_Profile_gamma1_4_3rd = .false.
     show_TRho_Profile_degeneracy_line = .true.
     show_TRho_Profile_Pgas_Prad_line = .true.
     show_TRho_Profile_burn_lines = .true.
     show_TRho_Profile_burn_labels = .true.
-
-      ! The regions shown may not correspond exactly to those used in the model as 
-      ! they are not updated to reflect changes made in a inlist that change the boundaries between eos or kap regions. 
 
       ! ::
 
@@ -377,23 +392,16 @@
 
     TRho_Profile_fname = ''
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ``TRho_Profile_use_decorator`` enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     TRho_Profile_use_decorator = .false.
 
-      ! axis limits
 
-      ! ::
-
-    TRho_Profile_xmin = -11.1
-    TRho_Profile_xmax = 10.2
-    TRho_Profile_ymin = 2.6
-    TRho_Profile_ymax = 10.2
-
-      ! file output
+      ! TRho Profile file output
+      ! ------------------------
 
       ! ::
 
@@ -404,32 +412,43 @@
     TRho_Profile_file_width = -1
     TRho_Profile_file_aspect_ratio = -1
 
-      ! mass location markers
+      ! Mass location markers
+      ! ---------------------
 
-      !|     profile_mass_point_color_index
-      !|     1 = foreground color
-      !|     2 = red
-      !|     3 = green
-      !|     4 = blue
-      !|     etc. the full range is defined in Set_Colours in pgstar_support.f
-      !|     profile_mass_point_symbol
-      !|     code number of the symbol to be drawn:
-      !|           -1, -2  : a single dot (diameter = current
-      !|                     line width).
-      !|           -3..-31 : a regular polygon with ABS(SYMBOL)
-      !|                     edges (style set by current fill style).
-      !|           0..31   : standard marker symbols.
-      !|           32..127 : ASCII characters (in current font).
-      !|                     e.g. to use letter F as a marker, let
-      !|                     SYMBOL = ICHAR('F').
-      !|           > 127  :  a Hershey symbol number.
-      !|     for info about codes, http://www.astro.caltech.edu/~tjp/pgplot/hershey.html
-      !|     profile_mass_point_str
-      !|     text to show with the marker
-      !|     profile_mass_point_str_clr
-      !|     color index for the string
+      ! if ``show_TRho_Profile_mass_locs = .true.``, display mass location markers on TRho profile plot
+      ! ::
 
-      ! set all the entries
+    show_TRho_Profile_mass_locs = .false.
+
+      ! Setting Colors 
+      ! ~~~~~~~~~~~~~~
+
+      ! ``profile_mass_point_color_index`` and ``profile_mass_point_str_clr`` 
+      ! set the color of the mass location's symbol and corresponding string, respectively, 
+      ! with 1 = foreground color, 2 = Red, 3 = Green, 4 = Blue, etc.
+      ! The full range of available indicies is defined in Set_Colours in pgstar.support.f.
+      
+      ! Setting Symbols and Text
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! ``profile_mass_point_symbol`` sets the symbol to be drawn for a given marker.
+      ! A selection of code numbers used to define the mass point symbol can be found in the table below.
+      ! For more information about code numbers, http://www.astro.caltech.edu/~tjp/pgplot/hershey.html
+
+      ! =========   ==============================================================================================
+      ! -1, -2      A single dot (diameter = current line width).
+      ! -3 .. -31   A regular polygon with ABS(SYMBOL) edges (style set by current fill style).
+      ! 0 .. 31     Standard marker symbols
+      ! 32 .. 127   ASCII characters (in current font). e.g. to use letter F as a marker, let SYMBOL = ICHAR('F').
+      ! > 127       A Hershey symbol number
+      ! =========   ==============================================================================================
+
+      !``profile_mass_point_str`` sets the text displayed with the marker. 
+
+      ! Syntax
+      ! ~~~~~~
+
+      ! To set defaults for all entries: 
 
       ! ::
 
@@ -441,7 +460,7 @@
     profile_mass_point_str_clr = 1
     profile_mass_point_str_scale = 1.0
 
-      ! set defaults
+      ! To then set individual qualities of any given ``profile_mass_point_q(N)``:
 
       ! ::
 

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -304,8 +304,7 @@
 
     TRho_Profile_win_flag = .false.
 
-      ! Window Sizing
-      ! -------------
+      ! **Window Sizing**
 
       ! ::
 
@@ -318,8 +317,7 @@
     TRho_Profile_txt_scale = 1.0
     TRho_Profile_title = 'TRho_Profile'
 
-      ! Axis limits
-      ! -----------
+      ! **Axis limits**
 
       ! ::
 
@@ -337,8 +335,7 @@
     TRho_switch_to_Column_Depth = .false.
     TRho_switch_to_mass = .false.
 
-      ! Legend 
-      ! ------
+      ! **Legend**
 
       ! ::
 
@@ -357,8 +354,7 @@
     TRho_Profile_text_info_yfac = 0.6
     TRho_Profile_text_info_dyfac = -0.04
 
-      ! Decorators
-      ! ----------
+      ! **Decorators**
 
       ! If ``show_TRho_accretion_mesh_borders = .true.``, plots the borders of the mesh and newly accreted material in the appropriate xcoord
 
@@ -400,8 +396,7 @@
     TRho_Profile_use_decorator = .false.
 
 
-      ! TRho Profile file output
-      ! ------------------------
+      ! **file output**
 
       ! ::
 
@@ -420,16 +415,14 @@
 
     show_TRho_Profile_mass_locs = .false.
 
-      ! Setting Colors 
-      ! ~~~~~~~~~~~~~~
+      ! **Setting Colors**
 
       ! ``profile_mass_point_color_index`` and ``profile_mass_point_str_clr`` 
       ! set the color of the mass location's symbol and corresponding string, respectively, 
       ! with 1 = foreground color, 2 = Red, 3 = Green, 4 = Blue, etc.
       ! The full range of available indicies is defined in Set_Colours in pgstar.support.f.
       
-      ! Setting Symbols and Text
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~
+      ! **Setting Symbols and Text**
 
       ! ``profile_mass_point_symbol`` sets the symbol to be drawn for a given marker.
       ! A selection of code numbers used to define the mass point symbol can be found in the table below.
@@ -445,8 +438,7 @@
 
       !``profile_mass_point_str`` sets the text displayed with the marker. 
 
-      ! Syntax
-      ! ~~~~~~
+      ! **Syntax**
 
       ! To set defaults for all entries: 
 
@@ -493,25 +485,47 @@
 ! Abundance window
 ! ================
 
-      ! current model abundance profiles
+      ! Display current model abundance profiles
 
       ! ::
 
     Abundance_win_flag = .false.
 
+      ! **Window sizing**
+
       ! ::
 
     Abundance_win_width = 6
     Abundance_win_aspect_ratio = 0.75
-
-      ! ::
-
     Abundance_xleft = 0.15
     Abundance_xright = 0.85
     Abundance_ybot = 0.15
     Abundance_ytop = 0.85
     Abundance_txt_scale = 1.0
     Abundance_title = 'Abundance'
+
+      ! **Axis Limits and labels**
+
+      ! X-axis limits are set by ``Abundance_xmin`` and ``Abundance_xmax``. 
+      ! Y-axis limits are set by ``Abundance_log_mass_frac_min`` and ``Abundance_log_mass_frac_max``
+
+      ! ::
+
+    Abundance_xmin = -101d0
+    Abundance_xmax = -101d0
+    Abundance_log_mass_frac_min = 101
+    Abundance_log_mass_frac_max = 0.3
+    Abundance_xaxis_reversed = .false.
+    Abundance_xaxis_name = 'mass'
+
+      ! **Legend**
+      
+      ! ::
+
+    Abundance_legend_max_cnt = 16
+    Abundance_legend_txt_scale_factor = 0.8
+
+      ! **Isotope Selecton**
 
       ! ::
 
@@ -528,42 +542,21 @@
     num_abundance_line_labels = 5
     Abundance_line_txt_scale_factor = 0.8
 
-      ! ::
 
-    Abundance_legend_max_cnt = 16
-    Abundance_legend_txt_scale_factor = 0.8
-
-      ! ::
-
-    Abundance_xaxis_name = 'mass'
-    Abundance_xaxis_reversed = .false.
-
-      ! abundance xaxis limits -- to override system default selections
-
-      ! ::
-
-    Abundance_xmin = -101d0
-    Abundance_xmax = -101d0
-
-      ! abundance yaxis limits -- to override system default selections
-
-      ! ::
-
-    Abundance_log_mass_frac_min = 101
-    Abundance_log_mass_frac_max = 0.3
+      ! **Decorators**
 
       ! ::
 
     Abundance_show_photosphere_location = .false.
 
-      ! Enables calling a subroutine to add extra information to a plot
+      ! ''Abundance_use_decorator`` enables calling a subroutine to add extra information to a plot
       ! see ``$MESA_DIR/star/other/pgstar_decorator.f90``
 
       ! ::
 
     Abundance_use_decorator = .false.
 
-      ! file output
+      ! **file output**
 
       ! ::
 
@@ -577,7 +570,7 @@
 ! Power window
 ! ============
 
-      ! current model nuclear power profiles
+      ! Display current model nuclear power profiles
 
       ! ::
 


### PR DESCRIPTION
These changes:
- Fix some typos in the pgstar documentation
- Fix some formatting for proper display in browser
- Clarify language throughout, removing many references to "this", replacing them with the appropriate explicit variables 
- Reinforce a common documentation format for each window type in pgstar with consistent labelling and ordering

I did not alter any variable names, but did move some around in their respective sections for clarity. 
I mostly opted to use bolded text as opposed to level headings, as the heading levels were not quite clear when output to html and Sphinx seems to not like repeated heading text. 