### PR TITLE
Adds more options for approaching core-collapse

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -542,7 +542,7 @@
       !   Format originally defined for the GONG solar model project.  A
       !   definition was given in 2005 for the `CoRoT/ESTA project`_ and
       !   `GONG itself <https://phys.au.dk/~jcd/solar_models/file-format.pdf>`_.
-      !   MESA's implementation largely follows this subsequent 
+      !   MESA's implementation largely follows this subsequent
       !   `2015 definition <https://phys.au.dk/~jcd/ASTEC_results/file-format.pdf>`_.
 
       ! ``'OSC'``
@@ -673,7 +673,7 @@
       ! format_for_OSC_data
       ! ~~~~~~~~~~~~~~~~~~~
 
-      ! float format for ``'OSC'`` data format 
+      ! float format for ``'OSC'`` data format
 
       ! ::
 
@@ -1338,7 +1338,7 @@
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
       !     envelope_fraction_left = (star_mass - he_core_mass)/(initial_mass - he_core_mass)
-      
+
       ! Stop when ``envelope_fraction_left`` < this limit.
 
       ! ::
@@ -1350,7 +1350,7 @@
       ! ~~~~~~~~~~~~~~~~
 
       !     xmstar = mstar - M_center
-      
+
       ! stop when xmstar in grams is < this.  <= 0 means no limit.
 
       ! ::
@@ -1362,7 +1362,7 @@
       ! ~~~~~~~~~~~~~~~~
 
       !     xmstar = mstar - M_center
-      
+
       ! stop when xmstar in grams is > this.  <= 0 means no limit.
 
       ! ::
@@ -1916,8 +1916,8 @@
       ! ::
 
     stop_near_zams = .false.
-    
-    
+
+
       ! stop_at_phase_PreMS
       ! ~~~~~~~~~~~~~~~~~~~
       ! stop_at_phase_ZAMS
@@ -1948,7 +1948,7 @@
       ! if true, when phase of evolution reaches this point.
 
       ! ::
-    
+
     stop_at_phase_PreMS = .false.
     stop_at_phase_ZAMS = .false.
     stop_at_phase_IAMS = .false.
@@ -1962,7 +1962,7 @@
     stop_at_phase_O_Burn = .false.
     stop_at_phase_Si_Burn = .false.
     stop_at_phase_WDCS = .false.
-    
+
 
       ! Lnuc_div_L_upper_limit
       ! ~~~~~~~~~~~~~~~~~~~~~~
@@ -2368,7 +2368,7 @@
       ! ::
 
     mlt_make_surface_no_mixing = .false.
-    
+
 
 
       ! T_mix_limit
@@ -3108,7 +3108,7 @@
     RSP_nz_outer = 40
     RSP_T_anchor = 11d3
     RSP_T_inner = 2d6
-    RSP_testing = .false. 
+    RSP_testing = .false.
 
       ! ::
 
@@ -3355,7 +3355,7 @@
       ! Mixing coefficients are multiplied by this factor.
       ! The ``mix_factor`` is applied in subroutine ``get_convection_sigmas`` in ``star/private/mix_info.f90`` --
       ! the lagrangian diffusion coefficient sigma(k) at cell boundary k is set to
-      ! ``mix_factor*D*(4*pi*r(k)^2*rho_face(k))^2``. 
+      ! ``mix_factor*D*(4*pi*r(k)^2*rho_face(k))^2``.
       ! Note that the value of D is not changed -- it is just used as a term in calculating sigma.
 
       ! ::
@@ -4166,13 +4166,13 @@
       ! setting up outer boundary conditions. We caution that the use of ``'fixed_'`` atmosphere
       ! options might conflict with mlt_option = ``TDC``.
 
-      ! + ``'T_tau'``: 
+      ! + ``'T_tau'``:
       !   set Tsurf and Psurf by solving for the atmosphere structure given a T(tau) relation.
       !   The choice of relation is set by the ``atm_T_tau_relation`` control. See also
       !   the ``atm_T_tau_opacity``, ``atm_T_tau_errtol``, ``atm_T_tau_max_tries`` and
       !   ``atm_T_tau_max_steps`` controls.
       !
-      ! + ``'table'``: 
+      ! + ``'table'``:
       !   set Tsurf and Psurf by interpolating in pre-calculated tables based on model
       !   atmospheres. The choice of table is set by the ``atm_table`` control.
       !   Requires tau_factor = 1, as surface of the model must always attach at the base
@@ -4183,14 +4183,14 @@
       !   Teff and log_g. This is consistent with the assumptions used for table construction:
       !   geometrically thin atmospheres with constant flux.
       !
-      ! + ``'irradiated_grey'``: 
+      ! + ``'irradiated_grey'``:
       !   set Tsurf by solving for the atmosphere structure given the irradiated-grey
       !   T(tau) relation of Guillot, T, and Havel, M., A&A 527, A20 (2011).
       !   See also the ``atm_irradiated_opacity``, ``atm_irradiated_errtol``, ``atm_irradiated_T_eq``,
       !   ``atm_irradiated_T_eq``, ``atm_irradiated_kap_v``, ``atm_irradiated_kap_v_div_kap_th``,
       !   ``atm_irradiated_P_surf`` and ``atm_irradiated_max_tries`` controls.
       !
-      ! + ``'fixed_Teff'`` : 
+      ! + ``'fixed_Teff'`` :
       ! set Tsurf from Eddington T(tau) relation
       !     for current surface tau and Teff = ``atm_fixed_Teff``.
       ! set Psurf = Radiation_Pressure(Tsurf)
@@ -4199,7 +4199,7 @@
       ! get value of Tsurf from control parameter ``atm_fixed_Tsurf``.
       ! set Teff from Eddington T(tau) relation for given Tsurf and tau=2/3
       ! set Psurf = Radiation_Pressure(Tsurf)
-      !      
+      !
       ! + ``'fixed_Psurf'`` :
       ! get value of Psurf from control parameter ``atm_fixed_Psurf``.
       ! set Tsurf from L and R using ``L = 4*pi*R^2*boltz_sigma*T^4``.
@@ -4208,7 +4208,7 @@
       ! + ``'fixed_Psurf_and_Tsurf'`` :
       ! get value of Psurf from control parameter ``atm_fixed_Psurf``.
       ! get value of Tsurf from control parameter ``atm_fixed_Tsurf``.
-      ! see the ``conductive_flame`` test_suite for an example of 
+      ! see the ``conductive_flame`` test_suite for an example of
       ! this boundary condition implemented via the ``other_surface_PT`` hook.
 
       ! ::
@@ -4319,11 +4319,11 @@
       ! + ``'fixed'``:
       !   use a uniform opacity, fixed to the opacity of the outermost cell of the
       !   interior model
-      
+
       ! + ``'iterated'``:
       !   use a uniform opacity, iterated to be consistent with the final Tsurf and
       !   Psurf at the base of the atmosphere.
-      
+
       ! + ``'varying'``:
       !   use a varying opacity consistent with the local T and P throughout the
       !   atmosphere. Involves numerical integration of the hydrostatic equilibrium
@@ -4383,7 +4383,7 @@
       !   model atmospheres (Allard et al. 2001) for Teff < 3000 K.
       !   where no published results are available, the table has been
       !   filled in using integration of the Eddington T(tau) relation
-      
+
       ! + ``'photosphere'``:
       !   use model atmosphere tables for photosphere; range of Z's,
       !   as described in MESA Paper I (Paxton et al. 2011), Sec. 5.3.
@@ -4395,7 +4395,7 @@
       !   and the models by Castelli & Kurucz (2003).  where
       !   neither is available, an entry is generated by
       !   integrating the Eddington T(tau) relation
-      
+
       ! + ``'WD_tau_25'``:
       !   hydrogen atmosphere tables for cool white dwarfs
       !   giving Pgas and T at log10(tau) = 1.4 (tau = 25.11886)
@@ -4404,7 +4404,7 @@
       !   R.D. Rohrmann, L.G. Althaus, and S.O. Kepler,
       !   Lyman α wing absorption in cool white dwarf stars,
       !   Mon. Not. R. Astron. Soc. 411, 781–791 (2011)
-      
+
       ! + ``'DB_WD_tau_25'``:
       !   helium dominated (log(H/He)=-5.0) atmosphere tables for DB
       !   white dwarfs, provided by Odette Toloza and Detlev Koester.
@@ -4627,7 +4627,7 @@
 
       ! If ``.true.``, modify the radiative gradient so that the
       ! temperature profile of the optically thin layers follow the
-      ! T(τ) relation chosen by ``atm_T_tau_relation``.  
+      ! T(τ) relation chosen by ``atm_T_tau_relation``.
       ! ::
 
     use_T_tau_gradr_factor = .false.
@@ -4650,7 +4650,7 @@
 
       ! mdot_omega_power
       ! ~~~~~~~~~~~~~~~~
-      
+
       ! Enhanced mass loss due to rotation
       ! as in Heger, Langer, and Woosley, 2000, ApJ, 528:368-396.
 
@@ -7294,12 +7294,12 @@
       ! ~~~~~~~~~~~~~~~~~~~~~~~
 
       ! Choice of appropriate option for the WD core mixture:
-      
+
       ! + ``'CO'`` : carbon-oxygen phase separation using the two-component
       !   phase diagram of `Blouin & Daligault (2021a) <https://ui.adsabs.harvard.edu/abs/2021PhRvE.103d3204B/abstract>`_.
       ! + ``'ONe'`` : oxygen-neon phase separation using the two-component
       !   phase diagram of `Blouin & Daligault (2021b) <https://ui.adsabs.harvard.edu/abs/2021ApJ...919...87B/abstract>`_.
-      
+
       ! ::
 
     phase_separation_option = 'CO'
@@ -7330,7 +7330,7 @@
       ! ::
 
     phase_separation_mixing_use_brunt = .true.
-    
+
 
 ! eos controls
 ! ============
@@ -7485,7 +7485,7 @@
       ! or use the faster method by allowing for a small tolerance on the mixture used for the computations of these variables (``'mombarg'``).
 
       ! ::
-      
+
       op_mono_method = 'hu'
 
       ! emesh_data_for_op_mono_path
@@ -7501,7 +7501,7 @@
       ! and then unpack it in place with ``unxz -v OP_mono_master_grid_MESA_emesh.txt.xz``
 
       ! ::
-      
+
     emesh_data_for_op_mono_path = ''      ! '' defaults to $MESA_OP_MONO_MASTER_GRID
 
 
@@ -8185,9 +8185,9 @@
       ! ::
 
     use_dPrad_dm_form_of_T_gradient_eqn = .false.
-    use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = .false.    
-    
-    
+    use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = .false.
+
+
       ! drag_coefficient
       ! ~~~~~~~~~~~~~~~~
       ! min_q_for_drag
@@ -8204,11 +8204,20 @@
       ! following surface boundary conditions:
       ! ``use_momentum_outer_BC``, ``use_zero_Pgas_outer_BC``, or ``use_fixed_Psurf_outer_BC``
 
+      ! If use_drag_energy = .true. adds the work done by the drag force
+      ! to the energy balance. Since the drag force is proportional to
+      ! the velocity which is subject to numerical spikes and
+      ! oscillations, you may not want to use the work done by it in the
+      ! model If set to .false. but drag_coefficient is nonzero, the
+      ! drag force will be applied in the momentum equation (as a
+      ! numerical trick to damp spurious velocities) but not in the
+      ! energy equation.
+
       ! ::
 
+    use_drag_energy = .true.
     drag_coefficient = 0d0
     min_q_for_drag = 0d0
-    
 
       ! for hydro comparison tests (e.g., Sedov)
 
@@ -8278,7 +8287,7 @@
     RTI_m_full_boost = 4d0
     RTI_m_no_boost = 5d0
 
-    
+
       ! retry_for_v_above_clight
       ! ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -8289,7 +8298,7 @@
       ! ::
 
     retry_for_v_above_clight = .true.
-    
+
 
 ! solver controls
 ! ===============
@@ -8511,7 +8520,7 @@
       ! ~~~~~~~~~~~~~~~~~~~~~~~~
 
       ! ::
-    
+
     max_X_for_conv_timescale = 1d0
     min_X_for_conv_timescale = 0d0
     max_q_for_conv_timescale = 1d0
@@ -8660,7 +8669,7 @@
 
       ! do_normalize_dqs_as_part_of_set_qs
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      
+
       ! normalize_dqs destroys bit-for-bit read as inverse of write for models.
       ! ok for create pre ms etc., but not for read model
       ! create_pre_ms calls normalize_dqs even if this flag is false.
@@ -8668,12 +8677,12 @@
       ! ::
 
    do_normalize_dqs_as_part_of_set_qs = .false.
-   
+
 
       ! use_DGESVX_in_bcyclic
       ! use_equilibration_in_DGESVX
       ! report_min_rcond_from_DGESXV
-      
+
       ! FOR DEBUGGING ONLY.   NOT FOR GENERAL USE.
 
       ! ::
@@ -9161,7 +9170,7 @@
       !          'Lnuc_cat'             delta_lgL_nuc_cat_limit
       !          'Lnuc_H'               delta_lgL_H_limit
       !          'Lnuc_He'              delta_lgL_He_limit
-      !          'lgL_power_phot'       delta_lgL_power_photo_limit 
+      !          'lgL_power_phot'       delta_lgL_power_photo_limit
       !          'Lnuc_z'               delta_lgL_z_limit
       !          'bad_X_sum'            (solver found bad mass sum)
       !          'dL/L'                 dL_div_L_limit
@@ -9223,12 +9232,12 @@
       ! time_delta_coeff - smaller forces smaller timesteps giving better time resolution.
       ! multiplier for all real number timestep limits and hard limits.
       ! does not apply to integer valued limits such as
-      
+
       ! + solver_iters_timestep_limit
       ! + burn_steps_limit
       ! + diffusion_steps_limit
       ! + diffusion_iters_limit
-      
+
       ! does not apply to varcontrol_target.
       ! analogous to mesh_delta_coeff for better spatial resolution.
 
