### PR TITLE
fix/test pgbinary crashing in single star mode

### DIFF
--- a/binary/defaults/pgbinary.defaults
+++ b/binary/defaults/pgbinary.defaults
@@ -2971,11 +2971,11 @@
    Orbit_title = 'Orbit'
    Orbit_txt_scale_factor = 1.0
 
-      ! show the roche lobe sizes
+      ! show the star sizes
 
       ! ::
 
-   Orbit_show_RL = .true.
+   Orbit_show_stars = .true.
 
       ! file output
 

--- a/binary/private/pgbinary_ctrls_io.f90
+++ b/binary/private/pgbinary_ctrls_io.f90
@@ -1332,7 +1332,7 @@ module pgbinary_ctrls_io
       Orbit_file_width, &
       Orbit_file_aspect_ratio, &
       Orbit_txt_scale_factor, &
-      Orbit_show_RL, &
+      Orbit_show_stars, &
 
       annotation1_ci, &
       annotation1_ch, &
@@ -2806,7 +2806,7 @@ contains
       pg% Orbit_file_width = Orbit_file_width
       pg% Orbit_file_aspect_ratio = Orbit_file_aspect_ratio
       pg% Orbit_txt_scale_factor = Orbit_txt_scale_factor
-      pg% Orbit_show_RL = Orbit_show_RL
+      pg% Orbit_show_stars = Orbit_show_stars
 
       pg% annotation1_ci = annotation1_ci
       pg% annotation1_ch = annotation1_ch

--- a/binary/private/pgbinary_orbit.f90
+++ b/binary/private/pgbinary_orbit.f90
@@ -131,9 +131,7 @@ contains
       xmax = max(x1max, x2max)
       
       q = b% m(2) / b% m(1)
-      if (b% pg% Orbit_show_RL .and. abs(log10(q)) <= 2) then
-         call pgsci(clr_Goldenrod)
-         call pgpt1(x1s(1), y1s(1), -1)
+      if (b% pg% Orbit_show_stars .and. abs(log10(q)) <= 2) then
          if (b% point_mass_i /= 1) then
             this_psi = Psi_fit(b% r(1) / b% separation, q)
             xl1 = xl1_fit(q)
@@ -167,6 +165,9 @@ contains
             y1s_RL(2 * num_points + 1) = y1s_RL(1)
             x1max = maxval(abs(x1s_RL))
             xmax = max(x1max, xmax)
+         else
+            x1s_RL = 0d0
+            y1s_RL = 0d0
          end if
          
          if (b% point_mass_i /= 2) then
@@ -207,7 +208,7 @@ contains
             x2s_RL = 0d0
             y2s_RL = 0d0
          end if
-      else if (b% pg% Orbit_show_RL .and. abs(log10(q)) > 2) then
+      else if (b% pg% Orbit_show_stars .and. abs(log10(q)) > 2) then
          write(*, 1) "pgbinary: Not plotting RL, q too extreme: abs(log(q)) = ", abs(log10(q))
       end if
       
@@ -229,7 +230,7 @@ contains
       call pgslw(b% pg% pgbinary_lw / 2)
       call pgline(2 * num_points + 1, x2s, y2s)
       
-      if (b% pg% Orbit_show_RL .and. abs(log10(q)) <= 2) then
+      if (b% pg% Orbit_show_stars .and. abs(log10(q)) <= 2) then
          call pgslw(int(2.0 * b% pg% pgbinary_lw / 3.0))
          call pgsfs(3)
          call pgshs(45.0, 0.33, 0.0)

--- a/binary/private/pgbinary_orbit.f90
+++ b/binary/private/pgbinary_orbit.f90
@@ -203,6 +203,9 @@ contains
             y2s_RL(2 * num_points + 1) = y2s_RL(1)
             x2max = maxval(abs(x2s_RL))
             xmax = max(x2max, xmax)
