### PR TITLE
Minor improvements to parallelization

### DIFF
--- a/mtx/public/mtx_solve_routines.inc
+++ b/mtx/public/mtx_solve_routines.inc
@@ -172,7 +172,7 @@
       
       
       subroutine my_laswp( n, a, lda,  k1, k2, ipiv, incx )
-         integer :: incx, k1, k2, lda
+         integer :: incx, k1, k2, lda, n
          integer :: ipiv(:)
          real(dp) :: a(:,:) ! a( lda, * )
          integer :: i, i1, i2, inc, ip, ix, ix0, j, k, n32

--- a/mtx/public/mtx_solve_routines.inc
+++ b/mtx/public/mtx_solve_routines.inc
@@ -5,7 +5,7 @@
          integer :: ipiv(:)
          real(dp) :: a(:,:),aj(m)
          real(dp), parameter :: one=1, zero=0
-         integer :: i, j, jp, ii, jj, n, mm
+         integer :: i, j, jp, ii, jj, n
          real(dp) :: tmp, da, ajjj
          do j = 1, m
             info = 0
@@ -51,7 +51,7 @@
          real(dp) :: a(:,:)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: m=4, lda=4
-         integer :: i, j, jp, ii, jj, n, mm
+         integer :: i, j, jp, ii, jj, n
          real(dp) :: tmp, da
          do j = 1, m
             info = 0
@@ -95,7 +95,7 @@
          real(dp) :: a(:,:)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: m=5, lda=5
-         integer :: i, j, jp, ii, jj, n, mm
+         integer :: i, j, jp, ii, jj, n
          real(dp) :: tmp, da
          do j = 1, m
             info = 0
@@ -524,7 +524,7 @@
          integer :: info, lda, m
          real(dp) :: a(:,:)
          real(dp), parameter :: one=1, zero=0
-         integer :: i, j, ii, jj, n, mm
+         integer :: i, j, ii, jj, n
          real(dp) :: tmp, da
          do j = 1, m
             info = 0

--- a/mtx/public/mtx_solve_routines.inc
+++ b/mtx/public/mtx_solve_routines.inc
@@ -48,9 +48,9 @@
 
       
       subroutine my_getf2_n4(a, ipiv, info)
-         integer :: info
-         integer :: ipiv(:)
-         real(dp) :: a(:,:)
+         integer, intent(out) :: info
+         integer, intent(out) :: ipiv(4)
+         real(dp), intent(inout) :: a(4,4)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: m=4, lda=4
          integer :: i, j, jp, jj
@@ -92,9 +92,9 @@
 
       
       subroutine my_getf2_n5(a, ipiv, info)
-         integer :: info
-         integer :: ipiv(:)
-         real(dp) :: a(:,:)
+         integer, intent(out) :: info
+         integer, intent(out) :: ipiv(5)
+         real(dp), intent(inout) :: a(5,5)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: m=5, lda=5
          integer :: i, j, jp, jj
@@ -208,12 +208,13 @@
             
       
       subroutine my_getrs1( n, a, lda, ipiv, b, ldb, info )
-         integer :: info, lda, ldb, n
-         integer :: ipiv(:)
-         real(dp) :: a(:,:), b(:)
+         integer, intent(out) :: info
+         integer, intent(in) :: ipiv(:), lda, ldb, n
+         real(dp), intent(in) :: a(:,:)
+         real(dp), intent(inout) :: b(:)
          real(dp), parameter :: one=1, zero=0
          real(dp) :: temp
-         integer :: i,k
+         integer :: i, k
          info = 0
          !$omp simd private(temp)
          do i = 1,n
@@ -242,13 +243,14 @@
             
       
       subroutine my_getrs1_n4( a, ipiv, b, info )
-         integer :: info
-         integer :: ipiv(:)
-         real(dp) :: a(:,:), b(:)
+         integer, intent(out) :: info
+         integer, intent(in) :: ipiv(4)
+         real(dp), intent(in) :: a(4,4)
+         real(dp), intent(inout) :: b(4)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: n = 4
          real(dp) :: temp
-         integer :: i,k
+         integer :: i, k
          info = 0
          !$omp simd private(temp)
          do i = 1,n
@@ -277,13 +279,14 @@
             
       
       subroutine my_getrs1_n5( a, ipiv, b, info )
-         integer :: info
-         integer :: ipiv(:)
-         real(dp) :: a(:,:), b(:)
+         integer, intent(out) :: info
+         integer, intent(in) :: ipiv(5)
+         real(dp), intent(in) :: a(5,5)
+         real(dp), intent(inout) :: b(5)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: n = 5
          real(dp) :: temp
