### PR TITLE
adding python3 for jenkins to get Flatiron Jenkins build compiling again

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
       tcsh \
       git \
       git-lfs \
+      python3 \
       ruby \
       && \
     apt-get autoremove --purge -y && \


### PR DESCRIPTION
 `forum` added a python3 dependency to the overall MESA build.

This is missing in the Jenkins (Flatiron) system and mesa fails to compile. E.g. See logs:

https://logs.mesastar.org/15919513ed6156d61b3de2ec101681a3be7624db/Jenkins/build.log

https://jenkins.flatironinstitute.org/job/mesa/job/main/394/execution/node/32/log/

The build is defined by `jenkins/Jenkinsfile` in https://github.com/MESAHub/mesa
which in turn uses `jenkins/Dockerfile` to define the environment.

I am adding the installation of python3 to the Dockerfile