@@ -10299,7 +10308,7 @@
     min_lgT_for_lgL_power_photo_limit = 9d0
     lgL_power_photo_burn_min = 10d0
     lgL_power_photo_drop_factor = 10
-    
+
 
       ! limits based on changes at photosphere
 
@@ -10396,7 +10405,7 @@
       ! ``abs_du_div_cs`` > ``min_abs_du_div_cs_for_dt_div_min_dr_div_cs_limit`` and
       ! and
       ! ``abs_u_div_cs`` > ``min_abs_u_div_cs_for_dt_div_min_dr_div_cs_limit``
-      ! 
+      !
       ! allow focus on regions near shock face.
 
       ! ::
@@ -10992,9 +11001,9 @@
       ! ~~~~~~~~~~~~~~~~~~
       ! delta_XSi_drop_only
       ! ~~~~~~~~~~~~~~~~~~~
-         
 
-      ! If true, then only limit drops in abundance. 
+
+      ! If true, then only limit drops in abundance.
 
       ! ::
 
@@ -11075,7 +11084,7 @@
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ! hard_limit_for_rel_error_in_energy_conservation
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
+
       ! ::
 
       !     rel_error_in_energy_conservation = abs(error_in_energy_conservation/total_energy)
@@ -11206,7 +11215,7 @@
     solver_test_partials_write_eos_call_info = .false.
     solver_epsder_struct = 1d-5
     solver_epsder_chem = 1d-5
-    
+
     energy_conservation_dump_model_number = -1
 
 
@@ -11443,7 +11452,7 @@
     use_other_set_pgstar_controls = .false.
     use_other_accreting_state = .false.
     use_other_eval_i_rot = .false.
-    
+
       ! ::
 
     use_other_export_pulse_data = .false.

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -7884,6 +7884,17 @@
 
     velocity_q_upper_bound = 1d99
 
+      ! velocity_tau_lower_bound
+      ! ~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Local override for global ``v_flag``.
+      ! If local tau < this bound, local ``v_flag`` is set false,
+      ! else local ``v_flag`` is set to global ``v_flag``.
+      ! this lets you force v = 0 in outer envelope.
+
+      ! ::
+
+    velocity_tau_lower_bound = -1d99
 
       ! velocity_logT_lower_bound
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -350,7 +350,7 @@
     include_P_in_velocity_time_centering, include_L_in_velocity_time_centering, &
     P_theta_for_velocity_time_centering, L_theta_for_velocity_time_centering, &
     steps_before_use_TDC, use_P_d_1_div_rho_form_of_work_when_time_centering_velocity, compare_TDC_to_MLT, &
-    velocity_logT_lower_bound, max_dt_yrs_for_velocity_logT_lower_bound, velocity_q_upper_bound, &
+    velocity_logT_lower_bound, max_dt_yrs_for_velocity_logT_lower_bound, velocity_tau_lower_bound, velocity_q_upper_bound, &
     use_drag_energy, drag_coefficient, min_q_for_drag, &
     retry_for_v_above_clight, &
 
@@ -1866,6 +1866,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  s% velocity_logT_lower_bound = velocity_logT_lower_bound
  s% max_dt_yrs_for_velocity_logT_lower_bound = max_dt_yrs_for_velocity_logT_lower_bound
+ s% velocity_tau_lower_bound = velocity_tau_lower_bound
  s% velocity_q_upper_bound = velocity_q_upper_bound
 
  s% retry_for_v_above_clight = retry_for_v_above_clight
@@ -3537,6 +3538,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  velocity_logT_lower_bound = s% velocity_logT_lower_bound
  max_dt_yrs_for_velocity_logT_lower_bound = s% max_dt_yrs_for_velocity_logT_lower_bound
+ velocity_tau_lower_bound = s% velocity_tau_lower_bound
  velocity_q_upper_bound = s% velocity_q_upper_bound
 
  retry_for_v_above_clight = s% retry_for_v_above_clight

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -39,14 +39,14 @@
  character (len=strlen) :: controls_namelist_name
 
  namelist /controls/ &
- 
+
     ! where to start
     initial_mass, initial_z, initial_y, initial_he3, &
-    
+
     ! definition of core boundaries
     he_core_boundary_h1_fraction, co_core_boundary_he4_fraction, one_core_boundary_he4_c12_fraction, &
     fe_core_boundary_si28_fraction, neutron_rich_core_boundary_Ye_max, min_boundary_fraction, &
-    
+
     ! when to stop
     max_model_number, relax_max_number_retries, max_number_retries, max_age, max_age_in_seconds, max_age_in_days, &
     num_adjusted_dt_steps_before_max_age, dt_years_for_steps_before_max_age, max_abs_rel_run_E_err, &
@@ -83,14 +83,14 @@
     log_g_upper_limit, log_g_lower_limit, power_nuc_burn_upper_limit, power_h_burn_upper_limit, &
     power_he_burn_upper_limit, power_z_burn_upper_limit, power_nuc_burn_lower_limit, &
     power_h_burn_lower_limit, power_he_burn_lower_limit, power_z_burn_lower_limit, &
-    
+
     ! max timesteps
     max_timestep, max_years_for_timestep, &
     hi_T_max_years_for_timestep, max_timestep_hi_T_limit, &
-    
+
     ! output of "snapshots" for restarts
     photo_interval, photo_digits, photo_directory, &
-    
+
     ! output of logs and profiles
     do_history_file, history_interval, write_header_frequency, terminal_interval, &
     terminal_show_age_units, terminal_show_timestep_units, terminal_show_log_dt, terminal_show_log_age, &
@@ -112,16 +112,16 @@
     min_q_for_inner_mach1_location, max_q_for_outer_mach1_location, &
     conv_core_gap_dq_limit, &
     alpha_TDC_DAMP, alpha_TDC_DAMPR, alpha_TDC_PtdVdt, &
-    
+
     ! burn zone eps definitions for use in logs and profiles
     burn_min1, burn_min2, &
     max_conv_vel_div_csound_maxq, width_for_limit_conv_vel, max_q_for_limit_conv_vel, &
     max_mass_in_gm_for_limit_conv_vel, max_r_in_cm_for_limit_conv_vel, &
-    
+
     ! for reported surface/center abundances
     surface_avg_abundance_dq, center_avg_value_dq, &
-    
-    ! mixing parameters 
+
+    ! mixing parameters
     min_convective_gap, min_thermohaline_gap, min_semiconvection_gap, min_thermohaline_dropout, &
     max_dropout_gradL_sub_grada, remove_embedded_semiconvection, recalc_mix_info_after_evolve, remove_mixing_glitches, &
     okay_to_remove_mixing_singleton, prune_bad_cz_min_Hp_height, prune_bad_cz_min_log_eps_nuc, &
@@ -175,7 +175,7 @@
     RSP_relax_initial_model, RSP_trace_RSP_build_model, &
    RSP_GREKM_avg_abs_limit, RSP_GREKM_avg_abs_frac_new, RSP_kap_density_factor, RSP_map_columns_filename, &
    RSP_relax_alfap_before_alfat, RSP_max_outer_dm_tries, RSP_max_inner_scale_tries, RSP_T_anchor_tolerance, &
-    ! mass gain or loss  
+    ! mass gain or loss
     mass_change, mass_change_full_on_dt, mass_change_full_off_dt, trace_dt_control_mass_change, &
     min_wind, max_wind, use_accreted_material_j, accreted_material_j, D_omega_mixing_rate, &
     D_omega_mixing_across_convection_boundary, max_q_for_D_omega_zero_in_convection_region, nu_omega_mixing_rate, &
@@ -192,12 +192,12 @@
     Nieuwenhuijzen_scaling_factor, Vink_scaling_factor, &
     Dutch_scaling_factor, Bjorklund_scaling_factor, Dutch_wind_lowT_scheme, wind_He_layer_limit, &
     wind_H_envelope_limit, wind_H_He_envelope_limit, hot_wind_full_on_T, cool_wind_full_on_T, &
-    
+
     ! composition of added mass
     accrete_same_as_surface, &
     accrete_given_mass_fractions, num_accretion_species, accretion_species_id, accretion_species_xa, &
     accretion_h1, accretion_h2, accretion_he3, accretion_he4, accretion_zfracs, accretion_dump_missing_metals_into_heaviest, &
-    
+
     ! special list of z fractions
     z_fraction_li, z_fraction_be, z_fraction_b, z_fraction_c, z_fraction_n,&
     z_fraction_o, z_fraction_f, z_fraction_ne, z_fraction_na, z_fraction_mg, z_fraction_al, &
@@ -205,16 +205,16 @@
     z_fraction_ca, z_fraction_sc, z_fraction_ti, z_fraction_v, z_fraction_cr, z_fraction_mn, &
     z_fraction_fe, z_fraction_co, z_fraction_ni, z_fraction_cu, z_fraction_zn, &
     lgT_lo_for_set_new_abundances, lgT_hi_for_set_new_abundances, &
-    
+
     ! automatic stops for mass loss/gain
     max_star_mass_for_gain, min_star_mass_for_loss, max_T_center_for_any_mass_loss, max_T_center_for_full_mass_loss, &
-    
+
     ! extra power source
     extra_power_source, &
-    
+
     ! relaxation parameters
     relax_dlnZ, relax_dY, &
-    
+
     ! mesh adjustment
     show_mesh_changes, okay_to_remesh, restore_mesh_on_retry, num_steps_to_hold_mesh_after_retry, &
     max_rel_delta_IE_for_mesh_total_energy_balance, &
@@ -286,7 +286,7 @@
     min_D_mix, min_center_Ye_for_min_D_mix, &
     smooth_outer_xa_big, smooth_outer_xa_small, nonlocal_NiCo_kap_gamma, nonlocal_NiCo_decay_heat, &
     dtau_gamma_NiCo_decay_heat, max_logT_for_net, reaction_neuQs_factor, &
-    
+
     ! element diffusion parameters
     diffusion_use_iben_macdonald, diffusion_use_paquette, diffusion_use_caplan, diffusion_use_cgs_solver, &
     diffusion_use_full_net, do_WD_sedimentation_heating, min_xa_for_WD_sedimentation_heating, &
@@ -318,7 +318,7 @@
     do_phase_separation_heating, &
     phase_separation_mixing_use_brunt, &
     phase_separation_no_diffusion, &
-    
+
     ! eos controls
     fix_d_eos_dxa_partials, &
 
@@ -326,13 +326,13 @@
     use_simple_es_for_kap, use_starting_composition_for_kap, &
     min_kap_for_dPrad_dm_eqn, low_logT_op_mono_full_off, low_logT_op_mono_full_on, high_logT_op_mono_full_off, &
     high_logT_op_mono_full_on, op_mono_min_X_to_include, use_op_mono_alt_get_kap, &
-    
-    
+
+
     include_L_in_correction_limits, include_v_in_correction_limits, include_u_in_correction_limits, include_w_in_correction_limits, &
-    
+
     ! asteroseismology controls
     get_delta_nu_from_scaled_solar, nu_max_sun, delta_nu_sun, astero_Teff_sun, delta_Pg_mode_freq, &
-    
+
     ! hydro parameters
     energy_eqn_option, &
     opacity_factor, opacity_max, min_logT_for_opacity_factor_off, min_logT_for_opacity_factor_on, &
@@ -351,7 +351,7 @@
     P_theta_for_velocity_time_centering, L_theta_for_velocity_time_centering, &
     steps_before_use_TDC, use_P_d_1_div_rho_form_of_work_when_time_centering_velocity, compare_TDC_to_MLT, &
     velocity_logT_lower_bound, max_dt_yrs_for_velocity_logT_lower_bound, velocity_q_upper_bound, &
-    drag_coefficient, min_q_for_drag, &
+    use_drag_energy, drag_coefficient, min_q_for_drag, &
     retry_for_v_above_clight, &
 
     ! hydro solver
@@ -410,8 +410,8 @@
     RSP2_T_anchor, RSP2_dq_1_factor, RSP2_nz, RSP2_nz_outer, RSP2_nz_div_IBOTOM, RSP2_report_adjust_w, &
     RSP2_w_min_for_damping, RSP2_source_seed, RSP2_w_fix_if_neg, max_X_for_conv_timescale, min_X_for_conv_timescale, &
     max_q_for_conv_timescale, min_q_for_conv_timescale, max_q_for_QHSE_timescale, min_q_for_QHSE_timescale, &
-    
-    
+
+
     ! timestep
     time_delta_coeff, min_timestep_factor, max_timestep_factor, timestep_factor_for_retries, retry_hold, &
     neg_mass_fraction_hold, timestep_dt_factor, use_dt_low_pass_controller, &
@@ -451,7 +451,7 @@
     delta_dX_div_X_cntr_min, delta_dX_div_X_cntr_max, delta_dX_div_X_cntr_limit, delta_dX_div_X_cntr_hard_limit, &
     delta_dX_div_X_drop_only, delta_lg_XH_drop_only, &
     delta_lg_XHe_drop_only, delta_lg_XC_drop_only, delta_lg_XNe_drop_only, delta_lg_XO_drop_only, delta_lg_XSi_drop_only, &
-    delta_XH_drop_only, delta_XHe_drop_only, delta_XC_drop_only, delta_XNe_drop_only, delta_XO_drop_only, delta_XSi_drop_only, &    
+    delta_XH_drop_only, delta_XHe_drop_only, delta_XC_drop_only, delta_XNe_drop_only, delta_XO_drop_only, delta_XSi_drop_only, &
     delta_lg_XH_cntr_min, delta_lg_XH_cntr_max, delta_lg_XH_cntr_limit, delta_lg_XH_cntr_hard_limit, &
     delta_lg_XHe_cntr_min, delta_lg_XHe_cntr_max, delta_lg_XHe_cntr_limit, delta_lg_XHe_cntr_hard_limit, &
     delta_lg_XC_cntr_min, delta_lg_XC_cntr_max, delta_lg_XC_cntr_limit, delta_lg_XC_cntr_hard_limit, &
