### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/source/using_mesa/building_inlists.rst
+++ b/docs/source/using_mesa/building_inlists.rst
@@ -58,7 +58,7 @@ You can also use pre-defined chemical compositions based on published data. Thes
 By default, the initial composition in MESA is ``initial_zfracs = 3`` which corresponds to the `GS98 <https://link.springer.com/article/10.1023%2FA%3A1005161325181>`__ metal fraction. There are 8 possible predefined choices for this control in MESA.
 
 If you want for example to use the more recent available solar composition given in `AGSS09 <https://www.annualreviews.org/doi/pdf/10.1146/annurev.astro.46.060407.145222>`__ , you need to set ``initial_zfracs = 6``.
-Since it is very important to use the opacity tables which are built using the solar composition used, we also have to set the ``kappa_file_prefix`` to the 2009 solar composition (the default table corresponds to the gs98 composition).
+Since it is very important to use the opacity tables which are built using the solar composition used, we also have to set the ``kap_file_prefix`` to the 2009 solar composition (the default table corresponds to the gs98 composition).
 
 .. literalinclude:: inlist_example
    :start-after: ! Modifications to model

--- a/star/test_suite/hb_2M/README.rst
+++ b/star/test_suite/hb_2M/README.rst
@@ -33,7 +33,7 @@ Then we specify the output. We save the final model, which will be the starting 
    :end-before: initial_zfracs = 6 
 
 Next, we specify the initial composition. There is no consensus yet on which is "the best" solar composition. By default, the initial composition in MESA is ``initial_zfracs = 3`` which corresponds to the `GS98 <https://link.springer.com/article/10.1023%2FA%3A1005161325181>`__ metal fraction. Here we want to use the more recent available solar composition given in `AGSS09 <https://www.annualreviews.org/doi/pdf/10.1146/annurev.astro.46.060407.145222>`__ , therefore we set ``initial_zfracs = 6``.
-Since it is very important to use the opacity tables which are built using the solar composition we use, we also have to set the ``kappa_file_prefix`` to the 2009 solar composition (the default table corresponds to the gs98 composition).
+Since it is very important to use the opacity tables which are built using the solar composition we use, we also have to set the ``kap_file_prefix`` to the 2009 solar composition (the default table corresponds to the gs98 composition).
 
 .. literalinclude:: ../../../star/test_suite/hb_2M/inlist_to_TAMS
    :start-after: history_columns_file = 'history_columns.list' 
@@ -43,7 +43,7 @@ We also have to choose a network of nuclear reactions. This network should be ch
 Here we want to use a nuclear reactions network, called ``pp_and_cno_extras.net``, which provides a more complete coverage for hydrogen and helium burning.
 
 .. literalinclude:: ../../../star/test_suite/hb_2M/inlist_to_TAMS
-   :start-after:  kappa_file_prefix = 'a09'
+   :start-after:  kap_file_prefix = 'a09'
    :end-before: /
 
 We do not specify anything about the eos, which means we use the default one.


### PR DESCRIPTION
`kappa_file_prefix` -> `kap_file_prefix`. I believe the former is not a valid configuration parameter.