### PR TITLE
Thermohaline hackathon: speeding up FRG24 implementation

### DIFF
--- a/turb/plotter/inlist_plotter
+++ b/turb/plotter/inlist_plotter
@@ -15,6 +15,7 @@
 
   ! whether or not to include T&C terms for extended matrix of FRG24 model
   FRG_withTC = .true.
+  safety = 3  ! balance between accuracy and speed for FRG24 model, safety=0 is less accurate but faster, safety=3 (max) is accurate but slow
 
   !! Parameters for thermohaline calculations
   

--- a/turb/plotter/src/turb_plotter.f90
+++ b/turb/plotter/src/turb_plotter.f90
@@ -10,7 +10,7 @@ program turb_plotter
   integer :: ierr, op_err
   character (len=32) :: my_mesa_dir
 
-  integer               :: nR0, nks, j, jmax, spectral_resolution
+  integer               :: nR0, nks, j, jmax, spectral_resolution, safety
   real(dp), allocatable :: ks(:), res(:,:)
   real(dp)              :: tau, Pr, Pm, HB1, HB2, DB, R0
   real(dp)              :: HB(3)
@@ -20,7 +20,7 @@ program turb_plotter
   real(dp), parameter :: UNSET = -999
   
   namelist /plotter/ &
-       tau, Pr, Pm, HB1, HB2, nR0, nks, spectral_resolution, FRG_withTC
+       tau, Pr, Pm, HB1, HB2, nR0, nks, spectral_resolution, FRG_withTC, safety
 
   include 'formats'
 
@@ -134,7 +134,7 @@ contains
 
      ! Now calculate again for full FRG24 model (adds in Pm dependence)
      do i = 1,3
-        call calc_frg24_w(Pr, tau, R0, HB(i), DB, ks, spectral_resolution, w, FRG_withTC, ierr, lamhat, l2hat)
+        call calc_frg24_w(Pr, tau, R0, HB(i), DB, ks, spectral_resolution, w, FRG_withTC, safety, ierr, lamhat, l2hat)
         if (ierr /= 0) then
            write(*,*) 'calc_frg24_w failed'
            write(*,*) 'R0', R0

--- a/turb/private/kh_instability.f90
+++ b/turb/private/kh_instability.f90
@@ -288,7 +288,7 @@ module kh_instability
 
       do m = -n, n
          ! Set up block indices
-         i_p = 4*(m + n)
+         i_p = 4*(m + n) + 1
          i_p_p = i_p + 4
          i_p_m = i_p - 4
 

--- a/turb/private/kh_instability.f90
+++ b/turb/private/kh_instability.f90
@@ -854,7 +854,7 @@ module kh_instability
       ! first, set up the 0th row, corresponding to C_0
       l(1, 1) = -tau * pow2(k_z)
       l(1, 2) = l_f * k_z * E_C
-      l(1, 4) = -j_imag * l_f * k_z * E_psi
+      l(1, 3) = -j_imag * l_f * k_z * E_psi
 
       ! next, the psi_1- row
       k2_1 = pow2(l_f) + pow2(k_z)

--- a/turb/private/kh_instability.f90
+++ b/turb/private/kh_instability.f90
@@ -1160,6 +1160,8 @@ module kh_instability
       elseif (safety == 3) then
          allocate(l_result_a(2*n, 2*n))
          ! and no need to allocate l_result_b: we can just reuse this array
+      elseif (safety == 4) then
+         allocate(l_result_a(4*n, 4*n))
       end if  ! TODO: there should be an "ELSE" statement here raising an error if safety isn't one of these values
 
 
@@ -1192,6 +1194,9 @@ module kh_instability
             call lmat_block_b(n_Sam, kz, R0, pr, tau, lhat, A_Psi, A_T, A_C, hb, db, l_result_a)
             gam_b = gamfromL(l_result_a, 2*n, .true.)
             gamk(i) = MAX(gam_a, gam_b)
+         elseif (safety == 4) then
+            call sams_lmat(n_Sam, 0d0, lhat, kz, A_Psi, A_T, A_C, pr, tau, R0, pr/db, hb, l_result_a)
+            gamk(i) = gamfromL(l_result_a,4*n,.true.)
          end if
          ! ! sams_lmat has dimension (2*n_sam+1)*4 = 4*n
          ! ! call sams_lmat(n_Sam, 0d0, lhat, kz, A_Psi, A_T, A_C, pr, tau, R0, pr/db, hb, l_result)