@@ -486,28 +486,28 @@
 
     use_compression_outer_BC, use_momentum_outer_BC, Tsurf_factor, use_zero_Pgas_outer_BC, &
     fixed_Psurf, use_fixed_Psurf_outer_BC, fixed_vsurf, use_fixed_vsurf_outer_BC, &
-    
+
     atm_build_tau_outer, atm_build_dlogtau, atm_build_errtol, &
 
     use_T_tau_gradr_factor, &
-    
+
     ! extra heat near surface to model irradiation
     irradiation_flux, column_depth_for_irradiation, &
-    
+
     ! uniform extra heat
     inject_uniform_extra_heat, min_q_for_uniform_extra_heat, max_q_for_uniform_extra_heat, &
     inject_extra_ergs_sec, base_of_inject_extra_ergs_sec, total_mass_for_inject_extra_ergs_sec, &
     start_time_for_inject_extra_ergs_sec, duration_for_inject_extra_ergs_sec, &
     inject_until_reach_model_with_total_energy, &
-    
+
     ! mass gain or loss
     no_wind_if_no_rotation, max_logT_for_k_below_const_q, &
     max_q_for_k_below_const_q, min_q_for_k_below_const_q, max_logT_for_k_const_mass, &
     min_q_for_k_const_mass, max_q_for_k_const_mass, &
-    
+
     ! info for debugging
     stop_for_bad_nums, report_ierr, report_bad_negative_xa, diffusion_dump_call_number, &
-     
+
     ! controls for the evolve routine
     trace_evolve, &
 
@@ -524,7 +524,7 @@
     use_other_before_struct_burn_mix, use_other_astero_freq_corr, use_other_timestep_limit, use_other_set_pgstar_controls, &
     use_other_screening, use_other_rate_get, use_other_net_derivs, use_other_split_burn, use_other_close_gaps, &
     x_ctrl, x_integer_ctrl, x_logical_ctrl, x_character_ctrl, &
-    
+
     ! extra files
     read_extra_controls_inlist, extra_controls_inlist_name, &
     save_controls_namelist, controls_namelist_name
@@ -536,10 +536,10 @@
  subroutine write_controls(s, fname, ierr)
     type (star_info), pointer :: s
  character (len=*), intent(in) :: fname
- integer, intent(out) :: ierr 
+ integer, intent(out) :: ierr
  integer :: iounit
  character (len=256) :: filename
- 
+
  ierr = 0
  filename = fname
 
@@ -551,7 +551,7 @@
     write(*,*) 'failed to open ' // trim(filename)
     return
  endif
- 
+
  call set_controls_for_writing(s, ierr)
  if (ierr /= 0) then
     close(iounit)
@@ -559,9 +559,9 @@
  end if
 
  write(iounit, nml=controls, iostat=ierr)
- 
+
  write(*,*) 'write controls namelist values to "' // trim(filename)//'"'
-    
+
  close(iounit)
 
  end subroutine write_controls
@@ -679,7 +679,7 @@
     read_extra_controls_inlist(i) = .false.
     extra(i) = extra_controls_inlist_name(i)
     extra_controls_inlist_name(i) = 'undefined'
-   
+
     if (read_extra(i)) then
        write(*,*) 'read ' // trim(extra(i))
        call read_controls_file(s, extra(i), level+1, ierr)
@@ -689,7 +689,7 @@
 
 
  end subroutine read_controls_file
- 
+
 
  subroutine set_default_controls
 
@@ -865,12 +865,12 @@
  s% star_mass_min_limit = star_mass_min_limit
  s% ejecta_mass_max_limit = ejecta_mass_max_limit
  s% remnant_mass_min_limit = remnant_mass_min_limit
- 
+
  s% star_species_mass_min_limit = star_species_mass_min_limit
  s% star_species_mass_min_limit_iso = star_species_mass_min_limit_iso
  s% star_species_mass_max_limit = star_species_mass_max_limit
  s% star_species_mass_max_limit_iso = star_species_mass_max_limit_iso
- 
+
  s% xmstar_min_limit = xmstar_min_limit
  s% xmstar_max_limit = xmstar_max_limit
  s% envelope_mass_limit = envelope_mass_limit
@@ -990,7 +990,7 @@
  s% min_tau_for_max_abs_v_location = min_tau_for_max_abs_v_location
  s% min_q_for_inner_mach1_location = min_q_for_inner_mach1_location
  s% max_q_for_outer_mach1_location = max_q_for_outer_mach1_location
- 
+
  s% conv_core_gap_dq_limit = conv_core_gap_dq_limit
 
  ! burn zone eps definitions for use in logs and profiles
@@ -1056,7 +1056,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% superad_reduction_gamma_inv_scale = superad_reduction_gamma_inv_scale
  s% superad_reduction_diff_grads_limit = superad_reduction_diff_grads_limit
  s% superad_reduction_limit = superad_reduction_limit
- 
+
  s% max_logT_for_mlt = max_logT_for_mlt
  s% mlt_make_surface_no_mixing = mlt_make_surface_no_mixing
  s% do_normalize_dqs_as_part_of_set_qs = do_normalize_dqs_as_part_of_set_qs
@@ -1081,7 +1081,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% burn_h_mix_region_logT = burn_h_mix_region_logT
  s% max_Y_for_burn_z_mix_region = max_Y_for_burn_z_mix_region
  s% max_X_for_burn_he_mix_region = max_X_for_burn_he_mix_region
- 
+
  s% limit_overshoot_Hp_using_size_of_convection_zone = limit_overshoot_Hp_using_size_of_convection_zone
 
  s% predictive_mix = predictive_mix
@@ -1333,7 +1333,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% wind_boost_full_on_L_div_Ledd = wind_boost_full_on_L_div_Ledd
  s% super_eddington_wind_max_boost = super_eddington_wind_max_boost
  s% trace_super_eddington_wind_boost = trace_super_eddington_wind_boost
- 
+
  s% max_tries_for_implicit_wind = max_tries_for_implicit_wind
  s% iwind_tolerance = iwind_tolerance
  s% iwind_lambda = iwind_lambda
@@ -1525,7 +1525,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% mesh_dlog_pnhe4_dlogP_extra = mesh_dlog_pnhe4_dlogP_extra
  s% mesh_dlog_photo_dlogP_extra = mesh_dlog_photo_dlogP_extra
  s% mesh_dlog_other_dlogP_extra = mesh_dlog_other_dlogP_extra
- 
+
  s% mesh_delta_coeff_factor_smooth_iters = mesh_delta_coeff_factor_smooth_iters
 
  s% T_function1_weight = T_function1_weight
@@ -1557,7 +1557,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% xa_function_weight = xa_function_weight
  s% xa_function_param = xa_function_param
  s% xa_mesh_delta_coeff = xa_mesh_delta_coeff
- 
+
  s% use_split_merge_amr = use_split_merge_amr
  s% split_merge_amr_nz_baseline = split_merge_amr_nz_baseline
  s% split_merge_amr_nz_r_core = split_merge_amr_nz_r_core
@@ -1796,7 +1796,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% high_logT_op_mono_full_on = high_logT_op_mono_full_on
  s% op_mono_min_X_to_include = op_mono_min_X_to_include
  s% use_op_mono_alt_get_kap = use_op_mono_alt_get_kap
-  
+
  s% include_L_in_correction_limits = include_L_in_correction_limits
  s% include_v_in_correction_limits = include_v_in_correction_limits
  s% include_u_in_correction_limits = include_u_in_correction_limits
@@ -1856,10 +1856,11 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% RTI_energy_floor = RTI_energy_floor
  s% RTI_D_mix_floor = RTI_D_mix_floor
  s% RTI_min_m_for_D_mix_floor = RTI_min_m_for_D_mix_floor
- s% RTI_log_max_boost = RTI_log_max_boost 
+ s% RTI_log_max_boost = RTI_log_max_boost
  s% RTI_m_full_boost = RTI_m_full_boost
  s% RTI_m_no_boost = RTI_m_no_boost
 
+ s% use_drag_energy = use_drag_energy
  s% drag_coefficient = drag_coefficient
  s% min_q_for_drag = min_q_for_drag
 
@@ -1882,7 +1883,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% tol_correction_extreme_T_limit = tol_correction_extreme_T_limit
  s% tol_correction_norm_extreme_T = tol_correction_norm_extreme_T
  s% tol_max_correction_extreme_T = tol_max_correction_extreme_T
- 
+
  s% tol_bad_max_correction = tol_bad_max_correction
  s% bad_max_correction_series_limit = bad_max_correction_series_limit
 
@@ -1894,7 +1895,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% tol_max_residual3 = tol_max_residual3
  s% warning_limit_for_max_residual = warning_limit_for_max_residual
  s% trace_solver_damping = trace_solver_damping
- 
+
  s% relax_use_gold_tolerances = relax_use_gold_tolerances
  s% relax_tol_correction_norm = relax_tol_correction_norm
  s% relax_tol_max_correction = relax_tol_max_correction
@@ -1908,9 +1909,9 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% relax_tol_residual_norm3 = relax_tol_residual_norm3
  s% relax_tol_max_residual3 = relax_tol_max_residual3
  s% relax_maxT_for_gold_tolerances = relax_maxT_for_gold_tolerances
- 
+
  s% use_gold_tolerances = use_gold_tolerances
- s% gold_solver_iters_timestep_limit = gold_solver_iters_timestep_limit 
+ s% gold_solver_iters_timestep_limit = gold_solver_iters_timestep_limit
  s% maxT_for_gold_tolerances = maxT_for_gold_tolerances
  s% gold_tol_residual_norm1 = gold_tol_residual_norm1
  s% gold_tol_max_residual1 = gold_tol_max_residual1
@@ -1921,9 +1922,9 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% gold_tol_residual_norm3 = gold_tol_residual_norm3
  s% gold_tol_max_residual3 = gold_tol_max_residual3
  s% steps_before_use_gold_tolerances = steps_before_use_gold_tolerances
- 
+
  s% use_gold2_tolerances = use_gold2_tolerances
- s% gold2_solver_iters_timestep_limit = gold2_solver_iters_timestep_limit 
+ s% gold2_solver_iters_timestep_limit = gold2_solver_iters_timestep_limit
  s% gold2_tol_residual_norm1 = gold2_tol_residual_norm1
  s% gold2_tol_max_residual1 = gold2_tol_max_residual1
  s% gold2_iter_for_resid_tol2 = gold2_iter_for_resid_tol2
@@ -1933,7 +1934,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% gold2_tol_residual_norm3 = gold2_tol_residual_norm3
  s% gold2_tol_max_residual3 = gold2_tol_max_residual3
  s% steps_before_use_gold2_tolerances = steps_before_use_gold2_tolerances
- 
+
  s% include_rotation_in_total_energy = include_rotation_in_total_energy
 
  s% convergence_ignore_equL_residuals = convergence_ignore_equL_residuals
@@ -1955,11 +1956,11 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% hydro_mtx_max_allowed_logRho = hydro_mtx_max_allowed_logRho
  s% hydro_mtx_min_allowed_logT = hydro_mtx_min_allowed_logT
  s% hydro_mtx_min_allowed_logRho = hydro_mtx_min_allowed_logRho
- 
+
  s% use_DGESVX_in_bcyclic = use_DGESVX_in_bcyclic
  s% use_equilibration_in_DGESVX = use_equilibration_in_DGESVX
  s% report_min_rcond_from_DGESXV = report_min_rcond_from_DGESXV
- 
+
  s% op_split_burn = op_split_burn
  s% op_split_burn_min_T = op_split_burn_min_T
  s% op_split_burn_eps = op_split_burn_eps
@@ -2050,7 +2051,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  s% RSP2_alfap = RSP2_alfap
  s% RSP2_alfad = RSP2_alfad
- s% RSP2_alfat = RSP2_alfat 
+ s% RSP2_alfat = RSP2_alfat
  s% RSP2_alfam = RSP2_alfam
  s% RSP2_alfar = RSP2_alfar
  s% RSP2_min_Lt_div_L_for_overshooting_mixing_type = RSP2_min_Lt_div_L_for_overshooting_mixing_type
@@ -2087,7 +2088,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% RSP2_w_min_for_damping = RSP2_w_min_for_damping
  s% RSP2_source_seed = RSP2_source_seed
  s% RSP2_w_fix_if_neg = RSP2_w_fix_if_neg
- 
+
  s% max_X_for_conv_timescale = max_X_for_conv_timescale
  s% min_X_for_conv_timescale = min_X_for_conv_timescale
  s% max_q_for_conv_timescale = max_q_for_conv_timescale
@@ -2112,7 +2113,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% neg_mass_fraction_hold = neg_mass_fraction_hold
  s% timestep_dt_factor = timestep_dt_factor
  s% use_dt_low_pass_controller = use_dt_low_pass_controller
- 
+
  s% force_timestep_min = force_timestep_min
  s% force_timestep_min_years = force_timestep_min_years
  s% force_timestep_min_factor = force_timestep_min_factor
@@ -2138,7 +2139,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% dt_div_dt_cell_collapse_hard_limit = dt_div_dt_cell_collapse_hard_limit
  s% dt_div_min_dr_div_cs_limit = dt_div_min_dr_div_cs_limit
  s% dt_div_min_dr_div_cs_hard_limit = dt_div_min_dr_div_cs_hard_limit
- 
+
  s% min_abs_du_div_cs_for_dt_div_min_dr_div_cs_limit = min_abs_du_div_cs_for_dt_div_min_dr_div_cs_limit
  s% min_abs_u_div_cs_for_dt_div_min_dr_div_cs_limit = min_abs_u_div_cs_for_dt_div_min_dr_div_cs_limit
  s% min_k_for_dt_div_min_dr_div_cs_limit = min_k_for_dt_div_min_dr_div_cs_limit
@@ -2158,7 +2159,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% dX_div_X_at_high_T_limit = dX_div_X_at_high_T_limit
  s% dX_div_X_at_high_T_hard_limit = dX_div_X_at_high_T_hard_limit
  s% dX_div_X_at_high_T_limit_lgT_min = dX_div_X_at_high_T_limit_lgT_min
