### PR TITLE
Prevent TDC with predictive mixing

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -2301,6 +2301,15 @@
       ! Note that TDC does not respect the ``alt_scale_height`` option, and continues to use ``h = P / rho g``
       ! even if that flag is set.
 
+      ! We caution that combining different mixing models in a stellar evolution
+      ! calculation might lead to physically inconsistent solutions,
+      ! because the different models have been developed separately,
+      ! and their underlying assumptions might not be compatible with each other.
+      ! Examples include combining the newly implemented time-dependent local limit
+      ! convection model ``TDC`` with an overshooting model, or combining ``TDC``
+      ! with other models for chemical composition gradients
+      ! (predictive mixing or convective premixing), rotation, etc. (MESA VI)
+      
       ! ::
 
     MLT_option = 'TDC'
@@ -2773,6 +2782,9 @@
 
       ! Set to .true. to enable this set of parameters
 
+      ! ``predictive_mix`` is incompattible with ``convective premixing``
+      ! and mlt_option = ``TDC``, due to conflicting assumptions.
+      
       ! ::
 
     predictive_mix(1) = .false.

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -2781,9 +2781,6 @@
       ! ~~~~~~~~~~~~~~
 
       ! Set to .true. to enable this set of parameters
-
-      ! ``predictive_mix`` is incompattible with ``convective premixing``
-      ! and mlt_option = ``TDC``, due to conflicting assumptions.
       
       ! ::
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -2781,7 +2781,7 @@
       ! ~~~~~~~~~~~~~~
 
       ! Set to .true. to enable this set of parameters
-      
+
       ! ::
 
     predictive_mix(1) = .false.

--- a/star/private/predictive_mix.f90
+++ b/star/private/predictive_mix.f90
@@ -375,7 +375,7 @@ contains
           k_bot_mz = k_bot_mz + 1
        endif
 
-       ! See if the mixed region has reached went out of bounds [1, s%nz-1]
+       ! See if the mixed region has gone out of bounds [1, s%nz-1]
 
        if ((      outward .AND. k_top_mz < 1) .OR. &
            (.NOT. outward .AND. k_bot_mz > s%nz-1)) then

--- a/star/private/predictive_mix.f90
+++ b/star/private/predictive_mix.f90
@@ -375,10 +375,10 @@ contains
           k_bot_mz = k_bot_mz + 1
        endif
 
-       ! See if the mixed region has gone out of bounds [1, s%nz-1]
+       ! Exit search if the mixed region has gone out of bounds
 
        if ((      outward .AND. k_top_mz < 1) .OR. &
-           (.NOT. outward .AND. k_bot_mz > s%nz-1)) then
+           (.NOT. outward .AND. k_bot_mz > s%nz)) then
           exit search_loop
        endif
 

--- a/star/private/predictive_mix.f90
+++ b/star/private/predictive_mix.f90
@@ -96,7 +96,7 @@ contains
 
        criteria_loop : do j = 1, NUM_PREDICTIVE_PARAM_SETS
 
-          if (.NOT. s%predictive_mix(j)) cycle criteria_loop
+          if (.NOT. s% predictive_mix(j)) cycle criteria_loop
 
           ! Check if the criteria match the current boundary
 
@@ -170,8 +170,13 @@ contains
 
           ! Perform the predictive mixing for this boundary
 
-          if (s%do_conv_premix) then
+          if (s% do_conv_premix) then
              call mesa_error(__FILE__,__LINE__,'Predictive mixing and convective premixing cannot be enabled at the same time')
+             stop
+          end if
+
+          if (s% MLT_option == 'TDC') then
+             call mesa_error(__FILE__,__LINE__,'Predictive mixing and TDC cannot be enabled at the same time')
              stop
           end if
 

--- a/star/private/predictive_mix.f90
+++ b/star/private/predictive_mix.f90
@@ -175,10 +175,10 @@ contains
              stop
           end if
 
-          if (s% MLT_option == 'TDC') then
-             call mesa_error(__FILE__,__LINE__,'Predictive mixing and TDC cannot be enabled at the same time')
-             stop
-          end if
+          !if (s% MLT_option == 'TDC') then
+          !   call mesa_error(__FILE__,__LINE__,'Predictive mixing and TDC cannot be enabled at the same time')
+          !   stop
+          !end if
 
           call do_predictive_mixing(s, i, j, ierr, mix_mask)
           if (ierr /= 0) return
@@ -375,6 +375,13 @@ contains
           k_bot_mz = k_bot_mz + 1
        endif
 
+       ! See if the mixed region has reached went out of bounds [1, s%nz-1]
+
+       if ((      outward .AND. k_top_mz < 1) .OR. &
+           (.NOT. outward .AND. k_bot_mz > s%nz-1)) then
+          exit search_loop
+       endif
+
        ! Evaluate average abundance in the mixed zone
 
        call eval_abundances(s, k_bot_mz, k_top_mz, xa_mz, xa_mz_burn)
@@ -487,13 +494,6 @@ contains
           if (DEBUG) then
              write(*,*) 'Exiting predictive search due to convection-zone split'
           endif
-          exit search_loop
-       endif
-
-       ! See if the mixed region has reached the center or surface
-
-       if ((      outward .AND. k_top_mz == 1) .OR. &
-           (.NOT. outward .AND. k_bot_mz == s%nz-1)) then
           exit search_loop
        endif
 


### PR DESCRIPTION
First stab at addressing gh-issue-[607](https://github.com/MESAHub/mesa/issues/607).

 I added an error that gets printed if predictive mixing is called while TDC is on. We could probably flag it earlier so you can't set both controls at the same time on start up? Open to any opinions here, should we disallow users from using these controls together, or just give them a big warning?

