### PR TITLE
chem: fix error handling of preprocessor

### DIFF
--- a/chem/preprocessor/src/chem_support.f90
+++ b/chem/preprocessor/src/chem_support.f90
@@ -116,6 +116,7 @@ module chem_support
       do i = 1, nlines
          read(mass_unit,'(A)',iostat = ios) buf
          call parse_line_mass_unit(buf, Z, A, eval, mass, error,ierr)
+         if (ierr /= 0) cycle
          N = A-Z
          ! store mass and convert from keV to MeV
          mass_table(Z,N) = mass*keV_to_MeV


### PR DESCRIPTION
The code to preprocess data about the chemical species does not properly handle errors when reading from the mass table. Currently only one element (re203) has an entry in this table that does not contain data. Instead, the mass excess of the previous row is reused. The processed data file included in the repository does not have this issue, so either it was manually corrected or the tool didn't have the bug when it was generated.

This might not be the best solution (maybe the error should be reported in some way, or the data tables updated), but now it is no longer using bogus data.