- 
+
  s% dX_decreases_only = dX_decreases_only
 
  s% dX_nuc_drop_min_X_limit = dX_nuc_drop_min_X_limit
@@ -2230,7 +2231,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% delta_lgL_nuc_at_high_T_limit = delta_lgL_nuc_at_high_T_limit
  s% delta_lgL_nuc_at_high_T_hard_limit = delta_lgL_nuc_at_high_T_hard_limit
  s% delta_lgL_nuc_at_high_T_limit_lgT_min = delta_lgL_nuc_at_high_T_limit_lgT_min
- 
+
  s% max_lgT_for_lgL_nuc_limit = max_lgT_for_lgL_nuc_limit
  s% lgL_nuc_burn_min = lgL_nuc_burn_min
  s% lgL_nuc_drop_factor = lgL_nuc_drop_factor
@@ -2545,7 +2546,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  star_mass_min_limit = s% star_mass_min_limit
  ejecta_mass_max_limit = s% ejecta_mass_max_limit
  remnant_mass_min_limit = s% remnant_mass_min_limit
- 
+
  star_species_mass_min_limit = s% star_species_mass_min_limit
  star_species_mass_min_limit_iso = s% star_species_mass_min_limit_iso
  star_species_mass_max_limit = s% star_species_mass_max_limit
@@ -2655,7 +2656,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  fgong_header = s% fgong_header
  fgong_ivers = s% fgong_ivers
- 
+
  max_num_gyre_points = s% max_num_gyre_points
  format_for_OSC_data = s% format_for_OSC_data
  fgong_zero_A_inside_r = s% fgong_zero_A_inside_r
@@ -2672,7 +2673,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  min_tau_for_max_abs_v_location = s% min_tau_for_max_abs_v_location
  min_q_for_inner_mach1_location = s% min_q_for_inner_mach1_location
  max_q_for_outer_mach1_location = s% max_q_for_outer_mach1_location
- 
+
  conv_core_gap_dq_limit = s% conv_core_gap_dq_limit
 
  ! burn zone eps definitions for use in logs and profiles
@@ -2724,7 +2725,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  gradT_excess_beta2 = s% gradT_excess_beta2
  gradT_excess_dlambda = s% gradT_excess_dlambda
  gradT_excess_dbeta = s% gradT_excess_dbeta
- 
+
  D_mix_zero_region_bottom_q = s% D_mix_zero_region_bottom_q
  D_mix_zero_region_top_q = s% D_mix_zero_region_top_q
  dq_D_mix_zero_at_H_He_crossover = s% dq_D_mix_zero_at_H_He_crossover
@@ -2736,7 +2737,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  superad_reduction_gamma_inv_scale = s% superad_reduction_gamma_inv_scale
  superad_reduction_diff_grads_limit = s% superad_reduction_diff_grads_limit
  superad_reduction_limit = s% superad_reduction_limit
- 
+
  max_logT_for_mlt = s% max_logT_for_mlt
  mlt_make_surface_no_mixing = s% mlt_make_surface_no_mixing
  do_normalize_dqs_as_part_of_set_qs = s% do_normalize_dqs_as_part_of_set_qs
@@ -2761,7 +2762,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  burn_h_mix_region_logT = s% burn_h_mix_region_logT
  max_Y_for_burn_z_mix_region = s% max_Y_for_burn_z_mix_region
  max_X_for_burn_he_mix_region = s% max_X_for_burn_he_mix_region
- 
+
  limit_overshoot_Hp_using_size_of_convection_zone = s% limit_overshoot_Hp_using_size_of_convection_zone
 
  predictive_mix = s% predictive_mix
@@ -2809,7 +2810,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  min_overshoot_q = s% min_overshoot_q
  overshoot_alpha = s% overshoot_alpha
- 
+
    RSP_max_num_periods = s% RSP_max_num_periods
    RSP_target_steps_per_cycle = s% RSP_target_steps_per_cycle
    RSP_min_max_R_for_periods = s% RSP_min_max_R_for_periods
@@ -2961,7 +2962,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  atm_build_tau_outer = s% atm_build_tau_outer
  atm_build_dlogtau = s% atm_build_dlogtau
  atm_build_errtol = s% atm_build_errtol
- 
+
  use_T_tau_gradr_factor = s% use_T_tau_gradr_factor
 
  ! extra heat near surface to model irradiation
@@ -2996,7 +2997,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  nu_omega_mixing_rate = s% nu_omega_mixing_rate
  nu_omega_mixing_across_convection_boundary = s% nu_omega_mixing_across_convection_boundary
  max_q_for_nu_omega_zero_in_convection_region = s% max_q_for_nu_omega_zero_in_convection_region
- 
+
  mdot_omega_power = s% mdot_omega_power
  max_rotational_mdot_boost = s% max_rotational_mdot_boost
  max_mdot_jump_for_rotation = s% max_mdot_jump_for_rotation
@@ -3012,7 +3013,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  wind_boost_full_on_L_div_Ledd = s% wind_boost_full_on_L_div_Ledd
  super_eddington_wind_max_boost = s% super_eddington_wind_max_boost
  trace_super_eddington_wind_boost = s% trace_super_eddington_wind_boost
- 
+
  max_tries_for_implicit_wind = s% max_tries_for_implicit_wind
  iwind_tolerance = s% iwind_tolerance
  iwind_lambda = s% iwind_lambda
@@ -3198,7 +3199,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  mesh_dlog_pnhe4_dlogP_extra = s% mesh_dlog_pnhe4_dlogP_extra
  mesh_dlog_photo_dlogP_extra = s% mesh_dlog_photo_dlogP_extra
  mesh_dlog_other_dlogP_extra = s% mesh_dlog_other_dlogP_extra
- 
+
  mesh_delta_coeff_factor_smooth_iters = s% mesh_delta_coeff_factor_smooth_iters
 
  T_function1_weight = s% T_function1_weight
@@ -3230,7 +3231,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  xa_function_weight = s% xa_function_weight
  xa_function_param = s% xa_function_param
  xa_mesh_delta_coeff = s% xa_mesh_delta_coeff
- 
+
  use_split_merge_amr = s% use_split_merge_amr
  split_merge_amr_nz_baseline = s% split_merge_amr_nz_baseline
  split_merge_amr_nz_r_core = s% split_merge_amr_nz_r_core
@@ -3455,7 +3456,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  ! eos controls
  fix_d_eos_dxa_partials = s% fix_d_eos_dxa_partials
- 
+
  ! opacity controls
  use_simple_es_for_kap = s% use_simple_es_for_kap
  use_starting_composition_for_kap = s% use_starting_composition_for_kap
@@ -3525,11 +3526,12 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  RTI_energy_floor = s% RTI_energy_floor
  RTI_D_mix_floor = s% RTI_D_mix_floor
  RTI_min_m_for_D_mix_floor = s% RTI_min_m_for_D_mix_floor
- RTI_log_max_boost = s% RTI_log_max_boost 
+ RTI_log_max_boost = s% RTI_log_max_boost
  RTI_m_full_boost = s% RTI_m_full_boost
  RTI_m_no_boost = s% RTI_m_no_boost
 
 
+ use_drag_energy = s% use_drag_energy
  drag_coefficient = s% drag_coefficient
  min_q_for_drag = s% min_q_for_drag
 
@@ -3552,7 +3554,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  tol_correction_extreme_T_limit = s% tol_correction_extreme_T_limit
  tol_correction_norm_extreme_T = s% tol_correction_norm_extreme_T
  tol_max_correction_extreme_T = s% tol_max_correction_extreme_T
- 
+
  tol_bad_max_correction = s% tol_bad_max_correction
  bad_max_correction_series_limit = s% bad_max_correction_series_limit
 
@@ -3564,7 +3566,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  tol_max_residual3 = s% tol_max_residual3
  warning_limit_for_max_residual = s% warning_limit_for_max_residual
  trace_solver_damping = s% trace_solver_damping
- 
+
  relax_use_gold_tolerances = s% relax_use_gold_tolerances
  relax_tol_correction_norm = s% relax_tol_correction_norm
  relax_tol_max_correction = s% relax_tol_max_correction
@@ -3578,9 +3580,9 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  relax_tol_residual_norm3 = s% relax_tol_residual_norm3
  relax_tol_max_residual3 = s% relax_tol_max_residual3
  relax_maxT_for_gold_tolerances = s% relax_maxT_for_gold_tolerances
- 
+
  use_gold_tolerances = s% use_gold_tolerances
- gold_solver_iters_timestep_limit = s% gold_solver_iters_timestep_limit 
+ gold_solver_iters_timestep_limit = s% gold_solver_iters_timestep_limit
  maxT_for_gold_tolerances = s% maxT_for_gold_tolerances
  gold_tol_residual_norm1 = s% gold_tol_residual_norm1
  gold_tol_max_residual1 = s% gold_tol_max_residual1
@@ -3591,9 +3593,9 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  gold_tol_residual_norm3 = s% gold_tol_residual_norm3
  gold_tol_max_residual3 = s% gold_tol_max_residual3
  steps_before_use_gold_tolerances = s% steps_before_use_gold_tolerances
- 
+
  use_gold2_tolerances = s% use_gold2_tolerances
- gold2_solver_iters_timestep_limit = s% gold2_solver_iters_timestep_limit 
+ gold2_solver_iters_timestep_limit = s% gold2_solver_iters_timestep_limit
  gold2_tol_residual_norm1 = s% gold2_tol_residual_norm1
  gold2_tol_max_residual1 = s% gold2_tol_max_residual1
  gold2_iter_for_resid_tol2 = s% gold2_iter_for_resid_tol2
@@ -3603,7 +3605,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  gold2_tol_residual_norm3 = s% gold2_tol_residual_norm3
  gold2_tol_max_residual3 = s% gold2_tol_max_residual3
  steps_before_use_gold2_tolerances = s% steps_before_use_gold2_tolerances
- 
+
  include_rotation_in_total_energy = s% include_rotation_in_total_energy
 
  convergence_ignore_equL_residuals = s% convergence_ignore_equL_residuals
@@ -3625,11 +3627,11 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  hydro_mtx_max_allowed_logRho = s% hydro_mtx_max_allowed_logRho
  hydro_mtx_min_allowed_logT = s% hydro_mtx_min_allowed_logT
  hydro_mtx_min_allowed_logRho = s% hydro_mtx_min_allowed_logRho
- 
+
  use_DGESVX_in_bcyclic = s% use_DGESVX_in_bcyclic
  use_equilibration_in_DGESVX = s% use_equilibration_in_DGESVX
  report_min_rcond_from_DGESXV = s% report_min_rcond_from_DGESXV
- 
+
  op_split_burn = s% op_split_burn
  op_split_burn_min_T = s% op_split_burn_min_T
  op_split_burn_eps = s% op_split_burn_eps
@@ -3720,7 +3722,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
 
  RSP2_alfap= s% RSP2_alfap
  RSP2_alfad = s% RSP2_alfad
- RSP2_alfat= s% RSP2_alfat 
+ RSP2_alfat= s% RSP2_alfat
  RSP2_alfam= s% RSP2_alfam
  RSP2_alfar= s% RSP2_alfar
  RSP2_min_Lt_div_L_for_overshooting_mixing_type = s% RSP2_min_Lt_div_L_for_overshooting_mixing_type
@@ -3782,7 +3784,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  neg_mass_fraction_hold = s% neg_mass_fraction_hold
  timestep_dt_factor = s% timestep_dt_factor
  use_dt_low_pass_controller = s% use_dt_low_pass_controller
- 
+
  force_timestep_min = s% force_timestep_min
  force_timestep_min_years = s% force_timestep_min_years
  force_timestep_min_factor = s% force_timestep_min_factor
@@ -3808,7 +3810,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  dt_div_dt_cell_collapse_hard_limit = s% dt_div_dt_cell_collapse_hard_limit
  dt_div_min_dr_div_cs_limit = s% dt_div_min_dr_div_cs_limit
  dt_div_min_dr_div_cs_hard_limit = s% dt_div_min_dr_div_cs_hard_limit
- 
+
  min_abs_du_div_cs_for_dt_div_min_dr_div_cs_limit = s% min_abs_du_div_cs_for_dt_div_min_dr_div_cs_limit
  min_abs_u_div_cs_for_dt_div_min_dr_div_cs_limit = s% min_abs_u_div_cs_for_dt_div_min_dr_div_cs_limit
  min_k_for_dt_div_min_dr_div_cs_limit = s% min_k_for_dt_div_min_dr_div_cs_limit
@@ -3898,7 +3900,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  delta_lgL_nuc_at_high_T_limit = s% delta_lgL_nuc_at_high_T_limit
  delta_lgL_nuc_at_high_T_hard_limit = s% delta_lgL_nuc_at_high_T_hard_limit
  delta_lgL_nuc_at_high_T_limit_lgT_min = s% delta_lgL_nuc_at_high_T_limit_lgT_min
- 
+
  max_lgT_for_lgL_nuc_limit = s% max_lgT_for_lgL_nuc_limit
  lgL_nuc_burn_min = s% lgL_nuc_burn_min
  lgL_nuc_drop_factor = s% lgL_nuc_drop_factor
@@ -4096,7 +4098,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  num_cells_for_smooth_brunt_B = s% num_cells_for_smooth_brunt_B
  steps_before_start_stress_test = s% steps_before_start_stress_test
  stress_test_relax = s% stress_test_relax
- 
+
 
 
  end subroutine set_controls_for_writing
@@ -4126,7 +4128,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
       upper_name = trim(StrUpCase(name))//'='
       val = ''
       ! Search for name inside namelist
-      do 
+      do
          read(iounit,'(A)',iostat=iostat) str
          ind = index(trim(str),trim(upper_name))
          if( ind /= 0 ) then
@@ -4137,7 +4139,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
             exit
          end if
          if(is_iostat_end(iostat)) exit
-      end do   
+      end do
 
       if(len_trim(val) == 0 .and. ind==0 ) ierr = -1
 
