### PR TITLE
added x_{type}_ctrl inlist controls to binary controls

### DIFF
--- a/binary/defaults/binary_controls.defaults
+++ b/binary/defaults/binary_controls.defaults
@@ -1494,3 +1494,16 @@
     use_other_CE_binary_evolve_step = .false.
     use_other_CE_binary_finish_step = .false.
     use_other_e2 = .false.
+
+
+! extra params as a convenience for developing new features
+! note: the parameter ``num_x_ctrls`` is defined in ``binary_def.f90``
+
+! ::
+
+    x_ctrl(1:binary_num_x_ctrls) = 0d0
+    x_integer_ctrl(1:binary_num_x_ctrls) = 0
+    x_logical_ctrl(1:binary_num_x_ctrls) = .false.
+    x_character_ctrl(1:binary_num_x_ctrls) = ''
+
+

--- a/binary/private/binary_ctrls_io.f90
+++ b/binary/private/binary_ctrls_io.f90
@@ -224,6 +224,10 @@
          use_other_CE_rlo_mdot, &
          use_other_CE_binary_evolve_step, &
          use_other_CE_binary_finish_step, &
+         x_ctrl, &
+         x_integer_ctrl, &
+         x_logical_ctrl, &
+         x_character_ctrl, &
 
          ! extra files
          read_extra_binary_controls_inlist, extra_binary_controls_inlist_name
@@ -530,6 +534,11 @@
          b% use_other_CE_rlo_mdot = use_other_CE_rlo_mdot
          b% use_other_CE_binary_evolve_step = use_other_CE_binary_evolve_step
          b% use_other_CE_binary_finish_step = use_other_CE_binary_finish_step
+
+         b% x_ctrl = x_ctrl
+         b% x_integer_ctrl = x_integer_ctrl
+         b% x_logical_ctrl = x_logical_ctrl
+         b% x_character_ctrl = x_character_ctrl
          
       end subroutine store_binary_controls
 
@@ -720,6 +729,11 @@
          use_other_CE_binary_evolve_step = b% use_other_CE_binary_evolve_step
          use_other_CE_binary_finish_step = b% use_other_CE_binary_finish_step
          
+         x_ctrl = b% x_ctrl
+         x_integer_ctrl = b% x_integer_ctrl
+         x_logical_ctrl = b% x_logical_ctrl
+         x_character_ctrl = b% x_character_ctrl
+
       end subroutine set_binary_controls_for_writing
       
       subroutine write_binary_controls(io,ierr)

--- a/binary/public/binary_controls.inc
+++ b/binary/public/binary_controls.inc
@@ -177,4 +177,9 @@ logical :: use_other_CE_binary_finish_step
 logical :: use_other_e2
 logical :: use_other_pgbinary_plots
 
+real(dp) :: x_ctrl(binary_num_x_ctrls)
+integer :: x_integer_ctrl(binary_num_x_ctrls)
+logical :: x_logical_ctrl(binary_num_x_ctrls)
+character (len=strlen) :: x_character_ctrl(binary_num_x_ctrls)
+
 ! end of controls

--- a/binary/public/binary_def.f90
+++ b/binary/public/binary_def.f90
@@ -37,6 +37,7 @@
 
       integer, parameter :: maxlen_binary_history_column_name = 80
       integer, parameter :: binary_num_xtra_vals = 30
+      integer, parameter :: binary_num_x_ctrls = 100
       
       ! time_step limit identifiers
       integer, parameter :: b_Tlim_comp = 1


### PR DESCRIPTION
This is a small quality of life change that adds ```x_{type}_ctrl``` inlist controls to the ```binary``` module mirroring those already present in the ```star_data``` module. This allows users to define system-specific controls in the ```binary_controls``` namelist instead of using the ```controls``` namelist specific to one of the stars. This is simply because sometimes it it would be preferable to put a special control in ```inlist_project``` rather than in ```inlist1``` when it applies to the whole binary system.

These controls can then be used in ```run_binary_extras.f90``` in a similar way to those in the star_data module:
```
   some_var = b% s1% x_ctrl(1)   ! star_data

   some_var = b% x_ctrl(1)       ! binary
```

The documentation in ```binary_controls.defaults``` has also been mirrored from that in ```controls.defaults```.