-         integer :: i,k
+         integer :: i, k
          info = 0
          !$omp simd private(temp)
          do i = 1,n

--- a/mtx/public/mtx_solve_routines.inc
+++ b/mtx/public/mtx_solve_routines.inc
@@ -1,11 +1,13 @@
 
       
       subroutine my_getf2(m, a, lda, ipiv, info)
-         integer :: info, lda, m
-         integer :: ipiv(:)
-         real(dp) :: a(:,:),aj(m)
-         real(dp), parameter :: one=1, zero=0
-         integer :: i, j, jp, ii, jj, n
+         integer, intent(in) :: m, lda
+         integer, intent(out) :: info
+         integer, intent(out) :: ipiv(:)
+         real(dp), intent(inout) :: a(:,:)
+         real(dp) :: aj(m)
+         real(dp), parameter :: one=1.0_dp, zero=0.0_dp
+         integer :: i, j, jp, jj
          real(dp) :: tmp, da, ajjj
          do j = 1, m
             info = 0
@@ -36,8 +38,8 @@
                do jj = j+1, m
                   ajjj = a(j,jj)
                   !$omp simd
-                  do ii = j+1, m
-                     a(ii,jj) = a(ii,jj) - aj(ii)*ajjj
+                  do i = j+1, m
+                     a(i,jj) = a(i,jj) - aj(i)*ajjj
                   end do
                end do
             end if
@@ -51,7 +53,7 @@
          real(dp) :: a(:,:)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: m=4, lda=4
-         integer :: i, j, jp, ii, jj, n
+         integer :: i, j, jp, jj
          real(dp) :: tmp, da
          do j = 1, m
             info = 0
@@ -80,8 +82,8 @@
                !call dger( m-j, m-j, -one, a( j+1, j ), 1, a( j, j+1 ), lda, a( j+1, j+1 ), lda )
                do jj = j+1, m
                   !$omp simd
-                  do ii = j+1, m
-                     a(ii,jj) = a(ii,jj) - a(ii,j)*a(j,jj)
+                  do i = j+1, m
+                     a(i,jj) = a(i,jj) - a(i,j)*a(j,jj)
                   end do
                end do
             end if
@@ -95,7 +97,7 @@
          real(dp) :: a(:,:)
          real(dp), parameter :: one=1, zero=0
          integer, parameter :: m=5, lda=5
-         integer :: i, j, jp, ii, jj, n
+         integer :: i, j, jp, jj
          real(dp) :: tmp, da
          do j = 1, m
             info = 0
@@ -124,8 +126,8 @@
                !call dger( m-j, m-j, -one, a( j+1, j ), 1, a( j, j+1 ), lda, a( j+1, j+1 ), lda )
                do jj = j+1, m
                   !$omp simd
-                  do ii = j+1, m
-                     a(ii,jj) = a(ii,jj) - a(ii,j)*a(j,jj)
+                  do i = j+1, m
+                     a(i,jj) = a(i,jj) - a(i,j)*a(j,jj)
                   end do
                end do
             end if
@@ -169,8 +171,8 @@
       end subroutine my_getrs
       
       
-      subroutine my_laswp( n,   a, lda,  k1, k2, ipiv,  incx )
-         integer :: incx, k1, k2, lda, n
+      subroutine my_laswp( n, a, lda,  k1, k2, ipiv, incx )
+         integer :: incx, k1, k2, lda
          integer :: ipiv(:)
          real(dp) :: a(:,:) ! a( lda, * )
          integer :: i, i1, i2, inc, ip, ix, ix0, j, k, n32
@@ -524,8 +526,8 @@
          integer :: info, lda, m
          real(dp) :: a(:,:)
          real(dp), parameter :: one=1, zero=0
-         integer :: i, j, ii, jj, n
-         real(dp) :: tmp, da
+         integer :: i, j, jj
+         real(dp) :: da
          do j = 1, m
             info = 0
             if( a( j, j ).ne.zero ) then
@@ -542,8 +544,8 @@
             if( j.lt.m ) then
                do jj = j+1, m
                   !$omp simd
-                  do ii = j+1, m
-                     a(ii,jj) = a(ii,jj) - a(ii,j)*a(j,jj)
+                  do i = j+1, m
+                     a(i,jj) = a(i,jj) - a(i,j)*a(j,jj)
                   end do
                end do
             end if

--- a/star/private/star_bcyclic.f90
+++ b/star/private/star_bcyclic.f90
@@ -248,7 +248,7 @@
          end if
 
 !call cali_begin_phase('co.loop1')