@@ -4169,4 +4171,3 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
 
 
  end module ctrls_io
-

--- a/star/private/hydro_energy.f90
+++ b/star/private/hydro_energy.f90
@@ -39,7 +39,7 @@
       public :: do1_energy_eqn
 
       contains
-      
+
 
       subroutine do1_energy_eqn( & ! energy conservation
             s, k, do_chem, nvar, ierr)
@@ -47,8 +47,8 @@
          type (star_info), pointer :: s
          integer, intent(in) :: k, nvar
          logical, intent(in) :: do_chem
-         integer, intent(out) :: ierr         
-         real(dp), dimension(nvar) :: d_dm1, d_d00, d_dp1      
+         integer, intent(out) :: ierr
+         real(dp), dimension(nvar) :: d_dm1, d_d00, d_dp1
          include 'formats'
          call get1_energy_eqn( &
             s, k, do_chem, nvar, &
@@ -56,7 +56,7 @@
          if (ierr /= 0) then
             if (s% report_ierr) write(*,2) 'ierr /= 0 for get1_energy_eqn', k
             return
-         end if         
+         end if
          call store_partials( &
             s, k, s% i_dlnE_dt, nvar, d_dm1, d_d00, d_dp1, 'do1_energy_eqn', ierr)
       end subroutine do1_energy_eqn
@@ -68,12 +68,12 @@
          use eps_grav, only: eval_eps_grav_and_partials
          use accurate_sum_auto_diff_star_order1
          use auto_diff_support
-         type (star_info), pointer :: s         
+         type (star_info), pointer :: s
          integer, intent(in) :: k, nvar
          logical, intent(in) :: do_chem
          real(dp), intent(out), dimension(nvar) :: d_dm1, d_d00, d_dp1
          integer, intent(out) :: ierr
-         
+
          type(auto_diff_real_star_order1) :: resid_ad, &
             dL_dm_ad, sources_ad, others_ad, d_turbulent_energy_dt_ad, &
             dwork_dm_ad, eps_grav_ad, dke_dt_ad, dpe_dt_ad, de_dt_ad
@@ -83,26 +83,26 @@
             d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1
          integer :: nz, i_dlnE_dt, i_lum, i_v
          logical :: test_partials, doing_op_split_burn, eps_grav_form
-                    
+
          include 'formats'
 
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-         
+
          ierr = 0
          call init
-            
-         call setup_eps_grav(ierr); if (ierr /= 0) return ! do this first - it sets eps_grav_form         
-         call setup_de_dt_and_friends(ierr); if (ierr /= 0) return   
-         call setup_dwork_dm(ierr); if (ierr /= 0) return         
-         call setup_dL_dm(ierr); if (ierr /= 0) return         
-         call setup_sources_and_others(ierr); if (ierr /= 0) return         
-         call setup_d_turbulent_energy_dt(ierr); if (ierr /= 0) return         
+
+         call setup_eps_grav(ierr); if (ierr /= 0) return ! do this first - it sets eps_grav_form
+         call setup_de_dt_and_friends(ierr); if (ierr /= 0) return
+         call setup_dwork_dm(ierr); if (ierr /= 0) return
+         call setup_dL_dm(ierr); if (ierr /= 0) return
+         call setup_sources_and_others(ierr); if (ierr /= 0) return
+         call setup_d_turbulent_energy_dt(ierr); if (ierr /= 0) return
          call set_energy_eqn_scal(s, k, scal, ierr); if (ierr /= 0) return
-         
+
          s% dL_dm(k) = dL_dm_ad%val
          s% dwork_dm(k) = dwork_dm_ad%val
-         s% energy_sources(k) = sources_ad%val 
+         s% energy_sources(k) = sources_ad%val
             ! nuclear heating, non_nuc_neu_cooling, irradiation heating, extra_heat, eps_mdot
          s% energy_others(k) = others_ad%val
             ! eps_WD_sedimentation, eps_diffusion, eps_pre_mix, eps_phase_separation
@@ -123,15 +123,15 @@
          resid_ad = scal*resid_ad
          residual = resid_ad%val
          s% equ(i_dlnE_dt, k) = residual
-         
+
          if (test_partials) then
             s% solver_test_partials_val = residual
          end if
          call unpack_res18(s% species, resid_ad)
 
-         if (test_partials) then  
+         if (test_partials) then
             s% solver_test_partials_var = s% i_u
-            s% solver_test_partials_dval_dx = d_d00(s% solver_test_partials_var)  
+            s% solver_test_partials_dval_dx = d_d00(s% solver_test_partials_var)
             write(*,*) 'get1_energy_eqn', s% solver_test_partials_var
             if (eps_grav_form) write(*,*) 'eps_grav_form', eps_grav_form
             !if (.false. .and. s% solver_iter == s% solver_test_partials_iter_number) then
@@ -153,9 +153,9 @@
             end if
             write(*,'(A)')
          end if
-         
+
          contains
-         
+
          subroutine init
             i_dlnE_dt = s% i_dlnE_dt
             i_lum = s% i_lum
@@ -167,7 +167,7 @@
                s% T_start(k) >= s% op_split_burn_min_T
             d_dm1 = 0d0; d_d00 = 0d0; d_dp1 = 0d0
          end subroutine init
-      
+
          subroutine setup_dwork_dm(ierr)
             integer, intent(out) :: ierr
             real(dp) :: dwork
@@ -178,7 +178,7 @@
             if (s% using_velocity_time_centering .and. &
                 s% use_P_d_1_div_rho_form_of_work_when_time_centering_velocity) then
                call eval_simple_PdV_work(s, k, skip_P, dwork_dm_ad, dwork, &
-                  d_dwork_dxa00, ierr) 
+                  d_dwork_dxa00, ierr)
                d_dwork_dxam1 = 0
                d_dwork_dxap1 = 0
                if (k == s% nz) then
@@ -193,7 +193,7 @@
                end if
             else
                call eval_dwork(s, k, skip_P, dwork_dm_ad, dwork, &
-                  d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1, ierr) 
+                  d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1, ierr)
             end if
             if (ierr /= 0) then
                if (s% report_ierr) write(*,*) 'failed in setup_dwork_dm', k
@@ -201,13 +201,13 @@
             end if
             dwork_dm_ad = dwork_dm_ad/dm
          end subroutine setup_dwork_dm
-         
-         subroutine setup_dL_dm(ierr)  
+
+         subroutine setup_dL_dm(ierr)
             integer, intent(out) :: ierr
             type(auto_diff_real_star_order1) :: L00_ad, Lp1_ad
             real(dp) :: L_theta
             include 'formats'
-            ierr = 0         
+            ierr = 0
             if (s% using_velocity_time_centering .and. &
                      s% include_L_in_velocity_time_centering) then
                L_theta = s% L_theta_for_velocity_time_centering
@@ -228,7 +228,7 @@
                v_00, v_p1, drag_force, drag_energy
             include 'formats'
             ierr = 0
-         
+
             if (s% eps_nuc_factor == 0d0 .or. s% nonlocal_NiCo_decay_heat) then
                eps_nuc_ad = 0 ! get eps_nuc from extra_heat instead
             else if (s% op_split_burn .and. s% T_start(k) >= s% op_split_burn_min_T) then
@@ -240,19 +240,19 @@
                eps_nuc_ad%d1Array(i_lnd_00) = s% d_epsnuc_dlnd(k)
                eps_nuc_ad%d1Array(i_lnT_00) = s% d_epsnuc_dlnT(k)
             end if
-            
+
             non_nuc_neu_ad = 0d0
             ! for reasons lost in the past, we always time center non_nuc_neu
             ! change that if you are feeling lucky.
             non_nuc_neu_ad%val = 0.5d0*(s% non_nuc_neu_start(k) + s% non_nuc_neu(k))
             non_nuc_neu_ad%d1Array(i_lnd_00) = 0.5d0*s% d_nonnucneu_dlnd(k)
             non_nuc_neu_ad%d1Array(i_lnT_00) = 0.5d0*s% d_nonnucneu_dlnT(k)
-            
+
             extra_heat_ad = s% extra_heat(k)
-            
+
             ! other = eps_WD_sedimentation + eps_diffusion + eps_pre_mix + eps_phase_separation
             ! no partials for any of these
-            others_ad = 0d0 
+            others_ad = 0d0
             if (s% do_element_diffusion) then
                if (s% do_WD_sedimentation_heating) then
                   others_ad%val = others_ad%val + s% eps_WD_sedimentation(k)
@@ -264,26 +264,30 @@
                others_ad%val = others_ad%val + s% eps_pre_mix(k)
             if (s% do_phase_separation .and. s% do_phase_separation_heating) &
                others_ad%val = others_ad%val + s% eps_phase_separation(k)
-            
+
             Eq_ad = 0d0
-            if (s% RSP2_flag) then             
+            if (s% RSP2_flag) then
                Eq_ad = s% Eq_ad(k) ! compute_Eq_cell(s, k, ierr)
                if (ierr /= 0) return
-            end if   
-            
+            end if
+
             call setup_RTI_diffusion(RTI_diffusion_ad)
 
             drag_energy = 0d0
             s% FdotV_drag_energy(k) = 0
             if (k .ne. s% nz) then
-               if (s% q(k) > s% min_q_for_drag .and. s% drag_coefficient > 0) then
+               if ((s% q(k) > s% min_q_for_drag) .and. &
+                  (s% drag_coefficient > 0) .and. &
+                  (s% use_drag_energy .eqv. .true.)) then
                   v_00 = wrap_v_00(s,k)
                   drag_force = s% drag_coefficient*v_00/s% dt
                   drag_energy = 0.5d0*v_00*drag_force
                   s% FdotV_drag_energy(k) = drag_energy%val
                ! drag energy for outer half-cell.   the 0.5d0 is for dm/2
                end if
-               if (s% q(k+1) > s% min_q_for_drag .and. s% drag_coefficient > 0) then
+               if ((s% q(k+1) > s% min_q_for_drag) .and. &
+                  (s% drag_coefficient > 0) .and. &
+                  (s% use_drag_energy .eqv. .true.)) then
                   v_p1 = wrap_v_p1(s,k)
                   drag_force = s% drag_coefficient*v_p1/s% dt
                   drag_energy = drag_energy + 0.5d0*v_p1*drag_force
@@ -295,11 +299,11 @@
             sources_ad = eps_nuc_ad - non_nuc_neu_ad + extra_heat_ad + Eq_ad + RTI_diffusion_ad + drag_energy
 
             sources_ad%val = sources_ad%val + s% irradiation_heat(k)
-            
+
             if (s% mstar_dot /= 0d0) sources_ad%val = sources_ad%val + s% eps_mdot(k)
 
          end subroutine setup_sources_and_others
-         
+
          subroutine setup_RTI_diffusion(diffusion_eps_ad)
             type(auto_diff_real_star_order1), intent(out) :: diffusion_eps_ad
             real(dp) :: diffusion_factor, emin_start, sigp1, sig00
@@ -341,7 +345,7 @@
             end if
             s% dedt_RTI(k) = diffusion_eps_ad%val
          end subroutine setup_RTI_diffusion
-         
+
          subroutine setup_d_turbulent_energy_dt(ierr)
             integer, intent(out) :: ierr
             include 'formats'
@@ -353,22 +357,22 @@
             end if
             s% detrbdt(k) = d_turbulent_energy_dt_ad%val
          end subroutine setup_d_turbulent_energy_dt
-         
+
          subroutine setup_eps_grav(ierr)
             integer, intent(out) :: ierr
             include 'formats'
             ierr = 0
-            
-            if (s% u_flag) then ! for now, assume u_flag means no eps_grav 
+
+            if (s% u_flag) then ! for now, assume u_flag means no eps_grav
                eps_grav_form = .false.
                return
             end if
 
             ! value from checking s% energy_eqn_option in hydro_eqns.f90
             eps_grav_form = s% eps_grav_form_for_energy_eqn
-         
+
             if (.not. eps_grav_form) then ! check if want it true
-               if (s% doing_relax .and. s% no_dedt_form_during_relax) eps_grav_form = .true.         
+               if (s% doing_relax .and. s% no_dedt_form_during_relax) eps_grav_form = .true.
             end if
 
             if (eps_grav_form) then
@@ -382,7 +386,7 @@
                end if
                eps_grav_ad = s% eps_grav_ad(k)
             end if
-            
+
          end subroutine setup_eps_grav
 
          subroutine setup_de_dt_and_friends(ierr)
@@ -399,7 +403,7 @@
             de_dt = 0d0; d_de_dt_dlnd = 0d0; d_de_dt_dlnT = 0d0
 
             if (.not. eps_grav_form) then
-            
+
                de_dt = (s% energy(k) - s% energy_start(k))/dt
                d_de_dt_dlnd = s% dE_dRho_for_partials(k)*s% rho(k)/dt
                d_de_dt_dlnT = s% Cv_for_partials(k)*s% T(k)/dt
@@ -407,10 +411,10 @@
                de_dt_ad%val = de_dt
                de_dt_ad%d1Array(i_lnd_00) = d_de_dt_dlnd
                de_dt_ad%d1Array(i_lnT_00) = d_de_dt_dlnT
-               
+
                call get_dke_dt_dpe_dt(s, k, dt, &
                   dke_dt, d_dkedt_dv00, d_dkedt_dvp1, &
-                  dpe_dt, d_dpedt_dlnR00, d_dpedt_dlnRp1, ierr)      
+                  dpe_dt, d_dpedt_dlnR00, d_dpedt_dlnRp1, ierr)
                if (ierr /= 0) then
                   if (s% report_ierr) write(*,2) 'failed in get_dke_dt_dpe_dt', k
                   return
@@ -419,21 +423,21 @@
                dke_dt_ad%val = dke_dt
                dke_dt_ad%d1Array(i_v_00) = d_dkedt_dv00
                dke_dt_ad%d1Array(i_v_p1) = d_dkedt_dvp1
