### PR TITLE
Revert "Ignore `max_allowed_nz` if ≤ 0"

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,8 +18,6 @@ Backwards-incompatible changes
 New Features
 ------------
 
-``max_allowed_nz`` is now ignored if the value is less than or equal to zero.
-
 
 .. _Bug Fixes main:
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -5597,7 +5597,6 @@
       ! ~~~~~~~~~~~~~~
 
       ! Maximum number of grid points allowed.
-      ! Array allowed to grow arbitrarily large if max_allowed_nz <= 0
 
       ! ::
 

--- a/star/private/mesh_plan.f90
+++ b/star/private/mesh_plan.f90
@@ -411,7 +411,7 @@
                if (ierr /= 0) return
             end if
             nz_new = nz_new + 1
-            if (max_allowed_nz > 0 .and. nz_new > max_allowed_nz) then
+            if (nz_new > max_allowed_nz) then
                write(*,*) 'tried to increase number of mesh points beyond max allowed nz', max_allowed_nz
                ierr = -1
                return
@@ -868,7 +868,7 @@
                dq_sum = sum(dq_new(1:k_new))
 
                k_new = k_new + 1
-               if (max_allowed_nz > 0 .and. k_new > max_allowed_nz) then
+               if (k_new > max_allowed_nz) then
                   write(*,*) 'tried to increase number of mesh points beyond max allowed nz', max_allowed_nz
                   ierr = -1
                   return


### PR DESCRIPTION
Reverts MESAHub/mesa#642

I tried setting `max_allowed_nz` to both 0 and -1 in the default work directory after building Warrick's branch, and I get 

```
 retry: get_T_tau -- L <= 0       1
          1   5.479738   3312.725 -21.748047 -21.748047  15.000000  15.000000   0.700000   0.001010   0.280000 -12.926136   1078      1
-5.3010E+00   5.479738   2.521737 -99.000000 -23.145915 -99.000000   0.000000   0.280000   0.009381   0.020000   0.013983      9
 5.0000E-06  -5.414988   4.078909 -99.000000 -99.000000  -8.223226   0.000000   0.003447   0.002085   0.020000  0.000E+00         retry

 tried to increase number of mesh points beyond max allowed nz          -1

 mesh_plan problem
 doing mesh_call_number           1
 s% model_number           1

           0 terminate reason: adjust_mesh_failed
 failed in relax num steps
 failed in do_relax_num_steps
 star_create_pre_ms_model ierr          -1
 do_load1_star ierr          -1
 do_before_evolve_loop ierr          -1
 do_before_evolve_loop ierr          -1
DATE: 2024-04-18
TIME: 19:17:29
```
in both cases.  Should that happen? Seems like no? 