### PR TITLE
Try to prevent core dump if mesh grows larger than `max_allowed_nz`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,7 +24,8 @@ New Features
 Bug Fixes
 ---------
 
-
+MESA no longer produces a segmentation fault if it tries to increase
+the number of cells beyond ``max_allowed_nz``.
 
 
 Changes in r24.03.1

--- a/star/private/adjust_mesh.f90
+++ b/star/private/adjust_mesh.f90
@@ -141,18 +141,6 @@
 
          s% mesh_call_number = s% mesh_call_number + 1
 
-         if (.not. associated(s% other_star_info)) then
-            allocate(s% other_star_info)
-            prv => s% other_star_info
-            c => null()
-         else
-            prv => s% other_star_info
-            c => copy_info
-            c = prv
-         end if
-
-         prv = s ! this makes copies of pointers and scalars
-
          sum_L_other = 0
          sum_L_other_limit = Lsun
          do j=1,num_categories
@@ -319,10 +307,22 @@
             call dealloc
             return
          end if
-         
+
          nz = nz_new
          s% nz = nz
          nvar = s% nvar_total
+
+         if (.not. associated(s% other_star_info)) then
+            allocate(s% other_star_info)
+            prv => s% other_star_info
+            c => null()
+         else
+            prv => s% other_star_info
+            c => copy_info
+            c = prv
+         end if
+
+         prv = s ! this makes copies of pointers and scalars
 
          if (dbg_remesh .or. dbg) write(*,*) 'call resize_star_info_arrays'
          call resize_star_info_arrays(s, c, ierr)


### PR DESCRIPTION
#621 reports a segfault/core dump if MESA tries to exceed the maximum allowed number of mesh points `max_allowed_nz`. I won't pretend I fully understand why this happens but here's a partial diagnosis and a fix that appears to work.

To trigger the basic issue, copy a standard work folder and add/change the following controls:
```
&star_job
    ...
    create_pre_main_sequence_model = .false.
    ...
/

&controls
    ...
    max_allowed_nz = 100
    stop_near_zams = .false.
    ...
/
```
This should immediately crash with a backtrace (on Linux) that contains:
```
Backtrace for this error:
...
#13  0x4bbc67 in __alloc_MOD_star_info_arrays
	at ../private/alloc.f90:512
#14  0x4c27d0 in __alloc_MOD_free_arrays
	at ../private/alloc.f90:281
#15  0x4c28a4 in __alloc_MOD_free_star_data
	at ../private/alloc.f90:235
...
```
I think the key offending line is `star/private/alloc.f90:281`,

https://github.com/MESAHub/mesa/blob/244c62924ce020ccda78ec31225d786fc4a51ad6/star/private/alloc.f90#L277-L285

which appears to empty and deallocate various arrays in the star pointer `s% other_star_info`. It's not clear to me why this fails but I noticed that it's allocated in `adjust_mesh.f90`¹:

https://github.com/MESAHub/mesa/blob/244c62924ce020ccda78ec31225d786fc4a51ad6/star/private/adjust_mesh.f90#L144-L152

which is quite a while before we actually try to use any of these pointers, and notably before the call to `do_mesh_plan`, which is where the restriction `max_allowed_nz` is enforced.

The "solution" in this PR is to move the allocated to *after* the call to `do_mesh_plan`, just before the pointers are used for the first time. I don't really understand how `other_star_info` is being misused but this does seem to work: the case above fails and quits without the core dump.

It might be possible to implement a simple test case for this, which would take ~10s or something to run. It also remains to experiment with whether with should allow `max_allowed_nz = -1` to place no limit on the mesh size but I plan to resolve that separately from fixing this core dump.

¹ Not to be confused with `mesh_adjust.f90`...