-               
+
                dpe_dt_ad = 0d0
                dpe_dt_ad%val = dpe_dt
                dpe_dt_ad%d1Array(i_lnR_00) = d_dpedt_dlnR00
                dpe_dt_ad%d1Array(i_lnR_p1) = d_dpedt_dlnRp1
-               
+
             end if
-            
+
             s% dkedt(k) = dke_dt
             s% dpedt(k) = dpe_dt
             s% dkedt(k) = dke_dt
             s% dedt(k) = de_dt
-         
+
          end subroutine setup_de_dt_and_friends
-         
+
          subroutine unpack_res18(species,res18)
             use star_utils, only: save_eqn_dxa_partials, unpack_residual_partials
             type(auto_diff_real_star_order1) :: res18
@@ -443,7 +447,7 @@
             real(dp), dimension(species) :: dxam1, dxa00, dxap1
             logical, parameter :: checking = .true.
             include 'formats'
-            
+
             ! do partials wrt composition
             dxam1 = 0d0; dxa00 = 0d0; dxap1 = 0d0
             if (.not. (s% nonlocal_NiCo_decay_heat .or. doing_op_split_burn)) then
@@ -456,27 +460,27 @@
                end if
             end if
 
-            if (.not. eps_grav_form) then          
+            if (.not. eps_grav_form) then
                do j=1,s% species
                   dequ = -scal*(s%energy(k)/dt)*s% dlnE_dxa_for_partials(j,k)
                   if (checking) call check_dequ(dequ,'dlnE_dxa_for_partials')
                   dxa00(j) = dxa00(j) + dequ
-               end do                           
+               end do
             else if (do_chem .and. (.not. doing_op_split_burn) .and. &
-                     (s% dxdt_nuc_factor > 0d0 .or. s% mix_factor > 0d0)) then                     
+                     (s% dxdt_nuc_factor > 0d0 .or. s% mix_factor > 0d0)) then
                do j=1,s% species
                   dequ = scal*s% d_eps_grav_dx(j,k)
                   if (checking) call check_dequ(dequ,'d_eps_grav_dx')
                   dxa00(j) = dxa00(j) + dequ
-               end do               
+               end do
             end if
-            
+
             do j=1,s% species
                dequ = -scal*d_dwork_dxa00(j)/dm
                if (checking) call check_dequ(dequ,'d_dwork_dxa00')
                dxa00(j) = dxa00(j) + dequ
             end do
-            if (k > 1) then 
+            if (k > 1) then
                do j=1,s% species
                   dequ = -scal*d_dwork_dxam1(j)/dm
                   if (checking) call check_dequ(dequ,'d_dwork_dxam1')
@@ -489,14 +493,14 @@
                   if (checking) call check_dequ(dequ,'d_dwork_dxap1')
                   dxap1(j) = dxap1(j) + dequ
                end do
-            end if         
+            end if
 
             call save_eqn_dxa_partials(&
                s, k, nvar, i_dlnE_dt, species, dxam1, dxa00, dxap1, 'get1_energy_eqn', ierr)
-            
+
             call unpack_residual_partials(s, k, nvar, i_dlnE_dt, &
                res18, d_dm1, d_d00, d_dp1)
-            
+
          end subroutine unpack_res18
 
          subroutine check_dequ(dequ, str)
@@ -514,7 +518,7 @@
                return
             end if
          end subroutine check_dequ
-         
+
          subroutine unpack1(j, dvar_m1, dvar_00, dvar_p1)
             integer, intent(in) :: j
             real(dp), intent(in) :: dvar_m1, dvar_00, dvar_p1
@@ -527,11 +531,11 @@
 
 
       subroutine eval_dwork(s, k, skip_P, dwork_ad, dwork, &
-            d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1, ierr) 
+            d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1, ierr)
          use accurate_sum_auto_diff_star_order1
          use auto_diff_support
          use star_utils, only: calc_Ptot_ad_tw
-         type (star_info), pointer :: s 
+         type (star_info), pointer :: s
          integer, intent(in) :: k
          logical, intent(in) :: skip_P
          type(auto_diff_real_star_order1), intent(out) :: dwork_ad
@@ -539,7 +543,7 @@
          real(dp), intent(out), dimension(s% species) :: &
             d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1
          integer, intent(out) :: ierr
-            
+
          real(dp) :: work_00, work_p1, dm, dV
          real(dp), dimension(s% species) :: &
             d_work_00_dxa00, d_work_00_dxam1, &
@@ -557,18 +561,18 @@
          call eval1_work(s, k+1, skip_P, &
             work_p1_ad, work_p1, d_work_p1_dxap1, d_work_p1_dxa00, ierr)
          if (ierr /= 0) return
-         work_p1_ad = shift_p1(work_p1_ad) ! shift the partials         
+         work_p1_ad = shift_p1(work_p1_ad) ! shift the partials
          dwork_ad = work_00_ad - work_p1_ad
          dwork = dwork_ad%val
          do j=1,s% species
             d_dwork_dxam1(j) = d_work_00_dxam1(j)
             d_dwork_dxa00(j) = d_work_00_dxa00(j) - d_work_p1_dxa00(j)
             d_dwork_dxap1(j) = -d_work_p1_dxap1(j)
-         end do         
+         end do
 
-         !test_partials = (k == s% solver_test_partials_k) 
+         !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-            
+
          if (test_partials) then
             s% solver_test_partials_val = 0
             s% solver_test_partials_var = 0
@@ -577,7 +581,7 @@
          end if
 
       end subroutine eval_dwork
-      
+
 
       ! ergs/s at face(k)
       subroutine eval1_work(s, k, skip_Peos, &
@@ -585,7 +589,7 @@
          use star_utils, only: get_Pvsc_ad, calc_Ptrb_ad_tw, get_rho_face
          use accurate_sum_auto_diff_star_order1
          use auto_diff_support
-         type (star_info), pointer :: s 
+         type (star_info), pointer :: s
          integer, intent(in) :: k
          logical, intent(in) :: skip_Peos
          type(auto_diff_real_star_order1), intent(out) :: work_ad
@@ -620,19 +624,19 @@
                end if
             end if
             work_ad%val = work
-            return    
+            return
          end if
-         
+
          call eval1_A_times_v_face_ad(s, k, A_times_v_face_ad, ierr)
          if (ierr /= 0) return
 
-         if (k > 1) then         
+         if (k > 1) then
             alfa = s% dq(k-1)/(s% dq(k-1) + s% dq(k))
          else
             alfa = 1d0
          end if
          beta = 1d0 - alfa
-         
+
          if (s% using_velocity_time_centering .and. &
                   s% include_P_in_velocity_time_centering) then
             P_theta = s% P_theta_for_velocity_time_centering
@@ -650,14 +654,14 @@
             if (skip_Peos) then
                Peos_ad = 0d0
             else
-               if (k > 1) then 
+               if (k > 1) then
                   PR_ad = P_theta*wrap_Peos_m1(s,k) + (1d0-P_theta)*s% Peos_start(k-1)
                else
                   PR_ad = 0d0
                end if
                PL_ad = P_theta*wrap_Peos_00(s,k) + (1d0-P_theta)*s% Peos_start(k)
                Peos_ad = alfa*PL_ad + beta*PR_ad
-               if (k > 1) then         
+               if (k > 1) then
                   do j=1,s% species
                      d_Pface_dxa00(j) = &
                         alfa*s% dlnPeos_dxa_for_partials(j,k)*P_theta*s% Peos(k)
@@ -673,12 +677,12 @@
                   end do
                end if
             end if
-         
+
             ! set Pvsc_ad
             if (.not. s% use_Pvsc_art_visc) then
                Pvsc_ad = 0d0
             else
-               if (k > 1) then 
+               if (k > 1) then
                   call get_Pvsc_ad(s, k-1, PvscR_ad, ierr)
                   if (ierr /= 0) return
                   PvscR_ad = shift_m1(PvscR_ad)
@@ -693,12 +697,12 @@
                   PvscL_ad = 0.5d0*(PvscL_ad + s% Pvsc_start(k))
                Pvsc_ad = alfa*PvscL_ad + beta*PvscR_ad
             end if
-         
+
             ! set Ptrb_ad
             if (.not. s% RSP2_flag) then
                Ptrb_ad = 0d0
             else
-               if (k > 1) then 
+               if (k > 1) then
                   call calc_Ptrb_ad_tw(s, k-1, PtrbR_ad, Ptrb_div_etrb, ierr)
                   if (ierr /= 0) return
                   PtrbR_ad = shift_m1(PtrbR_ad)
@@ -709,31 +713,31 @@
                if (ierr /= 0) return
                Ptrb_ad = alfa*PtrbL_ad + beta*PtrbR_ad
             end if
-         
+
             ! set extra_P
             if (.not. s% use_other_pressure) then
                extra_P = 0d0
-            else if (k > 1) then 
+            else if (k > 1) then
                ! my_val_m1 = shift_m1(get_my_val(s,k-1)) for use in terms going into equation at k
                extra_P = alfa*s% extra_pressure(k) + beta * shift_m1(s%extra_pressure(k-1))
             else
                extra_P = s% extra_pressure(k)
             end if
-         
+
             ! set mlt_Pturb_ad
             mlt_Pturb_ad = 0d0
             if (s% mlt_Pturb_factor > 0d0 .and. s% mlt_vc_old(k) > 0d0) &
                mlt_Pturb_ad = s% mlt_Pturb_factor*pow2(s% mlt_vc_old(k))*get_rho_face(s,k)/3d0
-         
+
             P_face_ad = Peos_ad + Pvsc_ad + Ptrb_ad + mlt_Pturb_ad + extra_P
-         
+
          end if
-         
+
          work_ad = A_times_v_face_ad*P_face_ad
          work = work_ad%val
-         
+
          if (k == 1) s% work_outward_at_surface = work
-         
+
          Av_face = A_times_v_face_ad%val
          do j=1,s% species
             d_work_dxa00(j) = Av_face*d_Pface_dxa00(j)
@@ -742,20 +746,20 @@
 
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-            
+
          if (test_partials) then
             s% solver_test_partials_val = 0
             s% solver_test_partials_var = 0
             s% solver_test_partials_dval_dx = 0
             write(*,*) 'eval1_work', s% solver_test_partials_var
          end if
-         
+
       end subroutine eval1_work
-      
-      
+
+
       subroutine eval1_A_times_v_face_ad(s, k, A_times_v_face_ad, ierr)
          use star_utils, only: get_area_info_opt_time_center
-         type (star_info), pointer :: s 
+         type (star_info), pointer :: s
          integer, intent(in) :: k
          type(auto_diff_real_star_order1), intent(out) :: A_times_v_face_ad
          integer, intent(out) :: ierr
@@ -765,7 +769,7 @@
          ierr = 0
          call get_area_info_opt_time_center(s, k, A_ad, inv_R2, ierr)
          if (ierr /= 0) return
-         
+
          u_face_ad = 0d0
          if (s% v_flag) then
             u_face_ad%val = s% vc(k)
@@ -781,18 +785,18 @@
             u_face_ad%val = (s% r(k) - s% r_start(k))/s% dt
             u_face_ad%d1Array(i_lnR_00) = s% r(k)/s% dt
          end if
-         
+
          A_times_v_face_ad = A_ad*u_face_ad
-      
+
       end subroutine eval1_A_times_v_face_ad
 
 
       subroutine eval_simple_PdV_work( &
-            s, k, skip_P, dwork_ad, dwork, d_dwork_dxa00, ierr) 
+            s, k, skip_P, dwork_ad, dwork, d_dwork_dxa00, ierr)
          use accurate_sum_auto_diff_star_order1
          use auto_diff_support
          use star_utils, only: calc_Ptot_ad_tw
-         type (star_info), pointer :: s 
+         type (star_info), pointer :: s
          integer, intent(in) :: k
          logical, intent(in) :: skip_P
          type(auto_diff_real_star_order1), intent(out) :: dwork_ad
@@ -809,8 +813,8 @@
 
          include 'formats'
          ierr = 0
-         
-         ! dV = 1/rho - 1/rho_start 
+
+         ! dV = 1/rho - 1/rho_start
          call eval1_A_times_v_face_ad(s, k, Av_face00_ad, ierr)
          if (ierr /= 0) return
          if (k < s% nz) then
@@ -827,21 +831,20 @@
 
          include_mlt_Pturb = s% mlt_Pturb_factor > 0d0 &
             .and. s% mlt_vc_old(k) > 0d0 .and. k > 1
-         
+
          call calc_Ptot_ad_tw( &
             s, k, skip_P, .not. include_mlt_Pturb, Ptot_ad, d_Ptot_dxa, ierr)
          if (ierr /= 0) return
-         
+
          do j=1,s% species
             d_dwork_dxa00(j) = d_Ptot_dxa(j)*(Av_face00 - Av_facep1)
          end do
          if (k == 1) s% work_outward_at_surface = Ptot_ad%val*Av_face00
-         
+
          dwork_ad = Ptot_ad*dV
          dwork = dwork_ad%val
 
       end subroutine eval_simple_PdV_work
 
-      
-      end module hydro_energy
 
+      end module hydro_energy

--- a/star/private/hydro_momentum.f90
+++ b/star/private/hydro_momentum.f90
@@ -41,7 +41,7 @@
 
       contains
 
-      
+
       subroutine do_surf_momentum_eqn(s, P_surf_ad, nvar, ierr)
          use star_utils, only: store_partials
          type (star_info), pointer :: s
@@ -56,12 +56,12 @@
          if (ierr /= 0) then
             if (s% report_ierr) write(*,2) 'ierr /= 0 for do_surf_momentum_eqn'
             return
-         end if         
+         end if
          call store_partials( &
             s, 1, s% i_dv_dt, nvar, d_dm1, d_d00, d_dp1, 'do_surf_momentum_eqn', ierr)
       end subroutine do_surf_momentum_eqn
 
-      
+
       subroutine do1_momentum_eqn(s, k, nvar, ierr)
          use star_utils, only: store_partials
          type (star_info), pointer :: s
