### PR TITLE
Revert "readthedocs sphinx context injection fix"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,13 +14,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('./_ext/'))
 
-# Set canonical URL from the Read the Docs Domain
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
-
-# Tell Jinja2 templates the build is running on Read the Docs
-if os.environ.get("READTHEDOCS", "") == "True":
-    html_context["READTHEDOCS"] = True
-
 
 # -- Project information -----------------------------------------------------
 
@@ -110,7 +103,6 @@ tags_create_badges = True
 tags_badge_colors = {
     "star": "primary",
     "binary": "primary",
-    "astero": "primary",
     "high-mass": "secondary",
     "low-mass": "secondary",
 }


### PR DESCRIPTION
Reverts MESAHub/mesa#699

because it breaks readthedocs build: 

https://readthedocs.org/projects/mesa-doc/builds/25214806/