### PR TITLE
bugfix dP to d_P in create_initial_model

### DIFF
--- a/star/private/create_initial_model.f90
+++ b/star/private/create_initial_model.f90
@@ -334,11 +334,11 @@
 
             ! 4th order rk step
             dy1=dydP*d_P
-            call derivs(cs,P+dP/2d0,S,y+dy1/2d0,dydP)
+            call derivs(cs,P+d_P/2d0,S,y+dy1/2d0,dydP)
             dy2=dydP*d_P
-            call derivs(cs,P+dP/2d0,S,y+dy2/2d0,dydP)
+            call derivs(cs,P+d_P/2d0,S,y+dy2/2d0,dydP)
             dy3=dydP*d_P
-            call derivs(cs,P+dP,S,y+dy3,dydP)
+            call derivs(cs,P+d_P,S,y+dy3,dydP)
             dy4=dydP*d_P
             y=y+dy1/6.d0+dy2/3.d0+dy3/3.d0+dy4/6.d0
             P=P+d_P


### PR DESCRIPTION
This is a bug in the RK4 solver of `create_initial_model` that has been in Mesa since before the code was added to github. `dP` needs to be `d_P`. The variable `dP` was never defined, and got interpreted as `dp` because Fortran is case-insensitive.

Luckily this bug does not seem to have a large effect in the solver convergence. Tested here: https://testhub.mesastar.org/bugfix%2Fpmocz%2Fquickfixes/commits/1aec194