### PR TITLE
Ignore `max_allowed_nz` if ≤ 0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,8 @@ Backwards-incompatible changes
 New Features
 ------------
 
+``max_allowed_nz`` is now ignored if the value is less than or equal to zero.
+
 
 .. _Bug Fixes main:
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -5597,7 +5597,6 @@
       ! ~~~~~~~~~~~~~~
 
       ! Maximum number of grid points allowed.
-      ! Only used if > 0.
       ! Array allowed to grow arbitrarily large if max_allowed_nz <= 0
 
       ! ::

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -5597,6 +5597,7 @@
       ! ~~~~~~~~~~~~~~
 
       ! Maximum number of grid points allowed.
+      ! Only used if > 0.
 
       ! ::
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -5598,6 +5598,7 @@
 
       ! Maximum number of grid points allowed.
       ! Only used if > 0.
+      ! Array allowed to grow arbitrarily large if max_allowed_nz <= 0
 
       ! ::
 

--- a/star/private/mesh_plan.f90
+++ b/star/private/mesh_plan.f90
@@ -411,7 +411,7 @@
                if (ierr /= 0) return
             end if
             nz_new = nz_new + 1
-            if (nz_new > max_allowed_nz) then
+            if (max_allowed_nz > 0 .and. nz_new > max_allowed_nz) then
                write(*,*) 'tried to increase number of mesh points beyond max allowed nz', max_allowed_nz
                ierr = -1
                return
@@ -868,7 +868,7 @@
                dq_sum = sum(dq_new(1:k_new))
 
                k_new = k_new + 1
-               if (k_new > max_allowed_nz) then
+               if (max_allowed_nz > 0 .and. k_new > max_allowed_nz) then
                   write(*,*) 'tried to increase number of mesh points beyond max allowed nz', max_allowed_nz
                   ierr = -1
                   return


### PR DESCRIPTION
As [suggested](https://github.com/MESAHub/mesa/issues/621#issuecomment-1959094641) in issue #621, this PR allows users to ignore `max_allowed_nz` by setting it zero or less, in effect allowing the mesh to grow arbitrarily large, and in keeping with many other controls that are ignored when negative. Consensus seems to be that this should *not* be the default, although we may want to increase it from the current default of 8000.

I'm not sure if we want to strictly compare to -1 or perhaps advise users to use that, which would leave us the option of using particular values of `max_allowed_nz` to control meshing behaviour. I think generally we'd want more description controls anyway (e.g. set a string, not a specific integer) but I thought I'd throw the idea out there before users start using all sorts of negative values in their inlists.