--- a/turb/private/kh_instability.f90
+++ b/turb/private/kh_instability.f90
@@ -702,7 +702,7 @@ module kh_instability
       ! to remove the T equation
       integer, intent(in)      :: n
       real(dp), intent(in)     :: k_z, R0, Pr, tau, l_f, E_psi, E_C, HB, DB
-      complex(dp), intent(out) :: l(3*n + 2,3*n + 2)
+      complex(dp), intent(out) :: l(3*n + 2, 3*n + 2)
   
       integer  :: m, j, dim, i_p, i_p_p, i_p_m, &
                   i_c, i_c_p, i_c_m, i_a, i_a_p, i_a_m
@@ -771,7 +771,7 @@ module kh_instability
       if (n > 1) then
          do m = 2, n
             ! Set up block indices
-            i_p = 3*m - 1
+            i_p = 3*m
             i_p_p = i_p + 3
             i_p_m = i_p - 3
 
@@ -835,7 +835,7 @@ module kh_instability
       ! to remove the T equation
       integer, intent(in)      :: n
       real(dp), intent(in)     :: k_z, R0, Pr, tau, l_f, E_psi, E_C, HB, DB
-      complex(dp), intent(out) :: l(3*n + 1,3*n + 1)
+      complex(dp), intent(out) :: l(3*n + 1, 3*n + 1)
   
       integer  :: m, j, dim, i_p, i_p_p, i_p_m, &
                   i_c, i_c_p, i_c_m, i_a, i_a_p, i_a_m