@@ -77,7 +77,7 @@
          if (ierr /= 0) then
             if (s% report_ierr) write(*,2) 'ierr /= 0 for get1_momentum_eqn', k
             return
-         end if         
+         end if
          call store_partials( &
             s, k, s% i_dv_dt, nvar, d_dm1, d_d00, d_dp1, 'do1_momentum_eqn', ierr)
       end subroutine do1_momentum_eqn
@@ -96,14 +96,14 @@
          integer, intent(in) :: nvar
          real(dp), intent(out) :: d_dm1(nvar), d_d00(nvar), d_dp1(nvar)
          integer, intent(out) :: ierr
-         
+
          real(dp) :: residual, dm_face, dPtot, iPtotavg, dm_div_A
          real(dp), dimension(s% species) :: &
             d_dPtot_dxam1, d_dPtot_dxa00, d_iPtotavg_dxam1, d_iPtotavg_dxa00, &
             d_residual_dxam1, d_residual_dxa00
          integer :: nz, j, i_dv_dt, i_lum, i_v
          logical :: test_partials
-         
+
          type(auto_diff_real_star_order1) :: resid1_ad, resid_ad, &
             other_ad, dm_div_A_ad, grav_ad, area_ad, dPtot_ad, d_mlt_Pturb_ad, &
             iPtotavg_ad, other_dm_div_A_ad, grav_dm_div_A_ad, &
@@ -111,15 +111,15 @@
          type(accurate_auto_diff_real_star_order1) :: residual_sum_ad
 
          include 'formats'
-         
+
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-         
+
          ierr = 0
          call init
 
 !   dv/dt = - G*m/r^2 - (dPtot_ad + d_mlt_Pturb_ad)*area/dm + extra_grav + Uq + RTI_diffusion + RTI_kick
-! 
+!
 !   grav_ad = expected_HSE_grav_term = -G*m/r^2 with possible modifications for rotation
 !   other_ad = expected_non_HSE_term = extra_grav - dv/dt + Uq
 !   extra_grav is from the other_momentum hook
@@ -129,7 +129,7 @@
 !   d_mlt_Pturb_ad = difference in MLT convective pressure across face
 !   RTI_terms_ad = RTI_diffusion + RTI_kick
 !   dm_div_A_ad = dm/area
-! 
+!
 !   0  = extra_grav - dv/dt + Uq - G*m/r^2 - RTI_diffusion - RTI_kick - (dPtot_ad + d_mlt_Pturb_ad)*area/dm
 !   0  = other + grav - RTI_terms - (dPtot_ad + d_mlt_Pturb_ad)*area/dm
 !   0  = (other + grav - RTI_terms)*dm/area - dPtot_ad - d_mlt_Pturb_ad
@@ -140,27 +140,27 @@
          call setup_dPtot(ierr); if (ierr /= 0) return ! dPtot_ad, iPtotavg_ad
          call setup_d_mlt_Pturb(ierr); if (ierr /= 0) return ! d_mlt_Pturb_ad
          call setup_RTI_terms(ierr); if (ierr /= 0) return ! RTI_terms_ad
-         
+
          other_dm_div_A_ad = other_ad*dm_div_A_ad
          grav_dm_div_A_ad = grav_ad*dm_div_A_ad
          RTI_terms_dm_div_A_ad = RTI_terms_ad*dm_div_A_ad
-         
+
          ! sum terms in residual_sum_ad using accurate_auto_diff_real_star_order1
          residual_sum_ad = &
             other_dm_div_A_ad + grav_dm_div_A_ad - dPtot_ad - d_mlt_Pturb_ad + RTI_terms_dm_div_A_ad
-         
+
          resid1_ad = residual_sum_ad ! convert back to auto_diff_real_star_order1
          resid_ad = resid1_ad*iPtotavg_ad ! scaling
          residual = resid_ad%val
-         s% equ(i_dv_dt, k) = residual     
-         
+         s% equ(i_dv_dt, k) = residual
+
          !s% xtra1_array(k) = s% Peos(k)
          !s% xtra2_array(k) = 1d0/s% rho(k)
          !s% xtra3_array(k) = s% T(k)
          !s% xtra4_array(k) = s% v(k)
          !s% xtra5_array(k) = s% etrb(k)
          !s% xtra6_array(k) = s% r(k)
-         
+
          if (is_bad(residual)) then
 !$omp critical (hydro_momentum_crit1)
             write(*,2) 'momentum eqn residual', k, residual
@@ -177,9 +177,9 @@
             s% solver_test_partials_dval_dx = d_d00(s% solver_test_partials_var)
             write(*,*) 'get1_momentum_eqn', s% solver_test_partials_var
          end if
-         
+
          contains
-         
+
          subroutine init
             i_dv_dt = s% i_dv_dt
             i_lum = s% i_lum
@@ -204,7 +204,7 @@
             end if
             d_dm1 = 0d0; d_d00 = 0d0; d_dp1 = 0d0
          end subroutine init
-         
+
          subroutine setup_HSE(dm_div_A, ierr)
             real(dp), intent(out) :: dm_div_A
             integer, intent(out) :: ierr
@@ -215,7 +215,7 @@
             dm_div_A_ad = dm_face/area_ad
             dm_div_A = dm_div_A_ad%val
          end subroutine setup_HSE
-         
+
          subroutine setup_non_HSE(ierr)
             integer, intent(out) :: ierr
             real(dp) :: other
@@ -236,7 +236,7 @@
                iPtotavg_ad, iPtotavg, d_iPtotavg_dxam1, d_iPtotavg_dxa00, ierr)
             if (ierr /= 0) return
          end subroutine setup_dPtot
-                  
+
          subroutine setup_d_mlt_Pturb(ierr)
             use star_utils, only: get_rho_face
             integer, intent(out) :: ierr
@@ -250,8 +250,8 @@
             else
                d_mlt_Pturb_ad = 0d0
             end if
-         end subroutine setup_d_mlt_Pturb         
-                  
+         end subroutine setup_d_mlt_Pturb
+
          subroutine setup_RTI_terms(ierr)
             use auto_diff_support
             integer, intent(out) :: ierr
@@ -284,10 +284,10 @@
                dvdt_kick = f*(rho_00 - rho_m1)/s% dt ! change v according to direction of lower density
             else
                dvdt_kick = 0d0
-            end if            
-            RTI_terms_ad = dvdt_diffusion + dvdt_kick            
+            end if
+            RTI_terms_ad = dvdt_diffusion + dvdt_kick
          end subroutine setup_RTI_terms
-         
+
          subroutine unpack_res18(species, res18)
             use star_utils, only: save_eqn_dxa_partials, unpack_residual_partials
             integer, intent(in) :: species
@@ -296,14 +296,14 @@
             logical, parameter :: checking = .true.
             integer :: j
             include 'formats'
-            ! do partials wrt composition   
-            resid1 = resid1_ad%val         
+            ! do partials wrt composition
+            resid1 = resid1_ad%val
             do j=1,species
                d_residual_dxa00(j) = resid1*d_iPtotavg_dxa00(j) - iPtotavg*d_dPtot_dxa00(j)
                if (checking) call check_dequ(d_dPtot_dxa00(j),'d_dPtot_dxa00(j)')
                if (checking) call check_dequ(d_iPtotavg_dxa00(j),'d_iPtotavg_dxa00(j)')
             end do
-            if (k > 1) then 
+            if (k > 1) then
                do j=1,species
                   d_residual_dxam1(j) = resid1*d_iPtotavg_dxam1(j) - iPtotavg*d_dPtot_dxam1(j)
                   if (checking) call check_dequ(d_dPtot_dxam1(j),'d_dPtot_dxam1(j)')
@@ -311,7 +311,7 @@
                end do
             else
                d_residual_dxam1 = 0d0
-            end if            
+            end if
             dxap1 = 0d0
             call save_eqn_dxa_partials(&
                s, k, nvar, i_dv_dt, species, &
@@ -335,10 +335,10 @@
                return
             end if
          end subroutine check_dequ
-            
+
       end subroutine get1_momentum_eqn
-      
-      
+
+
       ! returns -G*m/r^2 with possible modifications for rotation.  MESA 2, eqn 22.
       subroutine expected_HSE_grav_term(s, k, grav, area, ierr)
          use star_utils, only: get_area_info_opt_time_center
@@ -346,13 +346,13 @@
          integer, intent(in) :: k
          type(auto_diff_real_star_order1), intent(out) :: area, grav
          integer, intent(out) :: ierr
-         
+
          type(auto_diff_real_star_order1) :: inv_R2
          logical :: test_partials
 
          include 'formats'
          ierr = 0
-         
+
          call get_area_info_opt_time_center(s, k, area, inv_R2, ierr)
          if (ierr /= 0) return
 
@@ -364,17 +364,17 @@
 
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-         
+
          if (test_partials) then
             s% solver_test_partials_val = 0
             s% solver_test_partials_var = 0
             s% solver_test_partials_dval_dx = 0
             write(*,*) 'expected_HSE_grav_term', s% solver_test_partials_var
          end if
-      
+
       end subroutine expected_HSE_grav_term
-      
-      
+
+
       ! other = s% extra_grav(k) - s% dv_dt(k)
       subroutine expected_non_HSE_term( &
             s, k, other_ad, other, accel_ad, Uq_ad, ierr)
@@ -395,17 +395,17 @@
          include 'formats'
 
          ierr = 0
-         
+
          extra_ad = 0d0
          if (s% use_other_momentum .or. s% use_other_momentum_implicit) then
             extra_ad = s% extra_grav(k)
          end if
-         
+
          accel_ad = 0d0
          drag = 0d0
          s% dvdt_drag(k) = 0d0
          if (s% v_flag) then
-            
+
             if (s% i_lnT == 0) then
                local_v_flag = .true.
             else
@@ -432,7 +432,7 @@
                drag = -s% drag_coefficient*v_00/s% dt
                s% dvdt_drag(k) = drag%val
             end if
-         
+
          end if ! v_flag
 
          Uq_ad = 0d0
@@ -440,20 +440,20 @@
             Uq_ad = compute_Uq_face(s, k, ierr)
             if (ierr /= 0) return
          end if
-         
+
          other_ad = extra_ad - accel_ad + drag + Uq_ad
          other = other_ad%val
-         
+
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-         
+
          if (test_partials) then
             s% solver_test_partials_val = 0
             s% solver_test_partials_var = 0
             s% solver_test_partials_dval_dx = 0d0
             write(*,*) 'expected_non_HSE_term', s% solver_test_partials_var
          end if
-        
+
       end subroutine expected_non_HSE_term
 
       ! dPtot = pressure difference across face from center to center of adjacent cells.
@@ -472,7 +472,7 @@
          real(dp), intent(out), dimension(s% species) :: &
             d_dPtot_dxam1, d_dPtot_dxa00, d_iPtotavg_dxam1, d_iPtotavg_dxa00
          integer, intent(out) :: ierr
-         
+
          real(dp) :: Ptotm1, Ptot00, Ptotavg, alfa, beta
          real(dp), dimension(s% species) :: &
             d_Ptotm1_dxam1, d_Ptot00_dxa00, d_Ptotavg_dxam1, d_Ptotavg_dxa00
@@ -485,12 +485,12 @@
          include 'formats'
 
          ierr = 0
-         
+
          call calc_Ptot_ad_tw( &
             s, k, skip_P, skip_mlt_Pturb, Ptot00_ad, d_Ptot00_dxa00, ierr)
          if (ierr /= 0) return
          Ptot00 = Ptot00_ad%val
-            
+
          if (k > 1) then
             call calc_Ptot_ad_tw( &
                s, k-1, skip_P, skip_mlt_Pturb, Ptotm1_ad, d_Ptotm1_dxam1, ierr)
@@ -500,10 +500,10 @@
             Ptotm1_ad = P_surf_ad
          end if
          Ptotm1 = Ptotm1_ad%val
-            
+
          dPtot_ad = Ptotm1_ad - Ptot00_ad
          dPtot = Ptotm1 - Ptot00
-         
+
          do j=1,s% species
             d_dPtot_dxam1(j) = d_Ptotm1_dxam1(j)
             d_dPtot_dxa00(j) = -d_Ptot00_dxa00(j)
@@ -512,7 +512,7 @@
          if (k == 1) then
             Ptotavg_ad = Ptot00_ad
             do j=1,s% species
-               d_Ptotavg_dxam1(j) = 0d0  
+               d_Ptotavg_dxam1(j) = 0d0
                d_Ptotavg_dxa00(j) = d_Ptot00_dxa00(j)
             end do
          else
@@ -525,11 +525,11 @@
             end do
          end if
          Ptotavg = Ptotavg_ad%val
-         
+
          iPtotavg_ad = 1d0/Ptotavg_ad
-         iPtotavg = 1d0/Ptotavg         
+         iPtotavg = 1d0/Ptotavg
          do j=1,s% species
-            d_iPtotavg_dxam1(j) = -iPtotavg*d_Ptotavg_dxam1(j)/Ptotavg   
+            d_iPtotavg_dxam1(j) = -iPtotavg*d_Ptotavg_dxam1(j)/Ptotavg
             d_iPtotavg_dxa00(j) = -iPtotavg*d_Ptotavg_dxa00(j)/Ptotavg
          end do
 
@@ -542,8 +542,8 @@
             s% solver_test_partials_dval_dx = 0d0
             write(*,*) 'get_dPtot_face_info', s% solver_test_partials_var
          end if
-        
-      end subroutine get_dPtot_face_info      
+
+      end subroutine get_dPtot_face_info
 
 
       subroutine do1_radius_eqn(s, k, nvar, ierr)
@@ -559,12 +559,13 @@
          include 'formats'
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
-         ierr = 0         
+         ierr = 0
          if (.not. (s% u_flag .or. s% v_flag)) call mesa_error(__FILE__,__LINE__,'must have either v or u for do1_radius_eqn')
-         
+
          force_zero_v = (s% q(k) > s% velocity_q_upper_bound) .or. &
+            (s% tau(k) < s% velocity_tau_lower_bound) .or. &
             (s% lnT_start(k)/ln10 < s% velocity_logT_lower_bound .and. &
-               s% dt < secyer*s% max_dt_yrs_for_velocity_logT_lower_bound)                  
+               s% dt < secyer*s% max_dt_yrs_for_velocity_logT_lower_bound)
          if (force_zero_v) then
             if (s% u_flag) then
                v00 = wrap_u_00(s,k)