-!$OMP PARALLEL DO SIMD PRIVATE(ns,shift,shift2,i) COLLAPSE(2)
+!$OMP PARALLEL DO PRIVATE(ns,shift,shift2,i) COLLAPSE(2)
          do ns = nmin, nblk, 2  ! copy umat and lmat
             do i = 1, nvar2
                ! kcount = (ns-nmin)/2 + 1
@@ -259,7 +259,7 @@
                s% bcyclic_odd_storage(nlevel)% lmat1(shift+i) = lblkF1(shift2+i)
             end do
          end do
-!$OMP END PARALLEL DO SIMD
+!$OMP END PARALLEL DO
 !call cali_end_phase('co.loop1')
 
          if (nvar2*kcount > s% bcyclic_odd_storage(nlevel)% ul_size) then

--- a/star/private/star_bcyclic.f90
+++ b/star/private/star_bcyclic.f90
@@ -248,18 +248,18 @@
          end if
 
 !call cali_begin_phase('co.loop1')
-!$OMP PARALLEL DO SIMD PRIVATE(ns, i) COLLAPSE(2)
+!$OMP PARALLEL DO PRIVATE(ns, shift, shift2, i) COLLAPSE(2)
          do ns = nmin, nblk, 2  ! copy umat and lmat
             do i = 1, nvar2
                ! kcount = (ns-nmin)/2 + 1
                ! shift = nvar2*(kcount-1)
-               !shift = nvar2*(ns-nmin)/2
-               !shift2 = nvar2*ncycle*(ns-1)
-               s% bcyclic_odd_storage(nlevel)% umat1(nvar2*(ns-nmin)/2+i) = ublkF1(nvar2*ncycle*(ns-1)+i)
-               s% bcyclic_odd_storage(nlevel)% lmat1(nvar2*(ns-nmin)/2+i) = lblkF1(nvar2*ncycle*(ns-1)+i)
+               shift = nvar2*(ns-nmin)/2
+               shift2 = nvar2*ncycle*(ns-1)
+               s% bcyclic_odd_storage(nlevel)% umat1(shift+i) = ublkF1(shift2+i)
+               s% bcyclic_odd_storage(nlevel)% lmat1(shift+i) = lblkF1(shift2+i)
             end do
          end do
-!$OMP END PARALLEL DO SIMD
+!$OMP END PARALLEL DO
 !call cali_end_phase('co.loop1')
 
          if (nvar2*kcount > s% bcyclic_odd_storage(nlevel)% ul_size) then

--- a/star/private/star_bcyclic.f90
+++ b/star/private/star_bcyclic.f90
@@ -248,18 +248,18 @@
          end if
 
 !call cali_begin_phase('co.loop1')
-!$OMP PARALLEL DO PRIVATE(ns,shift,shift2,i) COLLAPSE(2)
+!$OMP PARALLEL DO SIMD PRIVATE(ns, i) COLLAPSE(2)
          do ns = nmin, nblk, 2  ! copy umat and lmat
             do i = 1, nvar2
                ! kcount = (ns-nmin)/2 + 1
                ! shift = nvar2*(kcount-1)
-               shift = nvar2*(ns-nmin)/2
-               shift2 = nvar2*ncycle*(ns-1)
-               s% bcyclic_odd_storage(nlevel)% umat1(shift+i) = ublkF1(shift2+i)
-               s% bcyclic_odd_storage(nlevel)% lmat1(shift+i) = lblkF1(shift2+i)
+               !shift = nvar2*(ns-nmin)/2
+               !shift2 = nvar2*ncycle*(ns-1)
+               s% bcyclic_odd_storage(nlevel)% umat1(nvar2*(ns-nmin)/2+i) = ublkF1(nvar2*ncycle*(ns-1)+i)
+               s% bcyclic_odd_storage(nlevel)% lmat1(nvar2*(ns-nmin)/2+i) = lblkF1(nvar2*ncycle*(ns-1)+i)
             end do
          end do
-!$OMP END PARALLEL DO
+!$OMP END PARALLEL DO SIMD
 !call cali_end_phase('co.loop1')
 
          if (nvar2*kcount > s% bcyclic_odd_storage(nlevel)% ul_size) then


### PR DESCRIPTION
Removing some unused variables in parallel loops, and improving a couple omp pragma statements for tiny speedup.

To make future progress in parallelizing Mesa, we will need to parallelize the bcyclic solves when the # threads > # blocks

I've highlighted the timings of critical loops here in `star/private/star_bcyclic.f90`:

![caliper2_3](https://github.com/MESAHub/mesa/assets/7489877/d8b2d25b-e694-4bf2-a7c7-eebe2016e34f)