--- a/turb/private/parasite_model.f90
+++ b/turb/private/parasite_model.f90
@@ -143,6 +143,7 @@ module parasite_model
       !  would require knowing a priori what constitutes "large R0")
       ! safety = 2: low-tau limit
       ! safety = 3 (max): use full model (I don't think this option will ever be needed since tau is always tiny)
+      ! safety = 4 (actual max for now while debugging): use the original implementation; gives same answers as safety=3 but needlessly slower
   
       real(dp), intent(in) :: pr, tau, r0, hb, db 
       real(dp), intent(in) :: ks(:)

--- a/turb/private/parasite_model.f90
+++ b/turb/private/parasite_model.f90
@@ -20,7 +20,7 @@ module parasite_model
    ! Adrian said we can get rid of ideal, badks_exception, delta. 
    ! delta = Floquet wavenumber. delta = 0 means we are doing the analyisis for just one finger (n=1). For n > 1, delta = 1/n (e.g. 1/2 for 2 fingers). 
    ! Adrian says for most (all) cases delta = 0 is enough. We're keeping it there in case this turns out to be false in some edge case. 
-   ! For now ideal = 1 or 0. Ideal = 1 means ideal gas. Be sure it is an integer, not logical 
+   ! For now ideal = 1 or 0. Ideal = 1 means ideal MHD (zero resistivity or viscosity). Be sure it is an integer, not logical 
    ! badks_exception true should throw a warning telling the kz search domain does not contain sigma_max, so the search didn't complete. Changed that in kh_instability.
    ! Note we will need to decide what MESA should use as input for ks (the grid of kz values over which we do the search). Need to be robust
 
@@ -134,13 +134,19 @@ module parasite_model
   
     end function wf
 
-    function wf_withTC(pr, tau, r0, hb, db, ks, n, get_kmax, lamhat, l2hat) result(w)
+    function wf_withTC(pr, tau, r0, hb, db, ks, n, get_kmax, safety, lamhat, l2hat) result(w)
 
       ! Root finding for wf
+      ! safety = 0: Low-tau limit, low-Rm limit, ditch "block a" (which has the ordinary KH mode), use HG19 away from large R0
+      ! safety = 1: low-tau limit, uses low-Rm limit for "block b", still calculates "block a"
+      ! (I wonder if there's a middle ground here that's basically safety=2 but we use HG19 away from large R0?
+      !  would require knowing a priori what constitutes "large R0")
+      ! safety = 2: low-tau limit
+      ! safety = 3 (max): use full model (I don't think this option will ever be needed since tau is always tiny)
   
       real(dp), intent(in) :: pr, tau, r0, hb, db 
       real(dp), intent(in) :: ks(:)
-      integer, intent(in) :: n ! n MUST be odd
+      integer, intent(in) :: n, safety ! n MUST be odd
       logical, intent(in) :: get_kmax
       real(dp), intent(in), optional :: lamhat, l2hat
       real(dp) :: w
@@ -171,17 +177,17 @@ module parasite_model
       lhat = sqrt(l2hat_)
   
       ! Set bracketing interval
-      w1 = 2.0_dp*pi*lamhat_/lhat
-      w2 = w1 + sqrt(2.0_dp*hb)
+      w1 = 2.0_dp*pi*lamhat_/lhat  ! this is the BGS13 solution
+      w2 = w1 + sqrt(2.0_dp*hb)  ! this is the HG19 solution for large HB. I wonder if we should use the actual HG19 solution
 
       lrpar = 8 + size(ks)
-      lipar = 1
+      lipar = 2
       allocate(rpar(lrpar))
       allocate(ipar(lipar))
       
       ! Arguments to pass
       rpar = [lamhat_, lhat, hb, pr, tau, r0, db, C2, ks]
-      ipar = [n]
+      ipar = [n, safety]
       dfdx = 0d0 ! unused for bracket search
       
       y1 = gx_m_lam_withTC(w1, dfdx, lrpar, rpar, lipar, ipar, ierr)
@@ -204,7 +210,8 @@ module parasite_model
          y2 = y1
          
          w1 = w1/10d0
-         y1 = gx_m_lam(w1, dfdx, lrpar, rpar, lipar, ipar, ierr)
+         ! y1 = gx_m_lam(w1, dfdx, lrpar, rpar, lipar, ipar, ierr)  ! TODO: shouldn't this be gx_m_lam_withTC?
+         y1 = gx_m_lam_withTC(w1, dfdx, lrpar, rpar, lipar, ipar, ierr)
       end do
       
       i = 0
@@ -234,7 +241,7 @@ module parasite_model
       ! needs more work on gammax_kscan
       if (get_kmax) then
          call khparams_from_fingering(w, lhat, hb, pr, db, hb_star, re, rm)
-         gammax = gammax_kscan_withTC(w, hb, db, pr, tau, R0, lamhat, lhat, ks, n, .false.)
+         gammax = gammax_kscan_withTC(w, hb, db, pr, tau, R0, lamhat, lhat, ks, n, .false., safety)
       end if
 
       deallocate(rpar)
@@ -297,7 +304,7 @@ module parasite_model
 
       dfdx = 0d0 ! unused for bracket search
       
-      if (lipar /= 1) then
+      if (lipar /= 2) then
          ierr = -1
          write(*,*) "lrpar, lipar", lrpar, lipar
          stop "wrong number of parameters for bracketed root solve"
@@ -314,9 +321,10 @@ module parasite_model
            db => rpar(7), &
            C2 => rpar(8), &
            ks => rpar(9:), & 
-           n => ipar(1))
+           n => ipar(1), &
+           safety => ipar(2))
 
-        f = gammax_minus_lambda_withTC(w, lamhat, lhat, hb, pr, tau, r0, db, ks, n, .false.)
+        f = gammax_minus_lambda_withTC(w, lamhat, lhat, hb, pr, tau, r0, db, ks, n, .false., safety)
       end associate
 
       ierr = 0

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -115,6 +115,7 @@ module turb
 
    subroutine calc_frg24_w(pr, tau, r0, hb, db, ks, n, w, withTC, safety, ierr, lamhat, l2hat)
      use parasite_model
+     use thermohaline, only: solve_hg19_eqn32
 
      real(dp), intent(in) :: pr, tau, r0, hb, db 
      real(dp), intent(in) :: ks(:)
@@ -130,13 +131,22 @@ module turb
      if (present(lamhat)) then
         ! lamhat and l2hat already calculated, so can pass as arguments
         if(withTC) then
-           w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety, lamhat, l2hat)
+           if (safety == 0) then
+             ! TODO: is it bad for this minimization to be occurring here AND in thermohaline.f90?
+             call solve_hg19_eqn32(hb, l2hat, lamhat, w, ierr)
+             w = MIN(w, wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety, lamhat, l2hat))
+           else
+             w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety, lamhat, l2hat)
+           end if
         else
            w = wf(pr, tau, r0, hb, db, ks, n, 0d0, 0, .false., .false., lamhat, l2hat)
         end if
      else
         ! lamhat and l2hat need to be calculated inside the wf routine
         if(withTC) then
