### PR TITLE
fix bug in photo derivative

### DIFF
--- a/net/private/net_approx21.f90
+++ b/net/private/net_approx21.f90
@@ -824,7 +824,7 @@
                               ratdum(irdgn) * zz &
                   + ratdum(irhegn)*dratdumdd(irhegp)*ratdum(irdgn)*zz &
                   + ratdum(irhegn)*ratdum(irhegp)*dratdumdd(irdgn)*zz &
-                  - ratdum(iralf1)*zz*denomdt
+                  - ratdum(iralf1)*zz*denomdd
 
 
          ratdum(iralf2)     = ratdum(irheng)*ratdum(irdpg)* &


### PR DESCRIPTION
 'denomdt' should be 'denomdd'. If the test_suite passes, this should be fine for a merge.

