### PR TITLE
reimplement fixed atm options

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -90,6 +90,10 @@ starting models has been recalculated with a more stringent stopping condition,
 and now all pre-computed ZAMS models have a central hydrogen mass fraction very 
 near 0.697.
 
+The ``fixed_Teff``, ``fixed_Tsurf``, ``fixed_Psurf``,  and ``fixed_Psurf_and_Tsurf``
+atmosphere options have been reimplemented, although we caution users that their
+implementation might conflict with mlt_option = ``TDC``.
+
 Changes in r23.05.1
 ===================
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4173,7 +4173,8 @@
       ! ~~~~~~~~~~
 
       ! Controls how the surface temperature Tsurf and pressure Psurf are evaluated when
-      ! setting up outer boundary conditions
+      ! setting up outer boundary conditions. We caution that the use of ``'fixed_'`` atmosphere
+      ! options might conflict with mlt_option = ``TDC``.
 
       ! + ``'T_tau'``: 
       !   set Tsurf and Psurf by solving for the atmosphere structure given a T(tau) relation.
@@ -4217,6 +4218,8 @@
       ! + ``'fixed_Psurf_and_Tsurf'`` :
       ! get value of Psurf from control parameter ``atm_fixed_Psurf``.
       ! get value of Tsurf from control parameter ``atm_fixed_Tsurf``.
+      ! see the ``conductive_flame`` test_suite for an example of 
+      ! this boundary condition implemented via the ``other_surface_PT`` hook.
 
       ! ::
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4198,6 +4198,25 @@
       !   See also the ``atm_irradiated_opacity``, ``atm_irradiated_errtol``, ``atm_irradiated_T_eq``,
       !   ``atm_irradiated_T_eq``, ``atm_irradiated_kap_v``, ``atm_irradiated_kap_v_div_kap_th``,
       !   ``atm_irradiated_P_surf`` and ``atm_irradiated_max_tries`` controls.
+      !
+      ! + ``'fixed_Teff'`` : 
+      ! set Tsurf from Eddington T(tau) relation
+      !     for current surface tau and Teff = ``atm_fixed_Teff``.
+      ! set Psurf = Radiation_Pressure(Tsurf)
+      !
+      ! + ``'fixed_Tsurf'`` :
+      ! get value of Tsurf from control parameter ``atm_fixed_Tsurf``.
+      ! set Teff from Eddington T(tau) relation for given Tsurf and tau=2/3
+      ! set Psurf = Radiation_Pressure(Tsurf)
+      !      
+      ! + ``'fixed_Psurf'`` :
+      ! get value of Psurf from control parameter ``atm_fixed_Psurf``.
+      ! set Tsurf from L and R using ``L = 4*pi*R^2*boltz_sigma*T^4``.
+      ! set Teff using Eddington T(tau) relation for tau=2/3 and T=Tsurf.
+      !
+      ! + ``'fixed_Psurf_and_Tsurf'`` :
+      ! get value of Psurf from control parameter ``atm_fixed_Psurf``.
+      ! get value of Tsurf from control parameter ``atm_fixed_Tsurf``.
 
       ! ::
 

--- a/star/test_suite/conductive_flame/README.rst
+++ b/star/test_suite/conductive_flame/README.rst
@@ -29,7 +29,8 @@ controlled from the inlist.
 
 The inner boundary is at r = 0.  The outer boundary has a fixed
 temperature and a fixed pressure equal to the initial pressure of the
-material.  This is achieved via the ``use_other_surface_PT`` hook.
+material.  This is achieved via the ``use_other_surface_PT`` hook, but
+can also be done using the ``fixed_Psurf_and_Tsurf`` atmosphere option.
 
 After an initial transient, the entire flame structure, approximately
 isobaric, propagates into the upstream fuel with a unique speed and
@@ -55,5 +56,5 @@ routine ``flame_properties`` in the ``run_star_extras.f90``.
 .. |Schwab2020| replace:: `Schwab et al. (2020) <https://ui.adsabs.harvard.edu/abs/2020ApJ...891....5S/abstract>`__
 
 
-Last-Updated: 2021-06-21 (mesa b2364463) by Josiah Schwab
+Last-Updated: 2021-06-21 (mesa b2364463) by Josiah Schwab, + documentation 2024-01-22 EbF
 


### PR DESCRIPTION
A first pass at reimplementing The fixed surface options. See https://github.com/MESAHub/mesa/issues/583

I have tested it to be working locally for 'fixed_Tsurf' in the ppisn test case. 
Feel free to clean up any of it. Do we need a test case for this?
Should this be moved into atm_support.f90, or is it alright to live in hydro_vars.f90? 
