### PR TITLE
adding parallel do simd

### DIFF
--- a/star/private/star_bcyclic.f90
+++ b/star/private/star_bcyclic.f90
@@ -75,12 +75,13 @@
 
          ierr = 0
          neq = nvar*nz
-         !$omp simd
+         !$OMP PARALLEL DO SIMD
          do i = 1,nvar*neq
             lblkF1(i) = lblk1(i)
             dblkF1(i) = dblk1(i)
             ublkF1(i) = ublk1(i)
          end do
+         !$OMP END PARALLEL DO SIMD
 
          if (dbg) write(*,*) 'start bcyclic_factor'
 

--- a/star/private/star_solver.f90
+++ b/star/private/star_solver.f90
@@ -1016,11 +1016,11 @@
                call start_time(s, time0, total_time)
             end if
             
-            !$OMP SIMD
+            !$OMP PARALLEL DO SIMD
             do i=1,neq
                b1(i) = -equ1(i)
             end do
-            !$OMP END SIMD
+            !$OMP END PARALLEL DO SIMD
             
             if (s% use_DGESVX_in_bcyclic) then
                !$OMP PARALLEL DO SIMD

--- a/star/private/star_solver.f90
+++ b/star/private/star_solver.f90
@@ -1016,30 +1016,33 @@
                call start_time(s, time0, total_time)
             end if
             
-            !$omp simd
+            !$OMP PARALLEL DO SIMD
             do i=1,neq
                b1(i) = -equ1(i)
             end do
+            !$OMP END PARALLEL DO SIMD
             
             if (s% use_DGESVX_in_bcyclic) then
-               !$omp simd
+               !$OMP PARALLEL DO SIMD
                do i = 1, nvar*nvar*nz
                   save_ublk1(i) = ublk1(i)
                   save_dblk1(i) = dblk1(i)
                   save_lblk1(i) = lblk1(i)
                end do
+               !$OMP END PARALLEL DO SIMD
             end if
             
             call factor_mtx(ierr)
             if (ierr == 0) call solve_mtx(ierr)
             
             if (s% use_DGESVX_in_bcyclic) then
-               !$omp simd
+               !$OMP PARALLEL DO SIMD
                do i = 1, nvar*nvar*nz
                   ublk1(i) = save_ublk1(i)
                   dblk1(i) = save_dblk1(i)
                   lblk1(i) = save_lblk1(i)
                end do
+               !$OMP END PARALLEL DO SIMD
             end if
 
             if (s% doing_timing) then

--- a/star/private/star_solver.f90
+++ b/star/private/star_solver.f90
@@ -1016,11 +1016,11 @@
                call start_time(s, time0, total_time)
             end if
             
-            !$OMP PARALLEL DO SIMD
+            !$OMP SIMD
             do i=1,neq
                b1(i) = -equ1(i)
             end do
-            !$OMP END PARALLEL DO SIMD
+            !$OMP END SIMD
             
             if (s% use_DGESVX_in_bcyclic) then
                !$OMP PARALLEL DO SIMD


### PR DESCRIPTION
I am using Caliper (https://software.llnl.gov/Caliper/) to profile parts of the code and understand why scaling typically plateaus beyond 12 cores. Some of it has to do with overhead + small simulation size. But I am detecting some unparallelized code

Here, I've changed `!$omp simd` -->  `!$omp parallel do simd`  to ensure loops are not only vectorized but multi-threaded. The scaling is improved and the 2024 MESA summer school day 1 minilab1.1_5M and a couple seconds are shaved off runtime.

![image](https://github.com/MESAHub/mesa/assets/7489877/e012011d-5d27-4880-a1bd-09bc3d6eec88)