+           if (safety == 0) then
+            stop "In turb.f90 calc_frg24_w, have not yet implemented safety=0 for case where lamhat, l2hat not already calculated"
+           end if
            w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety)
         else
            w = wf(pr, tau, r0, hb, db, ks, n, 0d0, 0, .false., .false.)

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -144,7 +144,7 @@ module turb
      else
         ! lamhat and l2hat need to be calculated inside the wf routine
         if(withTC) then
-           if (safety == 0) then
+           if (safety == 0) then  ! TODO: fix this
             stop "In turb.f90 calc_frg24_w, have not yet implemented safety=0 for case where lamhat, l2hat not already calculated"
            end if
            w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety)

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -113,12 +113,12 @@ module turb
      
    end subroutine calc_hg19_w
 
-   subroutine calc_frg24_w(pr, tau, r0, hb, db, ks, n, w, withTC, ierr, lamhat, l2hat)
+   subroutine calc_frg24_w(pr, tau, r0, hb, db, ks, n, w, withTC, safety, ierr, lamhat, l2hat)
      use parasite_model
 
      real(dp), intent(in) :: pr, tau, r0, hb, db 
      real(dp), intent(in) :: ks(:)
-     integer, intent(in) :: n ! n MUST be odd
+     integer, intent(in) :: n, safety ! n MUST be odd
      real(dp), intent(out) :: w
      logical, intent(in) :: withTC
      integer, intent(out) :: ierr
@@ -130,14 +130,14 @@ module turb
      if (present(lamhat)) then
         ! lamhat and l2hat already calculated, so can pass as arguments
         if(withTC) then
-           w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., lamhat, l2hat)
+           w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety, lamhat, l2hat)
         else
            w = wf(pr, tau, r0, hb, db, ks, n, 0d0, 0, .false., .false., lamhat, l2hat)
         end if
      else
         ! lamhat and l2hat need to be calculated inside the wf routine
         if(withTC) then
-           w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false.)
+           w = wf_withTC(pr, tau, r0, hb, db, ks, n, .false., safety)
         else
            w = wf(pr, tau, r0, hb, db, ks, n, 0d0, 0, .false., .false.)
         end if


### PR DESCRIPTION
The FRG24 model for MHD thermohaline mixing, as currently implemented in the `thermohaline_hackathon` feature branch, is very slow (as pointed out by @evbauer in https://github.com/MESAHub/mesa/commit/d453d85031523d23698559e878bce5ea19de5001 in the context of #605). [I've TeXed up some notes](https://github.com/MESAHub/mesa/files/14658133/FRG24_MESA_speedup_summary.pdf) (TL;DR on page 2) on different ways to speed up the model---some with zero loss in accuracy, some with negligible loss in accuracy, and some with a loss in accuracy that is a factor of a few (but still more accurate than HG19 or the other models currently implemented). This draft PR covers these different speedups. Broadly speaking, they involve a change of basis that block-diagonalizes the matrix we're dealing with, asymptotic reductions of the equations, and reliance on HG19 where appropriate.

Some speedups this doesn't cover, but are worth exploring down the road if needed:

- The matrix whose eigenvalues we seek is very sparse, so ARPACK-NG's associated sparse methods are likely to be much faster than the currently-implemented LAPACK calls, especially in cases where the matrix size needs to be large. An example where I've tested this in the python implementation can be [seen here](https://github.com/afraser3/problems-with-parasites/blob/6684dc7f537938b62c35c25f3cab8311dcc7b627/python/kolmogorov_EVP.py#L814) (note that scipy.sparse is just a wrapper around ARPACK-NG, just as numpy.linalg is to LAPACK as I understand).
- Right now we're just sweeping over a bunch of k_z's when trying to maximize sigma vs k_z, and we're sort of shooting in the dark. Empirically, the peak always seems to fall between k_z/l_f = 10^-5 and 1, but that's a huge range! It should be possible to get at least an order-of-magnitude estimate of where the peak lies by using perturbative matrix methods (as in [this paper](https://doi.org/10.1080/03091929.2023.2268817)).
- In general, reducing the number of Fourier modes N or the density of k_z points scanned will directly speed things up at the cost of accuracy.
- Manipulating the matrix to have real-valued coefficients, which Rich has done in the past (Pascale has too, for a similar problem), would let us use DGEEV instead of ZGEEV. Presumably that's faster, but I don't know by how much.