### PR TITLE
adding copy button to docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@
 sphinx==5.3.0
 sphinx_rtd_theme==1.1.1
 readthedocs-sphinx-search==0.3.2
-
+sphinx_copybutton==0.5.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ version = 'main'
 extensions = [
     'sphinx.ext.autosectionlabel',
     'defaults2rst',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Adds a quality-of-life feature to make code blocks in the documentation copyable with a single click. 

![image](https://github.com/MESAHub/mesa/assets/7489877/a0bdceac-d1c6-43f1-a884-537ec2b7b46b)