+         else
+            x2s_RL = 0d0
+            y2s_RL = 0d0
          end if
       else if (b% pg% Orbit_show_RL .and. abs(log10(q)) > 2) then
          write(*, 1) "pgbinary: Not plotting RL, q too extreme: abs(log(q)) = ", abs(log10(q))

--- a/binary/private/pgbinary_star.f90
+++ b/binary/private/pgbinary_star.f90
@@ -203,7 +203,7 @@ contains
             call plot_case(b% s1, b% star_ids(1))
             call update_pgstar_history_file(b% s1, ierr)
          else
-            write(mass, '(f3.2)') b% m(1) / Msun
+            write(mass, '(f0.2)') b% m(1) / Msun
             call pgmtxt('T', -2.0, 0.5, 0.5, 'Star 1 not simulated')
             call pgmtxt('T', -3.0, 0.5, 0.5, 'point mass of ' // trim(adjustl(mass)) // ' M\d\(2281)')
          end if
@@ -216,7 +216,6 @@ contains
             call pgsvp(xleft, xright, ybot, ytop)
          end if
          if (b% point_mass_i /= 2) then
-
             call read_pgstar_inlist(b% s2, b% job% inlist_names(2), ierr)
             call update_pgstar_data(b% s2, ierr)
             call plot_case(b% s2, b% star_ids(2))

--- a/binary/private/pgbinary_star.f90
+++ b/binary/private/pgbinary_star.f90
@@ -222,7 +222,7 @@ contains
             call plot_case(b% s2, b% star_ids(2))
             call update_pgstar_history_file(b% s2, ierr)
          else
-            write(mass, '(f3.2)') b% m(2) / Msun
+            write(mass, '(f0.2)') b% m(2) / Msun
             call pgmtxt('T', -2.0, 0.5, 0.5, 'Star 2 not simulated')
             call pgmtxt('T', -3.0, 0.5, 0.5, 'point mass of ' // trim(adjustl(mass)) // ' M\d\(2281)')
          end if

--- a/binary/public/pgbinary_controls.inc
+++ b/binary/public/pgbinary_controls.inc
@@ -924,7 +924,7 @@ character (len = strlen) :: Star2_title, Star2_plot_name
 logical :: show_mtrans_status
 
 logical :: Orbit_win_flag, Orbit_file_flag, do_Orbit_win, do_Orbit_file
-logical :: Orbit_show_RL
+logical :: Orbit_show_stars
 integer :: Orbit_file_interval, id_Orbit_win, id_Orbit_file
 character (len = strlen) :: Orbit_file_dir, Orbit_file_prefix, Orbit_title
 real :: Orbit_win_width, Orbit_win_aspect_ratio, &

--- a/binary/test_suite/star_plus_point_mass/inlist
+++ b/binary/test_suite/star_plus_point_mass/inlist
@@ -20,6 +20,6 @@
 &pgbinary
 
       read_extra_pgbinary_inlist(1) = .true.
-      extra_pgbinary_inlist_name(1) = 'inlist_project'
+      extra_pgbinary_inlist_name(1) = 'inlist_pgbinary'
 
 / ! end of pgbinary namelist

--- a/binary/test_suite/star_plus_point_mass/inlist1
+++ b/binary/test_suite/star_plus_point_mass/inlist1
@@ -7,6 +7,9 @@
 
 / ! end of star_job namelist
 
+&eos
+
+/ ! end of eos namelist
 
 &kap
 
@@ -46,6 +49,7 @@
 
 
 &pgstar
-         
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'         
 
 / ! end of pgstar namelist

--- a/binary/test_suite/star_plus_point_mass/inlist2
+++ b/binary/test_suite/star_plus_point_mass/inlist2
@@ -30,7 +30,8 @@
 
 
 &pgstar
-         
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1)= 'inlist_pgstar'         
 
 
 / ! end of pgstar namelist

--- a/binary/test_suite/star_plus_point_mass/inlist_pgbinary
+++ b/binary/test_suite/star_plus_point_mass/inlist_pgbinary
@@ -1,0 +1,102 @@
+&pgbinary
+!pause = .true.
+
+pgbinary_age_disp = 1.7
+pgbinary_age_fjust = -0.5
+pgbinary_model_disp = 1.7
+pgbinary_model_fjust = 1.4
+
+pgbinary_grid_title_disp = 0.2
+pgbinary_title_disp = 0.2
+
+
+Orbit_win_flag = .true.
+Orbit_win_width = 8
+
+
+Grid1_win_flag = .true.
+
+Grid1_win_width = 19
+Grid1_win_aspect_ratio = 0.58
+
+Grid1_xleft = 0.0
+Grid1_xright = 1.0
+Grid1_ybot = 0.0
+Grid1_ytop = 0.95
+Grid1_title = ''
+
+Grid1_num_cols = 5
+Grid1_num_rows = 3
+Grid1_num_plots = 4
+
+Grid1_plot_name(1) = 'Star1'
+Grid1_plot_col(1) = 1
+Grid1_plot_colspan(1) = 2
+Grid1_plot_row(1) = 1
+Grid1_plot_rowspan(1) = 3
+Grid1_plot_pad_left(1) = 0.02
+Grid1_plot_pad_right(1) = 0.02
+Grid1_plot_pad_bot(1) = 0.01
+Grid1_plot_pad_top(1) = 0.00
+Grid1_txt_scale_factor(1) = 0.9
+Star1_plot_name = 'Grid2'
+do_star1_box = .true.
+star1_box_pad_left = -0.02
+star1_box_pad_right = 0.02
+star1_box_pad_bot = 0.0
+star1_box_pad_top = 0.001
+
+Grid1_plot_name(2) = 'Star2'
+Grid1_plot_col(2) = 3
+Grid1_plot_colspan(2) = 2
+Grid1_plot_row(2) = 1
+Grid1_plot_rowspan(2) = 3
+Grid1_plot_pad_left(2) = 0.02
+Grid1_plot_pad_right(2) = 0.02
+Grid1_plot_pad_bot(2) = 0.01
+Grid1_plot_pad_top(2) = 0.00
+Grid1_txt_scale_factor(2) = 0.9
+Star2_plot_name = 'Grid2'
+do_star2_box = .true.
+star2_box_pad_left = -0.018
+star2_box_pad_right = 0.02
+star2_box_pad_bot = 0.0
+star2_box_pad_top = 0.001
+
+Grid1_plot_name(3) = 'history_panels1'
+Grid1_plot_col(3) = 5
+Grid1_plot_colspan(3) = 1
+Grid1_plot_row(3) = 2
+Grid1_plot_rowspan(3) = 2
+Grid1_plot_pad_left(3) = 0.04
+Grid1_plot_pad_right(3) = 0.04
+Grid1_plot_pad_bot(3) = 0.04
+Grid1_plot_pad_top(3) = 0.00
+Grid1_txt_scale_factor(3) = 0.4
+
+History_panels1_title = ''
+History_panels1_num_panels = 2
+History_panels1_xaxis_name = 'model_number'
+History_panels1_yaxis_name(1) = 'rl_relative_overflow_1'
+History_panels1_other_yaxis_name(1) = 'rl_relative_overflow_2'
+History_panels1_yaxis_name(2) = 'period_days'
+History_panels1_other_yaxis_name(2) = 'lg_mtransfer_rate'
+History_panels1_other_ymin(2) = -10
+History_panels1_max_width = -1
+
+Grid1_plot_name(4) = 'Orbit'
+Grid1_plot_col(4) = 5
+Grid1_plot_colspan(4) = 1
+Grid1_plot_row(4) = 1
+Grid1_plot_rowspan(4) = 1
+Grid1_plot_pad_left(4) = 0.04
+Grid1_plot_pad_right(4) = 0.04
+Grid1_plot_pad_bot(4) = 0.03
+Grid1_plot_pad_top(4) = 0.00
+Grid1_txt_scale_factor(4) = 0.4
+
+Grid1_file_flag = .true.
+Grid1_file_interval = 10
+Grid1_file_width = -1
+Grid1_file_aspect_ratio = -1
+/ ! end of pgbinary namelist

--- a/binary/test_suite/star_plus_point_mass/inlist_pgstar
+++ b/binary/test_suite/star_plus_point_mass/inlist_pgstar
@@ -1,0 +1,107 @@
+&pgstar
+pgstar_interval = 1
+!pause = .true.
+
+pgstar_age_disp = 2.5
+pgstar_model_disp = 2.5
+
+!### scale for axis labels
+pgstar_xaxis_label_scale = 1.
+pgstar_left_yaxis_label_scale = 1.
+pgstar_right_yaxis_label_scale = 1.
+
+Grid2_num_cols = 4 ! divide plotting region into this many equal width cols
+Grid2_num_rows = 8 ! divide plotting region into this many equal height rows
+
+Grid2_num_plots = 6 ! <= 10
+
+Grid2_plot_name(1) = 'Profile_Panels1'
+Grid2_plot_row(1) = 1 ! number from 1 at top
+Grid2_plot_rowspan(1) = 3 ! plot spans this number of rows
+Grid2_plot_col(1) = 1 ! number from 1 at left
+Grid2_plot_colspan(1) = 2 ! plot spans this number of columns
+Grid2_plot_pad_left(1) = 0.01 ! fraction of full window width for padding on left
+Grid2_plot_pad_right(1) = 0.05 ! fraction of full window width for padding on right
+Grid2_plot_pad_top(1) = 0.01 ! fraction of full window height for padding at top
+Grid2_plot_pad_bot(1) = 0.02 ! fraction of full window height for padding at bottom
+Grid2_txt_scale_factor(1) = 0.7 ! multiply txt_scale for subplot by this
+
+Profile_Panels1_title = ''
+Profile_Panels1_num_panels = 2
+Profile_Panels1_xaxis_name = 'radius'
+Profile_Panels1_yaxis_name(1) = 'luminosity'
+Profile_Panels1_yaxis_name(2) = 'X_mass_fraction_H'
+Profile_Panels1_other_yaxis_name(2) = 'Y_mass_fraction_He'
+!   Profile_Panels1_yaxis_name(3) = 'log'
+!   Profile_Panels1_other_yaxis_name(3) = 'ft_rot'
+
+Grid2_plot_name(2) = 'Mixing'
+Grid2_plot_row(2) = 4 ! number from 1 at top
+Grid2_plot_rowspan(2) = 2 ! plot spans this number of rows
+Grid2_plot_col(2) = 1 ! number from 1 at left
+Grid2_plot_colspan(2) = 2 ! plot spans this number of columns
+Grid2_plot_pad_left(2) = 0.01 ! fraction of full window width for padding on left
+Grid2_plot_pad_right(2) = 0.05 ! fraction of full window width for padding on right
+Grid2_plot_pad_top(2) = 0.01 ! fraction of full window height for padding at top
+Grid2_plot_pad_bot(2) = 0.02 ! fraction of full window height for padding at bottom
+Grid2_txt_scale_factor(2) = 0.7 ! multiply txt_scale for subplot by this
+
+Mixing_title = ''
+
+Grid2_plot_name(3) = 'TRho_profile'
+Grid2_plot_row(3) = 6 ! number from 1 at top
+Grid2_plot_rowspan(3) = 2 ! plot spans this number of rows
+Grid2_plot_col(3) = 1 ! number from 1 at left
+Grid2_plot_colspan(3) = 2 ! plot spans this number of columns
+Grid2_plot_pad_left(3) = 0.01 ! fraction of full window width for padding on left
+Grid2_plot_pad_right(3) = 0.03 ! fraction of full window width for padding on right
+Grid2_plot_pad_top(3) = 0.01 ! fraction of full window height for padding at top
+Grid2_plot_pad_bot(3) = 0.02 ! fraction of full window height for padding at bottom
+Grid2_txt_scale_factor(3) = 0.7 ! multiply txt_scale for subplot by this
+
+Grid2_plot_name(5) = 'HR'
+HR_title = ''
+Grid2_plot_row(5) = 6 ! number from 1 at top
+Grid2_plot_rowspan(5) = 2 ! plot spans this number of rows
+Grid2_plot_col(5) = 3 ! number from 1 at left
+Grid2_plot_colspan(5) = 2 ! plot spans this number of columns
+Grid2_plot_pad_left(5) = 0.01 ! fraction of full window width for padding on left
+Grid2_plot_pad_right(5) = 0.01 ! fraction of full window width for padding on right
+Grid2_plot_pad_top(5) = 0.01 ! fraction of full window height for padding at top
+Grid2_plot_pad_bot(5) = 0.02 ! fraction of full window height for padding at bottom
+Grid2_txt_scale_factor(5) = 0.7 ! multiply txt_scale for subplot by this
+
+Grid2_plot_name(4) = 'History_Panels1'
+Grid2_plot_row(4) = 1 ! number from 1 at top
+Grid2_plot_rowspan(4) = 5 ! plot spans this number of rows
+Grid2_plot_col(4) = 3 ! number from 1 at left
+Grid2_plot_colspan(4) = 2 ! plot spans this number of columns
+Grid2_plot_pad_left(4) = 0.01 ! fraction of full window width for padding on left
+Grid2_plot_pad_right(4) = 0.01 ! fraction of full window width for padding on right
+Grid2_plot_pad_top(4) = 0.01 ! fraction of full window height for padding at top
+Grid2_plot_pad_bot(4) = 0.02 ! fraction of full window height for padding at bottom
+Grid2_txt_scale_factor(4) = 0.7 ! multiply txt_scale for subplot by this
+
+History_Panels1_title = ''
+History_Panels1_num_panels = 2
+History_Panels1_max_width = -1
+History_Panels1_xaxis_name = 'model_number'
+
+History_Panels1_yaxis_name(1) = 'log_R'
+History_Panels1_other_yaxis_name(1) = 'log_L'
+
+History_Panels1_yaxis_name(2) = 'center_h1'
+History_Panels1_other_yaxis_name(2) = 'center_he4'
+
+Grid2_plot_name(6) = 'Text_Summary1'
+Grid2_plot_row(6) = 8 ! number from 1 at top
+Grid2_plot_rowspan(6) = 1 ! plot spans this number of rows
+Grid2_plot_col(6) = 1 ! number from 1 at left
+Grid2_plot_colspan(6) = 4 ! plot spans this number of columns
+Grid2_plot_pad_left(6) = -0.01 ! fraction of full window width for padding on left
+Grid2_plot_pad_right(6) = -0.01 ! fraction of full window width for padding on right
+Grid2_plot_pad_top(6) = 0.01 ! fraction of full window height for padding at top
+Grid2_plot_pad_bot(6) = 0.00 ! fraction of full window height for padding at bottom
+Grid2_txt_scale_factor(6) = 0.2 ! multiply txt_scale for subplot by this
+
+/

--- a/binary/test_suite/star_plus_point_mass/inlist_project
+++ b/binary/test_suite/star_plus_point_mass/inlist_project
@@ -5,6 +5,8 @@
 
    evolve_both_stars = .false.
 
+   pgbinary_flag = .true.
+
 / ! end of binary_job namelist
 
 &binary_controls


### PR DESCRIPTION
See [gh-issue-634](https://github.com/MESAHub/mesa/issues/634), this should fix a bug that crashed pgbinary when running in single-star mode with intel-based compilers. This did not affect my m1 machine.

The issue and fix were both found by @ryosuke-hirai and Sohan Ghodla so we should thank them for this.

To test this i made the star_plus_point_mass test_suite use the same pgstar controls as the evolve_both_stars test_suite to showcase pgbinary running in single star mode. I also changed the pgbinary flag to '.true.' so testing using the intel based compilers can catch if pgbinary produces a backtrace.

Once this is tested, and if the test_suite changes are allowed by @matthiasfabry and/or @orlox, I'll add this bug to the changelog and we can merge this.