@@ -573,10 +574,10 @@
             end if
             resid_ad = v00/s% csound_start(k)
             call save_eqn_residual_info( &
-               s, k, nvar, s% i_dlnR_dt, resid_ad, 'do1_radius_eqn', ierr)           
+               s, k, nvar, s% i_dlnR_dt, resid_ad, 'do1_radius_eqn', ierr)
             return
          end if
-                  
+
          ! dr = r - r0 = v00*dt
          ! eqn: dr/r0 = v00*dt/r0
          ! (r - r0)/r0 = r/r0 - 1 = exp(lnR)/exp(lnR0) - 1
@@ -584,19 +585,19 @@
          ! eqn becomes: v00*dt/r0 = expm1(dlnR)
          dxh_lnR = wrap_dxh_lnR(s,k) ! lnR - lnR_start
          dr_div_r0_actual = expm1(dxh_lnR) ! expm1(x) = E^x - 1
-         
+
          v00 = wrap_opt_time_center_v_00(s,k)
          dr_div_r0_expected = v00*s% dt/s% r_start(k)
          resid_ad = dr_div_r0_expected - dr_div_r0_actual
-         
+
          s% equ(s% i_dlnR_dt, k) = resid_ad%val
-         
+
          if (test_partials) then
             s% solver_test_partials_val = 0
          end if
          call save_eqn_residual_info( &
-            s, k, nvar, s% i_dlnR_dt, resid_ad, 'do1_radius_eqn', ierr)           
-         if (test_partials) then   
+            s, k, nvar, s% i_dlnR_dt, resid_ad, 'do1_radius_eqn', ierr)
+         if (test_partials) then
             s% solver_test_partials_var = 0
             s% solver_test_partials_dval_dx = 0
             write(*,*) 'do1_radius_eqn', s% solver_test_partials_var
@@ -605,4 +606,3 @@
 
 
       end module hydro_momentum
-

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -64,7 +64,7 @@
 
          real(dp) :: star_mass_min_limit, star_mass_max_limit
          real(dp) :: remnant_mass_min_limit, ejecta_mass_max_limit
-         
+
          real(dp) :: star_species_mass_min_limit, star_species_mass_max_limit
          character (len=iso_name_length) :: &
             star_species_mass_min_limit_iso, star_species_mass_max_limit_iso
@@ -136,7 +136,7 @@
          real(dp) :: Lnuc_div_L_upper_limit, Lnuc_div_L_lower_limit
          real(dp) :: v_surf_div_v_kh_upper_limit, v_surf_div_v_kh_lower_limit
          real(dp) :: v_surf_div_v_esc_limit, Lnuc_div_L_zams_limit, v_surf_kms_limit
-         logical :: stop_near_zams, stop_at_phase_PreMS, & 
+         logical :: stop_near_zams, stop_at_phase_PreMS, &
             stop_at_phase_ZAMS, stop_at_phase_IAMS, stop_at_phase_TAMS, &
             stop_at_phase_He_Burn, stop_at_phase_ZACHeB, stop_at_phase_TACHeB, &
             stop_at_phase_TP_AGB, stop_at_phase_C_Burn, stop_at_phase_Ne_Burn, &
@@ -288,9 +288,9 @@
 
          real(dp) :: mlt_gradT_fraction, max_logT_for_mlt
 
-    
-            
-         
+
+
+
          logical :: use_superad_reduction
          real(dp) :: &
             superad_reduction_Gamma_limit, &
@@ -302,10 +302,10 @@
       ! mixing parameters
 
          real(dp) :: min_overshoot_q, overshoot_alpha
-         
+
          real(dp) :: burn_z_mix_region_logT, burn_he_mix_region_logT, burn_h_mix_region_logT
          real(dp) :: max_Y_for_burn_z_mix_region, max_X_for_burn_he_mix_region
-         
+
          logical :: limit_overshoot_Hp_using_size_of_convection_zone
 
          logical        :: predictive_mix(NUM_PREDICTIVE_PARAM_SETS)
@@ -337,7 +337,7 @@
          character(256) :: overshoot_bdy_loc(NUM_OVERSHOOT_PARAM_SETS)
          character(256) :: overshoot_scheme(NUM_OVERSHOOT_PARAM_SETS)
          real(dp)       :: overshoot_D_min
-         real(dp)       :: overshoot_brunt_B_max   
+         real(dp)       :: overshoot_brunt_B_max
 
          logical :: RSP_write_map, RSP_report_limit_dt, &
             use_other_RSP_linear_analysis, RSP_testing, RSP_use_Prad_for_Psurf, RSP_use_atm_grey_with_kap_for_Psurf, &
@@ -366,7 +366,7 @@
             RSP_kap_density_factor, RSP_T_anchor_tolerance, RSP_T_inner_tolerance, RSP_relax_dm_tolerance, &
             RSP_max_dt_times_min_rad_diff_time, RSP_Qvisc_linear_static, RSP_dq_1_factor, &
             RSP_surface_tau
-         
+
          real(dp) :: &
             max_conv_vel_div_csound, &
             max_v_for_convection, max_q_for_convection_with_hydro_on, &
@@ -421,7 +421,7 @@
          real(dp) :: fixed_vsurf
          logical :: use_fixed_Psurf_outer_BC
          real(dp) :: fixed_Psurf
-         
+
          real(dp) :: Tsurf_factor
 
       ! create atmosphere
@@ -450,7 +450,7 @@
          real(dp) :: mdot_omega_power, max_rotational_mdot_boost, lim_trace_rotational_mdot_boost, &
             rotational_mdot_boost_fac, rotational_mdot_kh_fac, surf_avg_tau, surf_avg_tau_min, &
             max_mdot_jump_for_rotation
-         
+
          integer :: max_tries_for_implicit_wind
          real(dp) :: iwind_tolerance, iwind_lambda
 
@@ -631,7 +631,7 @@
          real(dp) :: mesh_dlog_pnhe4_dlogP_extra
          real(dp) :: mesh_dlog_photo_dlogP_extra
          real(dp) :: mesh_dlog_other_dlogP_extra
-         
+
          integer :: mesh_delta_coeff_factor_smooth_iters
 
          real(dp) :: P_function_weight, E_function_weight, E_function_param
@@ -663,7 +663,7 @@
          real(dp) :: xa_function_weight(num_xa_function)
          real(dp) :: xa_function_param(num_xa_function)
          real(dp) :: xa_mesh_delta_coeff(num_xa_function)
-         
+
          logical :: use_split_merge_amr, trace_split_merge_amr, &
             equal_split_density_amr, &
             split_merge_amr_hybrid_zoning, &
@@ -693,7 +693,7 @@
 
          real(dp) :: reaction_neuQs_factor, nonlocal_NiCo_kap_gamma, &
             dtau_gamma_NiCo_decay_heat, max_logT_for_net
-         
+
          logical :: nonlocal_NiCo_decay_heat
 
          real(dp) :: weak_rate_factor, mix_factor, dxdt_nuc_factor, &
@@ -748,7 +748,7 @@
          real(dp) :: diffusion_T_full_on
          real(dp) :: diffusion_T_full_off
          real(dp) :: D_mix_ignore_diffusion
-         
+
          real(dp) :: D_mix_zero_region_bottom_q, D_mix_zero_region_top_q, &
             dq_D_mix_zero_at_H_He_crossover, dq_D_mix_zero_at_H_C_crossover
 
@@ -830,6 +830,7 @@
             L_theta_for_velocity_time_centering
          integer :: steps_before_use_velocity_time_centering
 
+         logical :: use_drag_energy
          real(dp) :: &
             drag_coefficient, &
             min_q_for_drag
@@ -845,7 +846,8 @@
 
          logical :: include_composition_in_eps_grav
          real(dp) :: velocity_logT_lower_bound, &
-            max_dt_yrs_for_velocity_logT_lower_bound, velocity_q_upper_bound
+            max_dt_yrs_for_velocity_logT_lower_bound, velocity_tau_lower_bound, &
+            velocity_q_upper_bound
          real(dp) :: Gamma_lnS_eps_grav_full_on, Gamma_lnS_eps_grav_full_off
          integer :: max_num_surf_revisions
          real(dp) :: max_abs_rel_change_surf_lnS
@@ -856,14 +858,14 @@
 
          logical :: include_L_in_correction_limits, &
             include_v_in_correction_limits, include_u_in_correction_limits
-         
+
          real(dp) :: max_X_for_conv_timescale, min_X_for_conv_timescale
          real(dp) :: max_q_for_conv_timescale, min_q_for_conv_timescale
          real(dp) :: max_q_for_QHSE_timescale, min_q_for_QHSE_timescale
 
          logical :: use_DGESVX_in_bcyclic, use_equilibration_in_DGESVX
          logical :: report_min_rcond_from_DGESXV
-         
+
          logical :: do_normalize_dqs_as_part_of_set_qs
 
          logical :: trace_solver_damping
@@ -881,7 +883,7 @@
          real(dp) :: tol_residual_norm1, tol_max_residual1
          real(dp) :: tol_residual_norm2, tol_max_residual2
          real(dp) :: tol_residual_norm3, tol_max_residual3
-         
+
          real(dp) :: warning_limit_for_max_residual
 
          logical :: relax_use_gold_tolerances
@@ -893,10 +895,10 @@
          integer :: &
             relax_solver_iters_timestep_limit, &
             relax_iter_for_resid_tol2, relax_iter_for_resid_tol3
-         
+
          integer :: steps_before_start_stress_test
          logical :: stress_test_relax
-         
+
          logical :: use_gold_tolerances
          integer :: &
             gold_solver_iters_timestep_limit, &
@@ -911,7 +913,7 @@
             gold_tol_max_residual2, &
             gold_tol_residual_norm3, &
             gold_tol_max_residual3
-         
+
          logical :: use_gold2_tolerances
          integer :: &
             gold2_solver_iters_timestep_limit, &
@@ -1027,10 +1029,10 @@
 
          real(dp) :: D_mix_rotation_max_logT_full_on, &
             D_mix_rotation_min_logT_full_off
-         
+
          real(dp) :: D_omega_mixing_rate, max_q_for_D_omega_zero_in_convection_region
          logical :: D_omega_mixing_across_convection_boundary
-         
+
          real(dp) :: nu_omega_mixing_rate, max_q_for_nu_omega_zero_in_convection_region
          logical :: nu_omega_mixing_across_convection_boundary
 
@@ -1063,26 +1065,26 @@
 
          logical :: solver_show_correction_info
          real(dp) :: solver_epsder_chem, solver_epsder_struct
-         
+
          logical :: fill_arrays_with_NaNs
          logical :: zero_when_allocate, warn_when_get_a_bad_eos_result, &
             warn_rates_for_high_temp, absolute_cumulative_energy_err
          real(dp) :: warn_when_large_rel_run_E_err, &
             warn_when_large_virial_thm_rel_err, max_safe_logT_for_rates, &
             eps_mdot_leak_frac_factor
-            
+
          logical :: stop_for_bad_nums
          integer :: diffusion_dump_call_number, energy_conservation_dump_model_number
 
       ! WD phase separation
-         
+
          logical :: do_phase_separation
          logical :: do_phase_separation_heating
          logical :: phase_separation_mixing_use_brunt
          character (len=32) :: phase_separation_option
 
       ! timestep parameters
-      
+
          real(dp) :: time_delta_coeff ! like mesh_delta_coeff
 
          real(dp) :: max_timestep
@@ -1100,7 +1102,7 @@
 
          real(dp) :: timestep_dt_factor
          logical :: use_dt_low_pass_controller
-         
+
          real(dp) :: force_timestep_min, force_timestep_min_years, force_timestep_min_factor, &
             force_timestep, force_timestep_years
 
@@ -1183,7 +1185,7 @@
          real(dp) :: delta_lgL_nuc_at_high_T_limit_lgT_min
          real(dp) :: max_lgT_for_lgL_nuc_limit
          real(dp) :: lgL_nuc_burn_min, lgL_nuc_drop_factor
-         
+
          real(dp) :: delta_lgL_power_photo_limit = -1
          real(dp) :: delta_lgL_power_photo_hard_limit = -1
          real(dp) :: min_lgT_for_lgL_power_photo_limit = 9d0
@@ -1228,7 +1230,7 @@
 
          real(dp) :: delta_log_eps_nuc_limit
          real(dp) :: delta_log_eps_nuc_hard_limit
-         
+
          logical :: delta_dX_div_X_drop_only
          logical :: delta_lg_XH_drop_only
          logical :: delta_lg_XHe_drop_only
@@ -1323,7 +1325,7 @@
 
          character (len=strlen) :: zams_filename
          logical :: set_rho_to_dm_div_dV
-         
+
          logical :: fix_d_eos_dxa_partials
 
          logical :: use_other_surface_PT


### PR DESCRIPTION
Implements:
1. `use_drag_energy`: boolean to consider the work done by the drag force in the energy equation (default) or not (in which case the drag force only applies to the momentum equation and its work is not calculated in the energy equation). This may be useful since the kinetic energy "appearing" in the models may be a purely numerical artifact, and we don't necessarily want to consider it as a physical source of energy.

2. `velocity_tau_lower_bound`, real upper limit to where velocities are considered, similar to `velocity_q_upper_bound` but hopefully more easy to generalize across different pre-SN stars. Note that when implementing this by hand in `run_star_extras.f90`, even setting very large values (i.e., upper mass coordinate for `v_flag` far inside the photosphere in `tau`-space), I couldn't remove the impact of the velocity spike on L,T_eff.

Tested that MESA compiles and runs with minor modifications to the inlists of `12M_pre_ms_to_core_collapse`.
See also individual commits for more details.