### PR TITLE
Chores - adding some missing intents, cleanup unused variables, a little formatting

### DIFF
--- a/atm/private/atm_table.f90
+++ b/atm/private/atm_table.f90
@@ -105,7 +105,6 @@ contains
     real(dp) :: dPrad_dL
     real(dp) :: dT_dlnR
     real(dp) :: dT_dlnM
-    real(dp) :: dT_dlnT
     real(dp) :: dT_dlnTeff
 
     include 'formats'

--- a/atm/private/table_atm.f90
+++ b/atm/private/table_atm.f90
@@ -83,8 +83,6 @@
             type(atm_info), intent(inout) :: ai
             integer, intent(out) :: ierr
             
-            integer :: nvec
-            character (len=500) :: buf
             real(dp), target :: vec_ary(20)
             real(dp), pointer :: vec(:)
 
@@ -505,7 +503,7 @@
             integer, intent(in)  :: iZ !index of Z table to be loaded
             integer, intent(out) :: ierr
             integer :: iounit, i, j, ibound_tmp(ng), ibcTmin, ibcTmax, ibcgmin, ibcgmax
-            integer :: cache_file_version, text_file_version, nvec
+            integer :: text_file_version, nvec
             real(dp) :: Teff_tmp(nT), logg_tmp(ng)
             real(dp) :: bcTmin(nT), bcTmax(ng), bcgmin(ng), bcgmax(ng), data_tmp(ng,nT)
             real(dp), target :: vec_ary(100)

--- a/star/job/run_star_support.f90
+++ b/star/job/run_star_support.f90
@@ -184,7 +184,7 @@
          
          logical :: first_try
          integer :: id
-         integer :: result, model_number, source, nsteps, j, ci, nz
+         integer :: result, model_number
          
          include 'formats'
          
@@ -308,7 +308,6 @@
          end interface
          integer :: id_from_read_star_job
          character (len=*) :: inlist_fname, restart_filename
-         character (len=512) :: temp_fname
          logical, intent(in) :: dbg
          integer, intent(in) :: binary_id
          integer, intent(out) :: id, ierr
@@ -506,9 +505,8 @@
          integer, intent(in) :: id
          type (star_info), pointer :: s         
          integer, intent(out) :: ierr
-         integer :: k, model_number, j
-         real(dp) :: gamma1_integral, integral_norm
-         integer :: num_DT, num_PT, num_FreeEOS
+         integer :: model_number, j
+         integer :: num_DT, num_FreeEOS
          
          1 format(a35, 99(1pe26.16))
          2 format(a35, i7, 1pe26.16)
@@ -1134,7 +1132,6 @@
       
       logical function stop_is_requested(s)
          type (star_info), pointer :: s         
-         integer :: ierr
          logical :: file_exists
          stop_is_requested = .false.
          if (mod(s% model_number,100) /= 0) return
@@ -1167,9 +1164,8 @@
          real(dp) :: item_values(max_num_items)
          integer, target :: index_arry(max_num_items) 
          integer, pointer :: index(:) 
-         integer :: item_order(max_num_items)
          integer :: ierr, omp_num_threads, item_num, num_items, i, j
-         real(dp) :: total, misc, tmp
+         real(dp) :: total, tmp
          include 'formats'
          ierr = 0
          omp_num_threads = utils_OMP_GET_MAX_THREADS()
@@ -1257,8 +1253,7 @@
       end subroutine show_times
       
       
-      subroutine do_saves( &
-            id, ierr)
+      subroutine do_saves(id, ierr)
          integer, intent(in) :: id
          type (star_info), pointer :: s
 
@@ -1627,7 +1622,6 @@
          logical, intent(in) :: restart
          integer, intent(out) :: ierr
          logical, parameter :: kap_use_cache = .true.
-         logical :: save_flag
          include 'formats'
       
          ierr = 0
@@ -1943,7 +1937,6 @@
          subroutine change_net(net_name)
             use const_def
             character (len=*), intent(in) :: net_name
-            integer :: j
             
             include 'formats'
             
@@ -1994,8 +1987,8 @@
          logical, intent(in) :: restart, pgstar_ok
          integer, intent(out) :: ierr
          
-         real(dp) :: log_m, log_lifetime, max_dt, max_timestep, minq, maxq
-         integer :: i, j, k, nzlo, nzhi, chem_id, chem_id1, chem_id2
+         real(dp) :: log_m, log_lifetime, max_dt, max_timestep
+         integer :: i, j, nzlo, nzhi, chem_id, chem_id1, chem_id2
          logical :: change_v, change_u
          include 'formats'
          
@@ -2988,7 +2981,7 @@
             integer :: num_pts, i, k, iounit
             ! these are needed to call eosPT_get
             real(dp) :: Rho, log10Rho, dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas
-            real(dp) :: T, log10T
+            real(dp) :: log10T
             ! these are needed to call eosDT_get_T
             real(dp) :: T_guess_gas, T_guess_rad, logT_guess
             integer :: eos_calls

--- a/star/other/other_accreting_state.f90
+++ b/star/other/other_accreting_state.f90
@@ -22,35 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_accreting_state
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_accreting_state = .true.
-      ! procedure pointer: s% other_accreting_state => my_routine
+module other_accreting_state
 
-      implicit none
-      
-            
-      contains
-      
-      ! Note that your routine will be called before many star variables have been set.
-      ! If you rely on these, you should call the star_set_vars_in_part1 routine from star_lib
-      ! to ensure that they are set.      
-      subroutine null_other_accreting_state(id, total_specific_energy, accretion_pressure, accretion_density, ierr)
-         use star_def
-         integer, intent(in) :: id
-         real(dp), intent(out) :: total_specific_energy, accretion_pressure, accretion_density
-         integer, intent(out) :: ierr
-         total_specific_energy = 0d0 ! erg/g
-         accretion_pressure = 0d0 ! erg/cm^3
-         accretion_density = 0d0 ! g/cm^3
-         ierr = 0
-      end subroutine null_other_accreting_state
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_accreting_state = .true.
+   ! procedure pointer: s% other_accreting_state => my_routine
 
+   implicit none
 
-      end module other_accreting_state
-      
-      
-      
-      
+contains
+
+   ! Note that your routine will be called before many star variables have been set.
+   ! If you rely on these, you should call the star_set_vars_in_part1 routine from star_lib
+   ! to ensure that they are set.
+   subroutine null_other_accreting_state(id, total_specific_energy, accretion_pressure, accretion_density, ierr)
+      use star_def
+      integer, intent(in) :: id
+      real(dp), intent(out) :: total_specific_energy, accretion_pressure, accretion_density
+      integer, intent(out) :: ierr
+      total_specific_energy = 0d0 ! erg/g
+      accretion_pressure = 0d0 ! erg/cm^3
+      accretion_density = 0d0 ! g/cm^3
+      ierr = 0
+   end subroutine null_other_accreting_state
+
+end module other_accreting_state
+

--- a/star/other/other_adjust_mdot.f90
+++ b/star/other/other_adjust_mdot.f90
@@ -22,29 +22,24 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_adjust_mdot
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_adjust_mdot = .true.
-      ! procedure pointer: s% other_adjust_mdot => my_routine
+module other_adjust_mdot
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_adjust_mdot = .true.
+   ! procedure pointer: s% other_adjust_mdot => my_routine
 
-      implicit none
-      
-      contains
+   implicit none
 
-      ! your routine will be called after winds and before mass adjustment
-      subroutine null_other_adjust_mdot(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_other_adjust_mdot
+contains
 
+   ! your routine will be called after winds and before mass adjustment
+   subroutine null_other_adjust_mdot(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_other_adjust_mdot
 
-      end module other_adjust_mdot
-      
-      
-      
-      
+end module other_adjust_mdot
+

--- a/star/other/other_adjust_mlt_gradt_fraction.f90
+++ b/star/other/other_adjust_mlt_gradt_fraction.f90
@@ -22,35 +22,25 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_adjust_mlt_gradT_fraction
 
-      ! consult star/other/README for general usage instructions
-      ! Note: there is no flag use_other_mlt_gradT_fraction
-      ! procedure pointer: s% other_adjust_mlt_gradT_fraction => my_routine
+module other_adjust_mlt_gradT_fraction
 
-      implicit none
-      
-      
-      contains
-      
-      
-      
-      subroutine default_other_adjust_mlt_gradT_fraction(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-      end subroutine default_other_adjust_mlt_gradT_fraction
+   ! consult star/other/README for general usage instructions
+   ! Note: there is no flag use_other_mlt_gradT_fraction
+   ! procedure pointer: s% other_adjust_mlt_gradT_fraction => my_routine
 
+   implicit none
 
+contains
 
-      end module other_adjust_mlt_gradT_fraction
-      
-      
-      
-      
+   subroutine default_other_adjust_mlt_gradT_fraction(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+   end subroutine default_other_adjust_mlt_gradT_fraction
+
+end module other_adjust_mlt_gradT_fraction

--- a/star/other/other_after_set_mixing_info.f90
+++ b/star/other/other_after_set_mixing_info.f90
@@ -22,26 +22,20 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_after_set_mixing_info
 
-      implicit none
-      
-            
-      contains
-      
-   
-      subroutine default_other_after_set_mixing_info(id, ierr)
-         use const_def, only: dp
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine default_other_after_set_mixing_info
+module other_after_set_mixing_info
 
+   implicit none
 
-      end module other_after_set_mixing_info
-      
-      
-      
-      
+contains
+
+   subroutine default_other_after_set_mixing_info(id, ierr)
+      use const_def, only: dp
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine default_other_after_set_mixing_info
+
+end module other_after_set_mixing_info
+

--- a/star/other/other_after_solver_setmatrix.f90
+++ b/star/other/other_after_solver_setmatrix.f90
@@ -22,23 +22,18 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_after_solver_setmatrix
 
-      implicit none
-      
-            
-      contains
-         
-      subroutine default_other_after_solver_setmatrix(id, ierr)
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine default_other_after_solver_setmatrix
+module other_after_solver_setmatrix
 
+   implicit none
 
-      end module other_after_solver_setmatrix
-      
-      
-      
-      
+contains
+
+   subroutine default_other_after_solver_setmatrix(id, ierr)
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine default_other_after_solver_setmatrix
+
+end module other_after_solver_setmatrix
+

--- a/star/other/other_after_struct_burn_mix.f90
+++ b/star/other/other_after_struct_burn_mix.f90
@@ -22,33 +22,27 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_after_struct_burn_mix
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_after_struct_burn_mix = .true.
-      ! procedure pointer: s% other_after_struct_burn_mix => my_routine
+module other_after_struct_burn_mix
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_after_struct_burn_mix = .true.
+   ! procedure pointer: s% other_after_struct_burn_mix => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      ! your routine will be called after the standard struct_burn_mix routine
-   
-      subroutine null_other_after_struct_burn_mix(id, dt, res)
-         use const_def, only: dp
-         use star_def
-         integer, intent(in) :: id
-         real(dp), intent(in) :: dt
-         integer, intent(out) :: res ! keep_going, redo, retry, terminate
-         res = keep_going
-      end subroutine null_other_after_struct_burn_mix
+   implicit none
 
+contains
 
-      end module other_after_struct_burn_mix
-      
-      
-      
-      
+   ! your routine will be called after the standard struct_burn_mix routine
+
+   subroutine null_other_after_struct_burn_mix(id, dt, res)
+      use const_def, only: dp
+      use star_def
+      integer, intent(in) :: id
+      real(dp), intent(in) :: dt
+      integer, intent(out) :: res ! keep_going, redo, retry, terminate
+      res = keep_going
+   end subroutine null_other_after_struct_burn_mix
+
+end module other_after_struct_burn_mix
+

--- a/star/other/other_alpha_mlt.f90
+++ b/star/other/other_alpha_mlt.f90
@@ -22,34 +22,26 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_alpha_mlt
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_alpha_mlt = .true.
-      ! procedure pointer: s% other_alpha_mlt => my_routine
+module other_alpha_mlt
 
-      implicit none
-      
-      
-      contains
-      
-      
-      subroutine default_other_alpha_mlt(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         s% alpha_mlt(:) = s% mixing_length_alpha
-      end subroutine default_other_alpha_mlt
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_alpha_mlt = .true.
+   ! procedure pointer: s% other_alpha_mlt => my_routine
 
+   implicit none
 
-      end module other_alpha_mlt
-      
-      
-      
-      
+contains
+
+   subroutine default_other_alpha_mlt(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      s%alpha_mlt(:) = s%mixing_length_alpha
+   end subroutine default_other_alpha_mlt
+
+end module other_alpha_mlt

--- a/star/other/other_am_mixing.f90
+++ b/star/other/other_am_mixing.f90
@@ -22,31 +22,27 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_am_mixing
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_am_mixing = .true.
-      ! procedure pointer: s% other_am_mixing => my_routine
+module other_am_mixing
 
-      implicit none
-      
-      contains
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_am_mixing = .true.
+   ! procedure pointer: s% other_am_mixing => my_routine
 
-      ! for extra angular momentum mixing
-      ! you can revise vectors s% am_nu_omega(:) and s% am_nu_j(:)
-      
-      subroutine null_other_am_mixing(id, ierr)
-         use star_def
-         use const_def   
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_other_am_mixing
-      
-      
-      end module other_am_mixing
-      
-      
-      
-      
+   implicit none
+
+contains
+
+   ! for extra angular momentum mixing
+   ! you can revise vectors s% am_nu_omega(:) and s% am_nu_j(:)
+
+   subroutine null_other_am_mixing(id, ierr)
+      use star_def
+      use const_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_other_am_mixing
+
+end module other_am_mixing
+

--- a/star/other/other_astero_freq_corr.f90
+++ b/star/other/other_astero_freq_corr.f90
@@ -38,7 +38,6 @@ contains
       integer, intent(in) :: id
       integer, intent(out) :: ierr
       type(star_info), pointer :: s
-      integer :: k
       ierr = 0
       call star_ptr(id, s, ierr)
       if (ierr /= 0) return

--- a/star/other/other_astero_freq_corr.f90
+++ b/star/other/other_astero_freq_corr.f90
@@ -22,35 +22,29 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_astero_freq_corr
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_astero_freq_corr = .true.
-      ! procedure pointer: s% other_astero_freq_corr => my_routine
+module other_astero_freq_corr
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_astero_freq_corr(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         ! see star/astero/src/astero_support.f, subroutine get_freq_corr.
-         ! note that your routine can use both astero_data and astero_support.
-      end subroutine default_other_astero_freq_corr
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_astero_freq_corr = .true.
+   ! procedure pointer: s% other_astero_freq_corr => my_routine
 
+   implicit none
 
-      end module other_astero_freq_corr
-      
-      
-      
-      
+contains
+
+   subroutine default_other_astero_freq_corr(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      ! see star/astero/src/astero_support.f, subroutine get_freq_corr.
+      ! note that your routine can use both astero_data and astero_support.
+   end subroutine default_other_astero_freq_corr
+
+end module other_astero_freq_corr
+

--- a/star/other/other_before_struct_burn_mix.f90
+++ b/star/other/other_before_struct_burn_mix.f90
@@ -22,33 +22,27 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_before_struct_burn_mix
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_before_struct_burn_mix = .true.
-      ! procedure pointer: s% other_before_struct_burn_mix => my_routine
+module other_before_struct_burn_mix
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_before_struct_burn_mix = .true.
+   ! procedure pointer: s% other_before_struct_burn_mix => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      ! your routine will be called before the standard struct_burn_mix routine
-   
-      subroutine null_other_before_struct_burn_mix(id, dt, res)
-         use const_def, only: dp
-         use star_def
-         integer, intent(in) :: id
-         real(dp), intent(in) :: dt
-         integer, intent(out) :: res ! keep_going, redo, retry, terminate
-         res = keep_going
-      end subroutine null_other_before_struct_burn_mix
+   implicit none
 
+contains
 
-      end module other_before_struct_burn_mix
-      
-      
-      
-      
+   ! your routine will be called before the standard struct_burn_mix routine
+
+   subroutine null_other_before_struct_burn_mix(id, dt, res)
+      use const_def, only: dp
+      use star_def
+      integer, intent(in) :: id
+      real(dp), intent(in) :: dt
+      integer, intent(out) :: res ! keep_going, redo, retry, terminate
+      res = keep_going
+   end subroutine null_other_before_struct_burn_mix
+
+end module other_before_struct_burn_mix
+

--- a/star/other/other_brunt.f90
+++ b/star/other/other_brunt.f90
@@ -22,34 +22,27 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_brunt
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_brunt = .true.
-      ! procedure pointer: s% other_brunt => my_routine
+module other_brunt
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_brunt(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         s% brunt_N2(1:s% nz) = 0
-      end subroutine default_other_brunt
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_brunt = .true.
+   ! procedure pointer: s% other_brunt => my_routine
 
+   implicit none
 
-      end module other_brunt
-      
-      
-      
-      
+contains
+
+   subroutine default_other_brunt(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      s%brunt_N2(1:s%nz) = 0
+   end subroutine default_other_brunt
+
+end module other_brunt
+

--- a/star/other/other_brunt_smoothing.f90
+++ b/star/other/other_brunt_smoothing.f90
@@ -22,31 +22,25 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_brunt_smoothing
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_brunt_smoothing = .true.
-      ! procedure pointer: s% other_brunt_smoothing => my_routine
+module other_brunt_smoothing
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_brunt_smoothing(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-      end subroutine null_other_brunt_smoothing
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_brunt_smoothing = .true.
+   ! procedure pointer: s% other_brunt_smoothing => my_routine
 
+   implicit none
 
-      end module other_brunt_smoothing
-      
-      
-      
-      
+contains
+
+   subroutine null_other_brunt_smoothing(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      !type(star_info), pointer :: s
+      !integer :: k
+      ierr = 0
+   end subroutine null_other_brunt_smoothing
+
+end module other_brunt_smoothing
+

--- a/star/other/other_build_initial_model.f90
+++ b/star/other/other_build_initial_model.f90
@@ -22,33 +22,27 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_build_initial_model
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_build_initial_model = .true.
-      ! procedure pointer: s% other_build_initial_model => my_routine
+module other_build_initial_model
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_build_initial_model(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-      end subroutine default_other_build_initial_model
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_build_initial_model = .true.
+   ! procedure pointer: s% other_build_initial_model => my_routine
 
+   implicit none
 
-      end module other_build_initial_model
-      
-      
-      
-      
+contains
+
+   subroutine default_other_build_initial_model(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+   end subroutine default_other_build_initial_model
+
+end module other_build_initial_model
+

--- a/star/other/other_build_initial_model.f90
+++ b/star/other/other_build_initial_model.f90
@@ -38,7 +38,6 @@ contains
       integer, intent(in) :: id
       integer, intent(out) :: ierr
       type(star_info), pointer :: s
-      integer :: k
       ierr = 0
       call star_ptr(id, s, ierr)
       if (ierr /= 0) return

--- a/star/other/other_cgrav.f90
+++ b/star/other/other_cgrav.f90
@@ -22,37 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_cgrav
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_cgrav = .true.
-      ! procedure pointer: s% other_cgrav => my_routine
+module other_cgrav
 
-      ! note that other_cgrav only changes G in the stellar structure
-      ! the binary module is unaffected by changes in cgrav
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_cgrav = .true.
+   ! procedure pointer: s% other_cgrav => my_routine
 
-      implicit none
+   ! note that other_cgrav only changes G in the stellar structure
+   ! the binary module is unaffected by changes in cgrav
 
-      
-      contains
-      
-      
-      subroutine default_other_cgrav(id, ierr)
-         use star_def
-         use const_def, only: standard_cgrav
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         s% cgrav(:) = standard_cgrav
-      end subroutine default_other_cgrav
+   implicit none
 
-      end module other_cgrav
-      
-      
-      
-      
+contains
+
+   subroutine default_other_cgrav(id, ierr)
+      use star_def
+      use const_def, only: standard_cgrav
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      s%cgrav(:) = standard_cgrav
+   end subroutine default_other_cgrav
+
+end module other_cgrav

--- a/star/other/other_close_gaps.f90
+++ b/star/other/other_close_gaps.f90
@@ -22,31 +22,26 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_close_gaps
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_close_gaps = .true.
-      ! procedure pointer: s% other_close_gaps => my_routine
-      ! This also requires the control remove_mixing_glitches = .true. 
+module other_close_gaps
 
-      implicit none
-      
-      contains
-      
-      
-      subroutine null_other_close_gaps(id, mix_type, min_gap, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(in) :: mix_type
-         real(dp), intent(in) :: min_gap
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_other_close_gaps
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_close_gaps = .true.
+   ! procedure pointer: s% other_close_gaps => my_routine
+   ! This also requires the control remove_mixing_glitches = .true.
 
+   implicit none
 
-      end module other_close_gaps
-      
-      
-      
-      
+contains
+
+   subroutine null_other_close_gaps(id, mix_type, min_gap, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(in) :: mix_type
+      real(dp), intent(in) :: min_gap
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_other_close_gaps
+
+end module other_close_gaps
+

--- a/star/other/other_d_mix.f90
+++ b/star/other/other_d_mix.f90
@@ -22,28 +22,23 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_D_mix
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_D_mix = .true.
-      ! procedure pointer: s% other_D_mix => my_routine
+module other_D_mix
 
-      implicit none
-      
-      contains
-      
-      
-      subroutine null_other_D_mix(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_other_D_mix
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_D_mix = .true.
+   ! procedure pointer: s% other_D_mix => my_routine
 
+   implicit none
 
-      end module other_D_mix
-      
-      
-      
-      
+contains
+
+   subroutine null_other_D_mix(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_other_D_mix
+
+end module other_D_mix
+

--- a/star/other/other_diffusion.f90
+++ b/star/other/other_diffusion.f90
@@ -22,37 +22,31 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_diffusion
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_diffusion = .true.
-      ! procedure pointer: s% other_diffusion => my_routine
+module other_diffusion
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_diffusion(id, dt, ierr)
-         use star_def
-         integer, intent(in) :: id
-         real(dp), intent(in) :: dt 
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         !write(*,*) 'null_other_diffusion'
-         !write(*,*) 'associated(s% edv)', associated(s% edv)
-         s% edv(:,1:s% nz) = 0
-         !write(*,*) 'done null_other_diffusion'
-      end subroutine null_other_diffusion
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_diffusion = .true.
+   ! procedure pointer: s% other_diffusion => my_routine
 
+   implicit none
 
-      end module other_diffusion
-      
-      
-      
-      
+contains
+
+   subroutine null_other_diffusion(id, dt, ierr)
+      use star_def
+      integer, intent(in) :: id
+      real(dp), intent(in) :: dt
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      !write(*,*) 'null_other_diffusion'
+      !write(*,*) 'associated(s% edv)', associated(s% edv)
+      s%edv(:, 1:s%nz) = 0
+      !write(*,*) 'done null_other_diffusion'
+   end subroutine null_other_diffusion
+
+end module other_diffusion
+

--- a/star/other/other_diffusion_coefficients.f90
+++ b/star/other/other_diffusion_coefficients.f90
@@ -22,55 +22,45 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_diffusion_coefficients
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_diffusion_coefficients = .true.
-      ! procedure pointer: s% other_diffusion_coefficients => my_routine
+module other_diffusion_coefficients
 
-      implicit none
-      
-            
-      contains
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_diffusion_coefficients = .true.
+   ! procedure pointer: s% other_diffusion_coefficients => my_routine
 
+   implicit none
 
+contains
 
 ! Compute atomic diffusion coefficients.
-! The input parameters are 
+! The input parameters are
 ! rho          density [gcm^-3]
 ! T            temperature [K]
-! m            number of elements  
+! m            number of elements
 ! A            mass [amu], note element NN is electrons
 ! charge       charge [e]
-! na           number density [cm^-3]  
+! na           number density [cm^-3]
 ! The output are the resistance coefficients in Burgers equations K_ij, z_ij, z'_ij and z''_ij
 ! It is also possible to output diffusion coefficients D_ij and thermal diffusion coeffcient
 !     A_th used in Cowling&Chapman formalism, note Ath(m,i) is Ath_ei
-      
-      
-      
+
 ! NOTE: the number of classes of isos = m-1; m is for electrons
 ! for j from 1 to m-1, you can get the chem id for class j by
 !        cid = chem_get_iso_id(s% diffusion_class_representative(j))
 ! e.g., if the representative for class j is he4, then cid will = ihe4 (defined in chem_def)
 
-      
-      subroutine null_other_diffusion_coefficients( &
-            id, k, nc, m, rho, T, A, X, Z, C, charge, na, &
-            Ddiff, Kdiff, Zdiff, Zdiff1, Zdiff2, Ath)
-         use star_def
-         use const_def, only: dp
-         integer, intent(in) :: id, k, nc, m  
-         real(dp), intent(in) :: rho, T, charge(m), na(m)
-         real(dp), intent(in), dimension(:) :: A, X, Z, C ! (m)
-         real(dp), intent(inout), dimension(m,m) :: &
-            Ddiff, Kdiff, Zdiff, Zdiff1, Zdiff2, Ath
-      end subroutine null_other_diffusion_coefficients
+   subroutine null_other_diffusion_coefficients( &
+      id, k, nc, m, rho, T, A, X, Z, C, charge, na, &
+      Ddiff, Kdiff, Zdiff, Zdiff1, Zdiff2, Ath)
+      use star_def
+      use const_def, only: dp
+      integer, intent(in) :: id, k, nc, m
+      real(dp), intent(in) :: rho, T, charge(m), na(m)
+      real(dp), intent(in), dimension(:) :: A, X, Z, C ! (m)
+      real(dp), intent(inout), dimension(m, m) :: &
+         Ddiff, Kdiff, Zdiff, Zdiff1, Zdiff2, Ath
+   end subroutine null_other_diffusion_coefficients
 
+end module other_diffusion_coefficients
 
-      end module other_diffusion_coefficients
-      
-      
-      
-      

--- a/star/other/other_diffusion_factor.f90
+++ b/star/other/other_diffusion_factor.f90
@@ -22,41 +22,35 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_diffusion_factor
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_diffusion_factor = .true.
-      ! procedure pointer: s% other_diffusion_factor => my_routine
+module other_diffusion_factor
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_diffusion_factor(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k, num_classes
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_diffusion_factor = .true.
+   ! procedure pointer: s% other_diffusion_factor => my_routine
 
-         if(s% diffusion_use_full_net) then
-            num_classes = s% species
-         else
-            num_classes = s% diffusion_num_classes
-         end if
+   implicit none
 
-         s% extra_diffusion_factor(1:num_classes, 1:s% nz) = 1d0
-      end subroutine default_other_diffusion_factor
+contains
 
+   subroutine default_other_diffusion_factor(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: num_classes
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
 
-      end module other_diffusion_factor
-      
-      
-      
-      
+      if (s%diffusion_use_full_net) then
+         num_classes = s%species
+      else
+         num_classes = s%diffusion_num_classes
+      end if
+
+      s%extra_diffusion_factor(1:num_classes, 1:s%nz) = 1d0
+   end subroutine default_other_diffusion_factor
+
+end module other_diffusion_factor
+

--- a/star/other/other_energy.f90
+++ b/star/other/other_energy.f90
@@ -22,37 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_energy
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_energy = .true.
-      ! procedure pointer: s% other_energy => my_routine
+module other_energy
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_energy(id, ierr)
-         use star_def
-         use auto_diff
-         use const_def, only: Rsun
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         !s% extra_heat(:) = s% extra_power_source
-         ! note that extra_heat is type(auto_diff_real_star_order1) so includes partials.
-      end subroutine default_other_energy
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_energy = .true.
+   ! procedure pointer: s% other_energy => my_routine
 
+   implicit none
 
-      end module other_energy
-      
-      
-      
-      
+contains
+
+   subroutine default_other_energy(id, ierr)
+      use star_def
+      use auto_diff
+      use const_def, only: Rsun
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      !s% extra_heat(:) = s% extra_power_source
+      ! note that extra_heat is type(auto_diff_real_star_order1) so includes partials.
+   end subroutine default_other_energy
+
+end module other_energy
+

--- a/star/other/other_energy_implicit.f90
+++ b/star/other/other_energy_implicit.f90
@@ -22,37 +22,31 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_energy_implicit
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_energy_implicit = .true.
-      ! procedure pointer: s% other_energy_implicit => my_routine
+module other_energy_implicit
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_energy_implicit(id, ierr)
-         use star_def
-         use const_def, only: Rsun
-         use auto_diff
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k, nz
-         ierr = 0
-         ! call star_ptr(id, s, ierr)
-         ! if (ierr /= 0) return
-         ! s% extra_heat(1:s%nz) = 1d0 ! erg/g/sec
-         ! note that extra_heat is type(auto_diff_real_star_order1) so includes partials.
-      end subroutine default_other_energy_implicit
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_energy_implicit = .true.
+   ! procedure pointer: s% other_energy_implicit => my_routine
 
+   implicit none
 
-      end module other_energy_implicit
-      
-      
-      
-      
+contains
+
+   subroutine default_other_energy_implicit(id, ierr)
+      use star_def
+      use const_def, only: Rsun
+      use auto_diff
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      !type(star_info), pointer :: s
+      !integer :: k, nz
+      ierr = 0
+      ! call star_ptr(id, s, ierr)
+      ! if (ierr /= 0) return
+      ! s% extra_heat(1:s%nz) = 1d0 ! erg/g/sec
+      ! note that extra_heat is type(auto_diff_real_star_order1) so includes partials.
+   end subroutine default_other_energy_implicit
+
+end module other_energy_implicit
+

--- a/star/other/other_eps_grav.f90
+++ b/star/other/other_eps_grav.f90
@@ -22,39 +22,33 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_eps_grav
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_eps_grav = .true.
-      ! procedure pointer: s% other_eps_grav => my_routine
+module other_eps_grav
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_eps_grav(id, k, dt, ierr)
-         use star_def
-         integer, intent(in) :: id, k
-         real(dp), intent(in) :: dt
-         integer, intent(out) :: ierr
-         ierr = 0
-         
-         ! NOTE: this is called after 1st doing the standard eps_grav calculation.
-         ! so if you decide you don't want to do anything special, just return.
-         
-         ! NOTE: need to set the auto_diff variable s% eps_grav_ad(k)
-         ! this is type(auto_diff_real_star_order1) so includes partials.
-         ! in addition to setting the value,
-         ! you must also set the partials, and there are lots of them.
-         
-      end subroutine null_other_eps_grav
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_eps_grav = .true.
+   ! procedure pointer: s% other_eps_grav => my_routine
 
+   implicit none
 
-      end module other_eps_grav
-      
-      
-      
-      
+contains
+
+   subroutine null_other_eps_grav(id, k, dt, ierr)
+      use star_def
+      integer, intent(in) :: id, k
+      real(dp), intent(in) :: dt
+      integer, intent(out) :: ierr
+      ierr = 0
+
+      ! NOTE: this is called after 1st doing the standard eps_grav calculation.
+      ! so if you decide you don't want to do anything special, just return.
+
+      ! NOTE: need to set the auto_diff variable s% eps_grav_ad(k)
+      ! this is type(auto_diff_real_star_order1) so includes partials.
+      ! in addition to setting the value,
+      ! you must also set the partials, and there are lots of them.
+
+   end subroutine null_other_eps_grav
+
+end module other_eps_grav
+

--- a/star/other/other_eval_fp_ft.f90
+++ b/star/other/other_eval_fp_ft.f90
@@ -22,41 +22,36 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_eval_fp_ft
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_eval_fp_ft = .true.
-      ! procedure pointer: s% other_eval_fp_ft => my_routine
+module other_eval_fp_ft
 
-      implicit none
-      
-            
-      contains
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_eval_fp_ft = .true.
+   ! procedure pointer: s% other_eval_fp_ft => my_routine
 
-      subroutine null_other_eval_fp_ft( &
-            id, nz, xm, r, rho, aw, ft, fp, r_polar, r_equatorial, report_ierr, ierr)
-         use num_lib
-         use star_utils
-         use auto_diff_support
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(in) :: nz
-         real(dp), intent(in) :: aw(:), r(:), rho(:), xm(:) ! (nz)
-         type(auto_diff_real_star_order1), intent(out) :: ft(:), fp(:) ! (nz)
-         real(dp), intent(inout) :: r_polar(:), r_equatorial(:) ! (nz)
-         logical, intent(in) :: report_ierr
-         integer, intent(out) :: ierr
+   implicit none
 
-         write(*,*) 'no implementation for other_eval_fp_ft'
-         ! must set fp, ft, r_polar and r_equatorial
-         ierr = -1
+contains
 
-      end subroutine null_other_eval_fp_ft
-      
+   subroutine null_other_eval_fp_ft( &
+      id, nz, xm, r, rho, aw, ft, fp, r_polar, r_equatorial, report_ierr, ierr)
+      use num_lib
+      use star_utils
+      use auto_diff_support
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(in) :: nz
+      real(dp), intent(in) :: aw(:), r(:), rho(:), xm(:) ! (nz)
+      type(auto_diff_real_star_order1), intent(out) :: ft(:), fp(:) ! (nz)
+      real(dp), intent(inout) :: r_polar(:), r_equatorial(:) ! (nz)
+      logical, intent(in) :: report_ierr
+      integer, intent(out) :: ierr
 
-      end module other_eval_fp_ft
-      
-      
-      
-      
+      write (*, *) 'no implementation for other_eval_fp_ft'
+      ! must set fp, ft, r_polar and r_equatorial
+      ierr = -1
+
+   end subroutine null_other_eval_fp_ft
+
+end module other_eval_fp_ft
+

--- a/star/other/other_eval_i_rot.f90
+++ b/star/other/other_eval_i_rot.f90
@@ -22,35 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_eval_i_rot
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_eval_i_rot = .true.
-      ! procedure pointer: s% other_eval_i_rot => my_routine
-         
-      implicit none
-      
-            
-      contains
+module other_eval_i_rot
 
-      subroutine null_other_eval_i_rot(id,k,r00,w_div_w_crit_roche, i_rot)
-         use star_def
-         use auto_diff_support
-         integer, intent(in) :: id, k
-         real(dp), intent(in) :: r00,w_div_w_crit_roche
-         type(auto_diff_real_star_order1), intent(out) :: i_rot
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_eval_i_rot = .true.
+   ! procedure pointer: s% other_eval_i_rot => my_routine
 
-         i_rot = 0
+   implicit none
 
-         write(*,*) 'no implementation for other_eval_i_rot'
-         stop
+contains
 
-      end subroutine null_other_eval_i_rot
-      
+   subroutine null_other_eval_i_rot(id, k, r00, w_div_w_crit_roche, i_rot)
+      use star_def
+      use auto_diff_support
+      integer, intent(in) :: id, k
+      real(dp), intent(in) :: r00, w_div_w_crit_roche
+      type(auto_diff_real_star_order1), intent(out) :: i_rot
 
-      end module other_eval_i_rot
-      
-      
-      
-      
+      i_rot = 0
+
+      write (*, *) 'no implementation for other_eval_i_rot'
+      stop
+
+   end subroutine null_other_eval_i_rot
+
+end module other_eval_i_rot
+

--- a/star/other/other_gradr_factor.f90
+++ b/star/other/other_gradr_factor.f90
@@ -22,36 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_gradr_factor
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_gradr_factor = .true.
-      ! procedure pointer: s% other_gradr_factor => my_routine
-      
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_gradr_factor(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         do k = 1, s% nz
-            s% gradr_factor(k) = 1d0
-         end do         
-      end subroutine null_other_gradr_factor
+module other_gradr_factor
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_gradr_factor = .true.
+   ! procedure pointer: s% other_gradr_factor => my_routine
 
-      end module other_gradr_factor
-      
-      
-      
-      
+   implicit none
+
+contains
+
+   subroutine null_other_gradr_factor(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      do k = 1, s%nz
+         s%gradr_factor(k) = 1d0
+      end do
+   end subroutine null_other_gradr_factor
+
+end module other_gradr_factor
+

--- a/star/other/other_j_for_adjust_j_lost.f90
+++ b/star/other/other_j_for_adjust_j_lost.f90
@@ -22,35 +22,29 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_j_for_adjust_J_lost
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_j_for_adjust_J_lost = .true.
-      ! procedure pointer: s% other_j_for_adjust_J_lost => my_routine
+module other_j_for_adjust_J_lost
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_j_for_adjust_J_lost = .true.
+   ! procedure pointer: s% other_j_for_adjust_J_lost => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      ! your routine will be called after winds and before mass adjustment
-   
-      subroutine null_other_j_for_adjust_J_lost(id, starting_j_rot_surf, j_for_mass_loss, ierr)
-         use star_def
-         integer, intent(in) :: id
-         real(dp), intent(in) :: starting_j_rot_surf
-         real(dp), intent(out) :: j_for_mass_loss
-         integer, intent(out) :: ierr
-         write(*,*) 'no implementation for other_j_for_adjust_J_lost'
-         ierr = -1
-         j_for_mass_loss = -1d99
-      end subroutine null_other_j_for_adjust_J_lost
+   implicit none
 
+contains
 
-      end module other_j_for_adjust_J_lost
-      
-      
-      
-      
+   ! your routine will be called after winds and before mass adjustment
+
+   subroutine null_other_j_for_adjust_J_lost(id, starting_j_rot_surf, j_for_mass_loss, ierr)
+      use star_def
+      integer, intent(in) :: id
+      real(dp), intent(in) :: starting_j_rot_surf
+      real(dp), intent(out) :: j_for_mass_loss
+      integer, intent(out) :: ierr
+      write (*, *) 'no implementation for other_j_for_adjust_J_lost'
+      ierr = -1
+      j_for_mass_loss = -1d99
+   end subroutine null_other_j_for_adjust_J_lost
+
+end module other_j_for_adjust_J_lost
+

--- a/star/other/other_kap.f90
+++ b/star/other/other_kap.f90
@@ -22,105 +22,96 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_kap
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_kap = .true.
-      ! procedure pointers: s% other_kap_get => my_routine
-      ! (if using OP MONO)  s% other_kap_get_op_mono => my_routine
+module other_kap
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_kap = .true.
+   ! procedure pointers: s% other_kap_get => my_routine
+   ! (if using OP MONO)  s% other_kap_get_op_mono => my_routine
 
-      implicit none
-      
-            
-      contains
+   implicit none
 
+contains
 
-      subroutine null_other_kap_get( &
-            id, k, handle, species, chem_id, net_iso, xa, &
-            log10_rho, log10_T, &
-            lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT, &
-            eta, d_eta_dlnRho, d_eta_dlnT, &
-            kap_fracs, kap, dln_kap_dlnRho, dln_kap_dlnT, dln_kap_dxa, ierr)
-         use star_def
-         use kap_def, only: num_kap_fracs
+   subroutine null_other_kap_get( &
+      id, k, handle, species, chem_id, net_iso, xa, &
+      log10_rho, log10_T, &
+      lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT, &
+      eta, d_eta_dlnRho, d_eta_dlnT, &
+      kap_fracs, kap, dln_kap_dlnRho, dln_kap_dlnT, dln_kap_dxa, ierr)
+      use star_def
+      use kap_def, only: num_kap_fracs
 
-         ! INPUT
-         integer, intent(in) :: id ! star id if available; 0 otherwise
-         integer, intent(in) :: k ! cell number or 0 if not for a particular cell         
-         integer, intent(in) :: handle ! from alloc_kap_handle
-         integer, intent(in) :: species
-         integer, pointer :: chem_id(:) ! maps species to chem id
-            ! index from 1 to species
-            ! value is between 1 and num_chem_isos         
-         integer, pointer :: net_iso(:) ! maps chem id to species number
-            ! index from 1 to num_chem_isos (defined in chem_def)
-            ! value is 0 if the iso is not in the current net
-            ! else is value between 1 and number of species in current net
-         real(dp), intent(in) :: xa(:) ! mass fractions
-         real(dp), intent(in) :: log10_rho ! density
-         real(dp), intent(in) :: log10_T ! temperature
-         real(dp), intent(in) :: lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT
-            ! free_e := total combined number per nucleon of free electrons and positrons
-         real(dp), intent(in) :: eta, d_eta_dlnRho, d_eta_dlnT
-            ! eta := electron degeneracy parameter
-         
-         ! OUTPUT
-         real(dp), intent(out) :: kap_fracs(num_kap_fracs)
-         real(dp), intent(out) :: kap ! opacity
-         real(dp), intent(out) :: dln_kap_dlnRho ! partial derivative at constant T
-         real(dp), intent(out) :: dln_kap_dlnT   ! partial derivative at constant Rho
-         real(dp), intent(out) :: dln_kap_dxa(:) ! partial derivative w.r.t. to species
-         integer, intent(out) :: ierr ! 0 means AOK.
-                  
-         kap_fracs = 0; kap = 0; dln_kap_dlnRho = 0; dln_kap_dlnT = 0; dln_kap_dxa = 0
-         
-         write(*,*) 'no implementation for other_kap_get'
-         ierr = -1
+      ! INPUT
+      integer, intent(in) :: id ! star id if available; 0 otherwise
+      integer, intent(in) :: k ! cell number or 0 if not for a particular cell
+      integer, intent(in) :: handle ! from alloc_kap_handle
+      integer, intent(in) :: species
+      integer, pointer :: chem_id(:) ! maps species to chem id
+      ! index from 1 to species
+      ! value is between 1 and num_chem_isos
+      integer, pointer :: net_iso(:) ! maps chem id to species number
+      ! index from 1 to num_chem_isos (defined in chem_def)
+      ! value is 0 if the iso is not in the current net
+      ! else is value between 1 and number of species in current net
+      real(dp), intent(in) :: xa(:) ! mass fractions
+      real(dp), intent(in) :: log10_rho ! density
+      real(dp), intent(in) :: log10_T ! temperature
+      real(dp), intent(in) :: lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT
+      ! free_e := total combined number per nucleon of free electrons and positrons
+      real(dp), intent(in) :: eta, d_eta_dlnRho, d_eta_dlnT
+      ! eta := electron degeneracy parameter
 
-      end subroutine null_other_kap_get
-      
-      
-      subroutine null_other_kap_get_op_mono( &
-            handle, zbar, log10_rho, log10_T, &
-            ! args for op_mono
-            use_op_mono_alt_get_kap, &
-            nel, izzp, fap, fac, screening, umesh, semesh, ff, rs, &
-            ! output
-            kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
-         use star_def
-         integer, intent(in) :: handle ! from alloc_kap_handle
-         real(dp), intent(in) :: zbar ! average ionic charge (for electron conduction)
-         real(dp), intent(in) :: log10_rho ! the density
-         real(dp), intent(in) :: log10_T ! the temperature
-         ! args for op_mono_get_kap
-         logical, intent(in) :: use_op_mono_alt_get_kap
-         integer, intent(in) :: nel
-         integer, intent(in) :: izzp(:) ! (nel)
-         real(dp), intent(in) :: fap(:) ! (nel) number fractions of elements
-         real(dp), intent(in) :: fac(:) ! (nel) scale factors for element opacity
-         logical, intent(in) :: screening
-         ! work arrays
-         real, pointer :: umesh(:), semesh(:), ff(:,:,:,:), rs(:,:,:)
-            ! umesh(nptot)
-            ! umesh(nptot)
-            ! ff(nptot, ipe, 4, 4)
-            ! rs(nptot, 4, 4)
-            ! ss(nptot, nrad, 4, 4)
-         ! output
-         real(dp), intent(out) :: kap ! opacity
-         real(dp), intent(out) :: dlnkap_dlnRho ! partial derivative at constant T
-         real(dp), intent(out) :: dlnkap_dlnT   ! partial derivative at constant Rho
-         integer, intent(out) :: ierr ! 0 means AOK.
-         kap = 0; dlnkap_dlnRho = 0; dlnkap_dlnT = 0
-         ierr = -1
-      end subroutine null_other_kap_get_op_mono
-      
+      ! OUTPUT
+      real(dp), intent(out) :: kap_fracs(num_kap_fracs)
+      real(dp), intent(out) :: kap ! opacity
+      real(dp), intent(out) :: dln_kap_dlnRho ! partial derivative at constant T
+      real(dp), intent(out) :: dln_kap_dlnT   ! partial derivative at constant Rho
+      real(dp), intent(out) :: dln_kap_dxa(:) ! partial derivative w.r.t. to species
+      integer, intent(out) :: ierr ! 0 means AOK.
 
+      kap_fracs = 0; kap = 0; dln_kap_dlnRho = 0; dln_kap_dlnT = 0; dln_kap_dxa = 0
 
-      end module other_kap
-      
-      
-      
-      
+      write (*, *) 'no implementation for other_kap_get'
+      ierr = -1
+
+   end subroutine null_other_kap_get
+
+   subroutine null_other_kap_get_op_mono( &
+      handle, zbar, log10_rho, log10_T, &
+      ! args for op_mono
+      use_op_mono_alt_get_kap, &
+      nel, izzp, fap, fac, screening, umesh, semesh, ff, rs, &
+      ! output
+      kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
+      use star_def
+      integer, intent(in) :: handle ! from alloc_kap_handle
+      real(dp), intent(in) :: zbar ! average ionic charge (for electron conduction)
+      real(dp), intent(in) :: log10_rho ! the density
+      real(dp), intent(in) :: log10_T ! the temperature
+      ! args for op_mono_get_kap
+      logical, intent(in) :: use_op_mono_alt_get_kap
+      integer, intent(in) :: nel
+      integer, intent(in) :: izzp(:) ! (nel)
+      real(dp), intent(in) :: fap(:) ! (nel) number fractions of elements
+      real(dp), intent(in) :: fac(:) ! (nel) scale factors for element opacity
+      logical, intent(in) :: screening
+      ! work arrays
+      real, pointer :: umesh(:), semesh(:), ff(:, :, :, :), rs(:, :, :)
+      ! umesh(nptot)
+      ! umesh(nptot)
+      ! ff(nptot, ipe, 4, 4)
+      ! rs(nptot, 4, 4)
+      ! ss(nptot, nrad, 4, 4)
+      ! output
+      real(dp), intent(out) :: kap ! opacity
+      real(dp), intent(out) :: dlnkap_dlnRho ! partial derivative at constant T
+      real(dp), intent(out) :: dlnkap_dlnT   ! partial derivative at constant Rho
+      integer, intent(out) :: ierr ! 0 means AOK.
+      kap = 0; dlnkap_dlnRho = 0; dlnkap_dlnT = 0
+      ierr = -1
+   end subroutine null_other_kap_get_op_mono
+
+end module other_kap
+

--- a/star/other/other_mesh_delta_coeff_factor.f90
+++ b/star/other/other_mesh_delta_coeff_factor.f90
@@ -22,34 +22,26 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_mesh_delta_coeff_factor
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_mesh_delta_coeff_factor = .true.
-      ! procedure pointer: s% other_mesh_delta_coeff_factor => my_routine
+module other_mesh_delta_coeff_factor
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_mesh_delta_coeff_factor = .true.
+   ! procedure pointer: s% other_mesh_delta_coeff_factor => my_routine
 
-      implicit none
+   implicit none
 
-      
-      contains
-      
-      
-      subroutine default_other_mesh_delta_coeff_factor(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         s% mesh_delta_coeff_factor(:) = 1d0
-      end subroutine default_other_mesh_delta_coeff_factor
+contains
 
-      end module other_mesh_delta_coeff_factor
-      
-      
-      
-      
+   subroutine default_other_mesh_delta_coeff_factor(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      s%mesh_delta_coeff_factor(:) = 1d0
+   end subroutine default_other_mesh_delta_coeff_factor
+
+end module other_mesh_delta_coeff_factor

--- a/star/other/other_mesh_functions.f90
+++ b/star/other/other_mesh_functions.f90
@@ -22,85 +22,75 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_mesh_functions
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_mesh_functions = .true.
-      ! procedure pointer: s% other_mesh_fcn_data => my_routine
+module other_mesh_functions
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_mesh_functions = .true.
+   ! procedure pointer: s% other_mesh_fcn_data => my_routine
 
-      ! remember to set use_other_mesh_functions = .true. to enable this.
-      ! edit the extras_controls routine to set the procedure pointers
-      ! e.g.,
-         ! s% how_many_other_mesh_fcns => how_many_my_other_mesh_fcns
-         ! s% other_mesh_fcn_data => my_other_mesh_fcn_data
+   ! remember to set use_other_mesh_functions = .true. to enable this.
+   ! edit the extras_controls routine to set the procedure pointers
+   ! e.g.,
+   ! s% how_many_other_mesh_fcns => how_many_my_other_mesh_fcns
+   ! s% other_mesh_fcn_data => my_other_mesh_fcn_data
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_how_many_other_mesh_fcns(id, n)
-         integer, intent(in) :: id
-         integer, intent(out) :: n
-         n = 0
-      end subroutine null_how_many_other_mesh_fcns
-      
-      
-      subroutine null_other_mesh_fcn_data( &
-            id, nfcns, names, gval_is_xa_function, vals1, ierr)
-         use const_def
-         integer, intent(in) :: id
-         integer, intent(in) :: nfcns
-         character (len=*) :: names(:)
-         logical, intent(out) :: gval_is_xa_function(:) ! (nfcns)
-         real(dp), pointer :: vals1(:) ! =(nz, nfcns)
-         integer, intent(out) :: ierr
-         gval_is_xa_function(1:nfcns) = .false.
-         ierr = 0
-      end subroutine null_other_mesh_fcn_data
+   implicit none
 
-      
-      ! here is an example that adds a mesh function for log(opacity)
-      subroutine how_many_other_mesh_fcns(id, n)
-         integer, intent(in) :: id
-         integer, intent(out) :: n
-         n = 1
-      end subroutine how_many_other_mesh_fcns
-      
-      
-      subroutine other_mesh_fcn_data( &
-            id, nfcns, names, gval_is_xa_function, vals1, ierr)
-         use star_def
-         use math_lib
-         use const_def
-         integer, intent(in) :: id
-         integer, intent(in) :: nfcns
-         character (len=*) :: names(:)
-         logical, intent(out) :: gval_is_xa_function(:) ! (nfcns)
-         real(dp), pointer :: vals1(:) ! =(nz, nfcns)
-         integer, intent(out) :: ierr
-         integer :: nz, k
-         real(dp), pointer :: vals(:,:)
-         real(dp), parameter :: weight = 20
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         names(1) = 'kap_function'
-         gval_is_xa_function(1) = .false.
-         nz = s% nz
-         vals(1:nz,1:nfcns) => vals1(1:nz*nfcns)
-         do k=1,nz
-            vals(k,1) = weight*log10(s% opacity(k))
-         end do
-      end subroutine other_mesh_fcn_data
+contains
 
+   subroutine null_how_many_other_mesh_fcns(id, n)
+      integer, intent(in) :: id
+      integer, intent(out) :: n
+      n = 0
+   end subroutine null_how_many_other_mesh_fcns
 
-      end module other_mesh_functions
-      
-      
-      
-      
+   subroutine null_other_mesh_fcn_data( &
+      id, nfcns, names, gval_is_xa_function, vals1, ierr)
+      use const_def
+      integer, intent(in) :: id
+      integer, intent(in) :: nfcns
+      character(len=*) :: names(:)
+      logical, intent(out) :: gval_is_xa_function(:) ! (nfcns)
+      real(dp), pointer :: vals1(:) ! =(nz, nfcns)
+      integer, intent(out) :: ierr
+      gval_is_xa_function(1:nfcns) = .false.
+      ierr = 0
+   end subroutine null_other_mesh_fcn_data
+
+   ! here is an example that adds a mesh function for log(opacity)
+   subroutine how_many_other_mesh_fcns(id, n)
+      integer, intent(in) :: id
+      integer, intent(out) :: n
+      n = 1
+   end subroutine how_many_other_mesh_fcns
+
+   subroutine other_mesh_fcn_data( &
+      id, nfcns, names, gval_is_xa_function, vals1, ierr)
+      use star_def
+      use math_lib
+      use const_def
+      integer, intent(in) :: id
+      integer, intent(in) :: nfcns
+      character(len=*) :: names(:)
+      logical, intent(out) :: gval_is_xa_function(:) ! (nfcns)
+      real(dp), pointer :: vals1(:) ! =(nz, nfcns)
+      integer, intent(out) :: ierr
+      integer :: nz, k
+      real(dp), pointer :: vals(:, :)
+      real(dp), parameter :: weight = 20
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      names(1) = 'kap_function'
+      gval_is_xa_function(1) = .false.
+      nz = s%nz
+      vals(1:nz, 1:nfcns) => vals1(1:nz*nfcns)
+      do k = 1, nz
+         vals(k, 1) = weight*log10(s%opacity(k))
+      end do
+   end subroutine other_mesh_fcn_data
+
+end module other_mesh_functions
+

--- a/star/other/other_mlt_results.f90
+++ b/star/other/other_mlt_results.f90
@@ -22,47 +22,40 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_mlt_results
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_mlt_results = .true.
-      ! procedure pointer: s% other_mlt_results => my_routine
+module other_mlt_results
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_mlt_results = .true.
+   ! procedure pointer: s% other_mlt_results => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_mlt_results(id, k, MLT_option, &  ! NOTE: k=0 is a valid arg
-            r, L, T, P, opacity, rho, chiRho, chiT, Cp, gradr, grada, scale_height, &
-            iso, XH1, cgrav, m, gradL_composition_term, mixing_length_alpha, &
-            alpha_semiconvection, thermohaline_coeff, &
-            mixing_type, gradT, Y_face, conv_vel, D, Gamma, ierr)
-         use const_def, only: dp
-         use auto_diff
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(in) :: k
-         character (len=*), intent(in) :: MLT_option
-         type(auto_diff_real_star_order1), intent(in) :: &
-            r, L, T, P, opacity, rho, chiRho, chiT, Cp, gradr, grada, scale_height
-         integer, intent(in) :: iso
-         real(dp), intent(in) :: &
-            XH1, cgrav, m, gradL_composition_term, &
-            mixing_length_alpha, alpha_semiconvection, thermohaline_coeff
-         integer, intent(out) :: mixing_type
-         type(auto_diff_real_star_order1), intent(out) :: &
-            gradT, Y_face, conv_vel, D, Gamma
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_other_mlt_results
+   implicit none
 
+contains
 
-      end module other_mlt_results
-      
-      
-      
-      
+   subroutine null_other_mlt_results(id, k, MLT_option, &  ! NOTE: k=0 is a valid arg
+                                     r, L, T, P, opacity, rho, chiRho, chiT, Cp, gradr, grada, scale_height, &
+                                     iso, XH1, cgrav, m, gradL_composition_term, mixing_length_alpha, &
+                                     alpha_semiconvection, thermohaline_coeff, &
+                                     mixing_type, gradT, Y_face, conv_vel, D, Gamma, ierr)
+      use const_def, only: dp
+      use auto_diff
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(in) :: k
+      character(len=*), intent(in) :: MLT_option
+      type(auto_diff_real_star_order1), intent(in) :: &
+         r, L, T, P, opacity, rho, chiRho, chiT, Cp, gradr, grada, scale_height
+      integer, intent(in) :: iso
+      real(dp), intent(in) :: &
+         XH1, cgrav, m, gradL_composition_term, &
+         mixing_length_alpha, alpha_semiconvection, thermohaline_coeff
+      integer, intent(out) :: mixing_type
+      type(auto_diff_real_star_order1), intent(out) :: &
+         gradT, Y_face, conv_vel, D, Gamma
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_other_mlt_results
+
+end module other_mlt_results
+

--- a/star/other/other_momentum.f90
+++ b/star/other/other_momentum.f90
@@ -22,37 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_momentum
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_momentum = .true.
-      ! procedure pointer: s% other_momentum => my_routine
+module other_momentum
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_momentum = .true.
+   ! procedure pointer: s% other_momentum => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_momentum(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         do k = 1, s% nz
-            !s% extra_grav(k) = 0d0 ! this is added to -G*m/r^2
-         end do
-      end subroutine default_other_momentum
+   implicit none
 
+contains
 
-      end module other_momentum
-      
-      
-      
-      
+   subroutine default_other_momentum(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      do k = 1, s%nz
+         !s% extra_grav(k) = 0d0 ! this is added to -G*m/r^2
+      end do
+   end subroutine default_other_momentum
+
+end module other_momentum
+

--- a/star/other/other_momentum_implicit.f90
+++ b/star/other/other_momentum_implicit.f90
@@ -22,36 +22,28 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_momentum_implicit
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_momentum_implicit = .true.
-      ! procedure pointer: s% other_momentum_implicit => my_routine
+module other_momentum_implicit
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_momentum_implicit = .true.
+   ! procedure pointer: s% other_momentum_implicit => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_momentum_implicit(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         ! s% extra_grav(1:s%nz) = 0 ! this is added to -G*m/r^2
-         ! note that extra_grav is type(auto_diff_real_star_order1) so includes partials.
-      end subroutine default_other_momentum_implicit
+   implicit none
 
+contains
 
-      end module other_momentum_implicit
-      
-      
-      
-      
+   subroutine default_other_momentum_implicit(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      ! s% extra_grav(1:s%nz) = 0 ! this is added to -G*m/r^2
+      ! note that extra_grav is type(auto_diff_real_star_order1) so includes partials.
+   end subroutine default_other_momentum_implicit
+
+end module other_momentum_implicit
+

--- a/star/other/other_net_derivs.f90
+++ b/star/other/other_net_derivs.f90
@@ -22,13 +22,13 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-   module other_net_derivs
+
+module other_net_derivs
 
    implicit none
 
-   ! set use_other_net_derivs = .true. in your controls namelist   
-        
+   ! set use_other_net_derivs = .true. in your controls namelist
+
    ! edit the extras_controls routine to set the procedure pointer
    !  other_net_derivs => my_net_derivs
 
@@ -38,30 +38,26 @@
 
    ! This hook only works with soft nets (so no approx networks)
 
-   contains
+contains
 
-
-   subroutine default_other_net_derivs(&
+   subroutine default_other_net_derivs( &
       n, dydt, eps_nuc_MeV, eta, ye, logtemp, temp, den, abar, zbar, &
       num_reactions, rate_factors, &
       symbolic, just_dydt, ierr)
       use net_def
-      
+
       implicit none
 
       type(Net_Info) :: n
-      real(qp), pointer, intent(inout) :: dydt(:,:)
+      real(qp), pointer, intent(inout) :: dydt(:, :)
       real(qp), intent(out) :: eps_nuc_MeV(:)
       integer, intent(in) :: num_reactions
       real(dp), intent(in) ::eta, ye, logtemp, temp, den, abar, zbar, &
-         rate_factors(:)
+                              rate_factors(:)
       logical, intent(in) :: symbolic, just_dydt
       integer, intent(out) :: ierr
 
    end subroutine default_other_net_derivs
 
-   end module other_net_derivs        
-        
-        
-        
-  
+end module other_net_derivs
+

--- a/star/other/other_net_get.f90
+++ b/star/other/other_net_get.f90
@@ -22,80 +22,74 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_net_get
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_net_get = .true.
-      ! procedure pointer: s% other_net_get => my_routine
+module other_net_get
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_net_get(  &
-            id, k, net_handle, just_dxdt, n, num_isos, num_reactions,  &
-            x, temp, log10temp, rho, log10rho,  &
-            abar, zbar, z2bar, ye, eta, d_eta_dlnT, d_eta_dlnRho, &
-            rate_factors, weak_rate_factor, &
-            reaction_Qs, reaction_neuQs, &
-            eps_nuc, d_eps_nuc_dRho, d_eps_nuc_dT, d_eps_nuc_dx,  &
-            dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
-            screening_mode, &
-            eps_nuc_categories, eps_neu_total, &
-            ierr)      
-         use star_def
-         use net_lib, only: net_get
-         use net_def, only: Net_Info
-         integer, intent(in) :: id ! id for star         
-         integer, intent(in) :: k ! cell number or 0 if not for a particular cell         
-         integer, intent(in) :: net_handle
-         logical, intent(in) :: just_dxdt
-         type (Net_Info) :: n
-         integer, intent(in) :: num_isos
-         integer, intent(in) :: num_reactions
-         real(dp), intent(in)  :: x(:) ! (num_isos)
-         real(dp), intent(in)  :: temp, log10temp ! log10 of temp
-         real(dp), intent(in)  :: rho, log10rho ! log10 of rho
-         real(dp), intent(in)  :: abar  ! mean number of nucleons per nucleus
-         real(dp), intent(in)  :: zbar  ! mean charge per nucleus
-         real(dp), intent(in)  :: z2bar ! mean charge squared per nucleus
-         real(dp), intent(in)  :: ye    
-         real(dp), intent(in)  :: eta, d_eta_dlnT, d_eta_dlnRho ! electron degeneracy from eos.
-         real(dp), intent(in), pointer :: rate_factors(:) ! (num_reactions)
-         real(dp), intent(in) :: weak_rate_factor
-         real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
-         real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
-         real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including losses to reaction neutrinos
-         real(dp), intent(out) :: d_eps_nuc_dT
-         real(dp), intent(out) :: d_eps_nuc_dRho
-         real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos)       
-         real(dp), intent(inout) :: dxdt(:) ! (num_isos)
-         real(dp), intent(inout) :: d_dxdt_dRho(:) ! (num_isos)
-         real(dp), intent(inout) :: d_dxdt_dT(:) ! (num_isos)
-         real(dp), intent(inout) :: d_dxdt_dx(:,:) ! (num_isos, num_isos)            
-         real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
-         real(dp), intent(out) :: eps_neu_total ! ergs/g/s neutrinos from weak reactions
-         integer, intent(in) :: screening_mode
-         integer, intent(out) :: ierr ! 0 means okay
-         call net_get( &
-            net_handle, just_dxdt, n, num_isos, num_reactions,  &
-            x, temp, log10temp, rho, log10rho,  &
-            abar, zbar, z2bar, ye, eta, d_eta_dlnT, d_eta_dlnRho, &
-            rate_factors, weak_rate_factor, &
-            reaction_Qs, reaction_neuQs, &
-            eps_nuc, d_eps_nuc_dRho, d_eps_nuc_dT, d_eps_nuc_dx,  &
-            dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx,  &
-            screening_mode, &
-            eps_nuc_categories, eps_neu_total, &
-            ierr)
-      end subroutine null_other_net_get
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_net_get = .true.
+   ! procedure pointer: s% other_net_get => my_routine
 
+   implicit none
 
-      end module other_net_get
-      
-      
-      
-      
+contains
+
+   subroutine null_other_net_get( &
+      id, k, net_handle, just_dxdt, n, num_isos, num_reactions, &
+      x, temp, log10temp, rho, log10rho, &
+      abar, zbar, z2bar, ye, eta, d_eta_dlnT, d_eta_dlnRho, &
+      rate_factors, weak_rate_factor, &
+      reaction_Qs, reaction_neuQs, &
+      eps_nuc, d_eps_nuc_dRho, d_eps_nuc_dT, d_eps_nuc_dx, &
+      dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx, &
+      screening_mode, &
+      eps_nuc_categories, eps_neu_total, &
+      ierr)
+      use star_def
+      use net_lib, only: net_get
+      use net_def, only: Net_Info
+      integer, intent(in) :: id ! id for star
+      integer, intent(in) :: k ! cell number or 0 if not for a particular cell
+      integer, intent(in) :: net_handle
+      logical, intent(in) :: just_dxdt
+      type(Net_Info) :: n
+      integer, intent(in) :: num_isos
+      integer, intent(in) :: num_reactions
+      real(dp), intent(in)  :: x(:) ! (num_isos)
+      real(dp), intent(in)  :: temp, log10temp ! log10 of temp
+      real(dp), intent(in)  :: rho, log10rho ! log10 of rho
+      real(dp), intent(in)  :: abar  ! mean number of nucleons per nucleus
+      real(dp), intent(in)  :: zbar  ! mean charge per nucleus
+      real(dp), intent(in)  :: z2bar ! mean charge squared per nucleus
+      real(dp), intent(in)  :: ye
+      real(dp), intent(in)  :: eta, d_eta_dlnT, d_eta_dlnRho ! electron degeneracy from eos.
+      real(dp), intent(in), pointer :: rate_factors(:) ! (num_reactions)
+      real(dp), intent(in) :: weak_rate_factor
+      real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
+      real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
+      real(dp), intent(out) :: eps_nuc ! ergs/g/s from burning after including losses to reaction neutrinos
+      real(dp), intent(out) :: d_eps_nuc_dT
+      real(dp), intent(out) :: d_eps_nuc_dRho
+      real(dp), intent(inout) :: d_eps_nuc_dx(:) ! (num_isos)
+      real(dp), intent(inout) :: dxdt(:) ! (num_isos)
+      real(dp), intent(inout) :: d_dxdt_dRho(:) ! (num_isos)
+      real(dp), intent(inout) :: d_dxdt_dT(:) ! (num_isos)
+      real(dp), intent(inout) :: d_dxdt_dx(:, :) ! (num_isos, num_isos)
+      real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
+      real(dp), intent(out) :: eps_neu_total ! ergs/g/s neutrinos from weak reactions
+      integer, intent(in) :: screening_mode
+      integer, intent(out) :: ierr ! 0 means okay
+      call net_get( &
+         net_handle, just_dxdt, n, num_isos, num_reactions, &
+         x, temp, log10temp, rho, log10rho, &
+         abar, zbar, z2bar, ye, eta, d_eta_dlnT, d_eta_dlnRho, &
+         rate_factors, weak_rate_factor, &
+         reaction_Qs, reaction_neuQs, &
+         eps_nuc, d_eps_nuc_dRho, d_eps_nuc_dT, d_eps_nuc_dx, &
+         dxdt, d_dxdt_dRho, d_dxdt_dT, d_dxdt_dx, &
+         screening_mode, &
+         eps_nuc_categories, eps_neu_total, &
+         ierr)
+   end subroutine null_other_net_get
+
+end module other_net_get
+

--- a/star/other/other_neu.f90
+++ b/star/other/other_neu.f90
@@ -22,46 +22,40 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_neu
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_neu = .true.
-      ! procedure pointer: s% other_neu => my_routine
+module other_neu
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_neu(  &
-            id, k, T, log10_T, Rho, log10_Rho, abar, zbar, log10_Tlim, flags, &
-            loss, sources, ierr)
-         use star_def
-         use neu_lib, only: neu_get
-         use neu_def
-         integer, intent(in) :: id ! id for star         
-         integer, intent(in) :: k ! cell number or 0 if not for a particular cell         
-         real(dp), intent(in) :: T ! temperature
-         real(dp), intent(in) :: log10_T ! log10 of temperature
-         real(dp), intent(in) :: Rho ! density
-         real(dp), intent(in) :: log10_Rho ! log10 of density
-         real(dp), intent(in) :: abar ! mean atomic weight
-         real(dp), intent(in) :: zbar ! mean charge
-         real(dp), intent(in) :: log10_Tlim 
-         logical, intent(inout) :: flags(num_neu_types) ! true if should include the type of loss
-         real(dp), intent(inout) :: loss(num_neu_rvs) ! total from all sources
-         real(dp), intent(inout) :: sources(num_neu_types, num_neu_rvs)
-         integer, intent(out) :: ierr
-         call neu_get(  &
-            T, log10_T, Rho, log10_Rho, abar, zbar, log10_Tlim, flags, &
-            loss, sources, ierr)
-      end subroutine null_other_neu
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_neu = .true.
+   ! procedure pointer: s% other_neu => my_routine
 
+   implicit none
 
-      end module other_neu
-      
-      
-      
-      
+contains
+
+   subroutine null_other_neu( &
+      id, k, T, log10_T, Rho, log10_Rho, abar, zbar, log10_Tlim, flags, &
+      loss, sources, ierr)
+      use star_def
+      use neu_lib, only: neu_get
+      use neu_def
+      integer, intent(in) :: id ! id for star
+      integer, intent(in) :: k ! cell number or 0 if not for a particular cell
+      real(dp), intent(in) :: T ! temperature
+      real(dp), intent(in) :: log10_T ! log10 of temperature
+      real(dp), intent(in) :: Rho ! density
+      real(dp), intent(in) :: log10_Rho ! log10 of density
+      real(dp), intent(in) :: abar ! mean atomic weight
+      real(dp), intent(in) :: zbar ! mean charge
+      real(dp), intent(in) :: log10_Tlim
+      logical, intent(inout) :: flags(num_neu_types) ! true if should include the type of loss
+      real(dp), intent(inout) :: loss(num_neu_rvs) ! total from all sources
+      real(dp), intent(inout) :: sources(num_neu_types, num_neu_rvs)
+      integer, intent(out) :: ierr
+      call neu_get( &
+         T, log10_T, Rho, log10_Rho, abar, zbar, log10_Tlim, flags, &
+         loss, sources, ierr)
+   end subroutine null_other_neu
+
+end module other_neu
+

--- a/star/other/other_opacity_factor.f90
+++ b/star/other/other_opacity_factor.f90
@@ -22,34 +22,26 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_opacity_factor
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_opacity_factor = .true.
-      ! procedure pointer: s% other_opacity_factor => my_routine
+module other_opacity_factor
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_opacity_factor(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         s% extra_opacity_factor(1:s% nz) = s% opacity_factor
-      end subroutine default_other_opacity_factor
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_opacity_factor = .true.
+   ! procedure pointer: s% other_opacity_factor => my_routine
 
+   implicit none
 
-      end module other_opacity_factor
-      
-      
-      
-      
+contains
+
+   subroutine default_other_opacity_factor(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      s%extra_opacity_factor(1:s%nz) = s%opacity_factor
+   end subroutine default_other_opacity_factor
+
+end module other_opacity_factor

--- a/star/other/other_overshooting_scheme.f90
+++ b/star/other/other_overshooting_scheme.f90
@@ -22,37 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_overshooting_scheme
 
-      ! consult star/other/README for general usage instructions
-      ! procedure pointer: s% other_overshooting_scheme => my_routine
-      ! note that this is enabled by setting s%overshooting_scheme = 'other'
-      ! so there is no use_other_overshooting_scheme flag.
+module other_overshooting_scheme
 
+   ! consult star/other/README for general usage instructions
+   ! procedure pointer: s% other_overshooting_scheme => my_routine
+   ! note that this is enabled by setting s%overshooting_scheme = 'other'
+   ! so there is no use_other_overshooting_scheme flag.
 
-      implicit none
-      
-      contains
-            
-      subroutine null_other_overshooting_scheme(id, i, j, k_a, k_b, D, vc, ierr)
-         use star_def
-         integer, intent(in) :: id, i, j
-         integer, intent(out) :: k_a, k_b
-         real(dp), intent(out), dimension(:) :: D, vc
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         k_a = -1
-         k_b = -1
-         D = 0d0
-         vc = 0d0
+   implicit none
 
-         ierr = -1
-      end subroutine null_other_overshooting_scheme
+contains
 
-      end module other_overshooting_scheme
-      
-      
-      
-      
+   subroutine null_other_overshooting_scheme(id, i, j, k_a, k_b, D, vc, ierr)
+      use star_def
+      integer, intent(in) :: id, i, j
+      integer, intent(out) :: k_a, k_b
+      real(dp), intent(out), dimension(:) :: D, vc
+      integer, intent(out) :: ierr
+      k_a = -1
+      k_b = -1
+      D = 0d0
+      vc = 0d0
+
+      ierr = -1
+   end subroutine null_other_overshooting_scheme
+
+end module other_overshooting_scheme

--- a/star/other/other_pgstar_plots.f90
+++ b/star/other/other_pgstar_plots.f90
@@ -22,33 +22,26 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_pgstar_plots
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_pgstar_plots = .true.
-      ! procedure pointer: s% other_pgstar_plots_info => my_routine
+module other_pgstar_plots
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_pgstar_plots = .true.
+   ! procedure pointer: s% other_pgstar_plots_info => my_routine
 
-      ! see star/other/sample_pgstar_plot.f90
-        
-      implicit none
+   ! see star/other/sample_pgstar_plot.f90
 
-                  
-      contains
-      
-      
-      ! default does nothing
-      subroutine null_other_pgstar_plots_info(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_other_pgstar_plots_info
+   implicit none
 
+contains
 
-      end module other_pgstar_plots
-      
-      
-      
-      
+   ! default does nothing
+   subroutine null_other_pgstar_plots_info(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_other_pgstar_plots_info
+
+end module other_pgstar_plots
+

--- a/star/other/other_photo_read.f90
+++ b/star/other/other_photo_read.f90
@@ -22,31 +22,24 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_photo_read
 
+module other_photo_read
 
-      implicit none
+   implicit none
 
-      ! note: there is no flag "use_other_photo_read".  
-      ! the other routine is always called when a photo is read.
-      ! see private/model_in.f
-      
-      contains
-      
+   ! note: there is no flag "use_other_photo_read".
+   ! the other routine is always called when a photo is read.
+   ! see private/model_in.f
 
-      subroutine default_other_photo_read(id, iounit, ierr)
-         use star_def
-         integer, intent(in) :: id, iounit
-         integer, intent(out) :: ierr
-         ierr = 0
-         !read(iounit,iostat=ierr) stuff
-      end subroutine default_other_photo_read
+contains
 
+   subroutine default_other_photo_read(id, iounit, ierr)
+      use star_def
+      integer, intent(in) :: id, iounit
+      integer, intent(out) :: ierr
+      ierr = 0
+      !read(iounit,iostat=ierr) stuff
+   end subroutine default_other_photo_read
 
+end module other_photo_read
 
-      end module other_photo_read
-      
-      
-      
-      

--- a/star/other/other_photo_write.f90
+++ b/star/other/other_photo_write.f90
@@ -22,30 +22,23 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_photo_write
 
+module other_photo_write
 
-      use star_def
+   use star_def
 
-      implicit none
+   implicit none
 
-      ! note: there is no flag "use_other_photo_write".  
-      ! the other routine is always called when a photo is written.
-      ! see private/model_out.f
-      
-      contains
-      
+   ! note: there is no flag "use_other_photo_write".
+   ! the other routine is always called when a photo is written.
+   ! see private/model_out.f
 
-      subroutine default_other_photo_write(id, iounit)
-         integer, intent(in) :: id, iounit
-         !write(iounit) stuff
-      end subroutine default_other_photo_write
+contains
 
+   subroutine default_other_photo_write(id, iounit)
+      integer, intent(in) :: id, iounit
+      !write(iounit) stuff
+   end subroutine default_other_photo_write
 
+end module other_photo_write
 
-      end module other_photo_write
-      
-      
-      
-      

--- a/star/other/other_pressure.f90
+++ b/star/other/other_pressure.f90
@@ -22,40 +22,33 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_pressure
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_pressure = .true.
-      ! procedure pointer: s% other_pressure => my_routine
+module other_pressure
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_pressure = .true.
+   ! procedure pointer: s% other_pressure => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_pressure(id, ierr)
-         use star_def
-         use auto_diff
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         do k=1,s%nz
-            s% extra_pressure(k) = 0d0
-         end do
-         ! note that extra_pressure is type(auto_diff_real_star_order1) so includes partials.
-         return
-      end subroutine default_other_pressure
+   implicit none
 
+contains
 
-      end module other_pressure
-      
-      
-      
-      
+   subroutine default_other_pressure(id, ierr)
+      use star_def
+      use auto_diff
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      do k = 1, s%nz
+         s%extra_pressure(k) = 0d0
+      end do
+      ! note that extra_pressure is type(auto_diff_real_star_order1) so includes partials.
+      return
+   end subroutine default_other_pressure
+
+end module other_pressure
+

--- a/star/other/other_rate_get.f90
+++ b/star/other/other_rate_get.f90
@@ -22,30 +22,29 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-   module other_rate
+
+module other_rate
 
    implicit none
 
-   ! set use_other_rate_get = .true. in your controls namelist   
-        
+   ! set use_other_rate_get = .true. in your controls namelist
+
    ! edit the extras_controls routine to set the procedure pointer
    !  other_rate_get => my_rate_get
 
-   ! This hook is primarily aimed at either modifying an existing mesa reaction or 
+   ! This hook is primarily aimed at either modifying an existing mesa reaction or
    ! providing your own custom rate that depends only on temperature (density factors are handled elsewhere)
    ! This hook can only handle existing reactions. This is not the place to try and add a new reaction.
 
    ! This is also called early in the setup of MESA so there is no stellar structure yet
    ! Thus we call this multiple times (each with a different temperature) for each reaction.
 
-   ! Note this will effect the cached rate written to data/rates_data/cache 
+   ! Note this will effect the cached rate written to data/rates_data/cache
    ! Becuase of this it will only get called if the rate does NOT already exist in your rates_cache
    ! I recommend you use the rates_cache_dir option to redirect your rates_cache when using this hook
    ! So you dont break your whole mesa install.
 
-   contains
-
+contains
 
    subroutine default_other_rate_get(ir, temp, tf, raw_rate, ierr)
       use rates_def
@@ -53,22 +52,18 @@
       implicit none
 
       integer :: ir ! Rate id
-      real(dp),intent(in) ::    temp      !< Temperature
-      type (T_Factors) :: tf !< Various temperature factors
-      real(dp),intent(inout) ::   raw_rate     !< Unscreened reaction_rate, note this will have the default mesa rate on entry
+      real(dp), intent(in) ::    temp      !< Temperature
+      type(T_Factors) :: tf !< Various temperature factors
+      real(dp), intent(inout) ::   raw_rate     !< Unscreened reaction_rate, note this will have the default mesa rate on entry
       integer, intent(out) ::   ierr
-   
+
       ierr = 0
 
       if (trim(reaction_name(ir)) == 'r_c12_ag_o16') then
-         raw_rate = 1.0 * raw_rate
+         raw_rate = 1.0*raw_rate
       end if
 
    end subroutine default_other_rate_get
 
-   end module other_rate
-        
-        
-        
-        
-  
+end module other_rate
+

--- a/star/other/other_remove_surface.f90
+++ b/star/other/other_remove_surface.f90
@@ -22,37 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_remove_surface
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_remove_surface = .true.
-      ! procedure pointer: s% other_remove_surface => my_routine
+module other_remove_surface
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_remove_surface = .true.
+   ! procedure pointer: s% other_remove_surface => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_remove_surface(id, ierr, k)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         integer, intent(out) :: k
+   implicit none
 
-         type (star_info), pointer :: s
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
+contains
 
-         k = 0 ! The cell to remove down to.
-      end subroutine default_other_remove_surface
+   subroutine default_other_remove_surface(id, ierr, k)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      integer, intent(out) :: k
 
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
 
-      end module other_remove_surface
-      
-      
-      
-      
+      k = 0 ! The cell to remove down to.
+   end subroutine default_other_remove_surface
+
+end module other_remove_surface
+

--- a/star/other/other_rsp_build_model.f90
+++ b/star/other/other_rsp_build_model.f90
@@ -22,42 +22,36 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_rsp_build_model
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_RSP_build_model = .true.
-      ! procedure pointer: s% other_rsp_build_model => my_routine
+module other_rsp_build_model
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_RSP_build_model = .true.
+   ! procedure pointer: s% other_rsp_build_model => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      ! here is a list of what this routine needs to set.  
-      ! star arrays have been allocated but nothing else.
-      ! note that nz is set by RSP_nz.
-      
-      ! scalars
-         ! M_center, L_center, R_center, v_center
-         ! star_mass, mstar, xmstar, tau_factor, rsp_period
-      
-      ! vectors
-         ! m, dm, dm_bar, r, Vol, v, T, w, Fr, erad, L
-         ! don't need to set xh or xa
+   implicit none
 
-      subroutine null_other_rsp_build_model(id, ierr)
-         use star_def
-         integer, intent(in) :: id ! star id if available; 0 otherwise
-         integer, intent(out) :: ierr ! 0 means AOK.         
-         write(*,*) 'no implementation for other_rsp_build_model'
-         ierr = -1
-      end subroutine null_other_rsp_build_model
+contains
 
+   ! here is a list of what this routine needs to set.
+   ! star arrays have been allocated but nothing else.
+   ! note that nz is set by RSP_nz.
 
-      end module other_rsp_build_model
-      
-      
-      
-      
+   ! scalars
+   ! M_center, L_center, R_center, v_center
+   ! star_mass, mstar, xmstar, tau_factor, rsp_period
+
+   ! vectors
+   ! m, dm, dm_bar, r, Vol, v, T, w, Fr, erad, L
+   ! don't need to set xh or xa
+
+   subroutine null_other_rsp_build_model(id, ierr)
+      use star_def
+      integer, intent(in) :: id ! star id if available; 0 otherwise
+      integer, intent(out) :: ierr ! 0 means AOK.
+      write (*, *) 'no implementation for other_rsp_build_model'
+      ierr = -1
+   end subroutine null_other_rsp_build_model
+
+end module other_rsp_build_model
+

--- a/star/other/other_rsp_linear_analysis.f90
+++ b/star/other/other_rsp_linear_analysis.f90
@@ -22,37 +22,29 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_rsp_linear_analysis
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_RSP_linear_analysis = .true.
-      ! procedure pointer: s% other_rsp_linear_analysis => my_routine
+module other_rsp_linear_analysis
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_RSP_linear_analysis = .true.
+   ! procedure pointer: s% other_rsp_linear_analysis => my_routine
 
+   use star_def
+
+   implicit none
+
+contains
+
+   subroutine null_other_rsp_linear_analysis(id, restart, ierr)
       use star_def
+      integer, intent(in) :: id ! star id if available; 0 otherwise
+      logical, intent(in) :: restart
+      integer, intent(out) :: ierr ! 0 means AOK.
 
-      implicit none
-      
-            
-      contains
+      write (*, *) 'no implementation for other_rsp_linear_analysis'
+      ierr = -1
 
+   end subroutine null_other_rsp_linear_analysis
 
-      subroutine null_other_rsp_linear_analysis(id, restart, ierr)
-         use star_def
-         integer, intent(in) :: id ! star id if available; 0 otherwise
-         logical, intent(in) :: restart
-         integer, intent(out) :: ierr ! 0 means AOK.
-         
-         write(*,*) 'no implementation for other_rsp_linear_analysis'
-         ierr = -1
+end module other_rsp_linear_analysis
 
-      end subroutine null_other_rsp_linear_analysis
-      
-
-
-      end module other_rsp_linear_analysis
-      
-      
-      
-      

--- a/star/other/other_screening.f90
+++ b/star/other/other_screening.f90
@@ -22,32 +22,31 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-   module other_screening
+
+module other_screening
 
    implicit none
 
-   ! set use_other_screening = .true. in your controls namelist   
-        
+   ! set use_other_screening = .true. in your controls namelist
+
    ! edit the extras_controls routine to set the procedure pointer
    !  other_screening => my_screening
 
-   contains
-
+contains
 
    subroutine default_other_screening(sc, z1, z2, a1, a2, screen, dscreendt, dscreendd, ierr)
       use rates_def
 
       implicit none
 
-      type (Screen_Info) :: sc ! See rates_def
+      type(Screen_Info) :: sc ! See rates_def
       ! This contains lots of useful things like temperature, density etc as well as some precomputed
       ! terms that are useful for screening calculations. The derived type is set in do_screen_set_context (screen.f90)
-      real(dp),intent(in) ::    z1, z2      !< charge numbers of reactants
-      real(dp),intent(in) ::    a1, a2     !< mass numbers of reactants
-      real(dp),intent(out) ::   screen     !< on return, screening factor for this reaction
-      real(dp),intent(out) ::   dscreendt     !< on return, temperature derivative of the screening factor
-      real(dp),intent(out) ::   dscreendd    !< on return, density derivative of the screening factor
+      real(dp), intent(in) ::    z1, z2      !< charge numbers of reactants
+      real(dp), intent(in) ::    a1, a2     !< mass numbers of reactants
+      real(dp), intent(out) ::   screen     !< on return, screening factor for this reaction
+      real(dp), intent(out) ::   dscreendt     !< on return, temperature derivative of the screening factor
+      real(dp), intent(out) ::   dscreendd    !< on return, density derivative of the screening factor
       integer, intent(out) ::   ierr
 
       screen = 0d0
@@ -56,11 +55,5 @@
       ierr = 0
    end subroutine default_other_screening
 
+end module other_screening
 
-
-   end module other_screening
-        
-        
-        
-        
-  

--- a/star/other/other_set_pgstar_controls.f90
+++ b/star/other/other_set_pgstar_controls.f90
@@ -22,33 +22,26 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_set_pgstar_controls
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_set_pgstar_controls = .true.
-      ! procedure pointer: s% other_set_pgstar_controls => my_routine
+module other_set_pgstar_controls
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_set_pgstar_controls = .true.
+   ! procedure pointer: s% other_set_pgstar_controls => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_set_pgstar_controls(id)
-         use star_def
-         integer, intent(in) :: id
-         type (star_info), pointer :: s
-         integer :: ierr
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-      end subroutine default_other_set_pgstar_controls
+   implicit none
 
+contains
 
-      end module other_set_pgstar_controls
-      
-      
-      
-      
+   subroutine default_other_set_pgstar_controls(id)
+      use star_def
+      integer, intent(in) :: id
+      type(star_info), pointer :: s
+      integer :: ierr
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+   end subroutine default_other_set_pgstar_controls
+
+end module other_set_pgstar_controls
+

--- a/star/other/other_solver_monitor.f90
+++ b/star/other/other_solver_monitor.f90
@@ -22,41 +22,34 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_solver_monitor
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_solver_monitor = .true.
-      ! procedure pointer: s% other_solver_monitor => my_routine
+module other_solver_monitor
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_solver_monitor = .true.
+   ! procedure pointer: s% other_solver_monitor => my_routine
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_solver_monitor( &
-            id, iter, passed_tol_tests, &
-            correction_norm, max_correction, &
-            residual_norm, max_residual, ierr)
-         use star_def
-         integer, intent(in) :: id, iter 
-            ! iter is the number of the iteration we have just finished
-         logical, intent(in) :: passed_tol_tests
-         real(dp), intent(in) :: correction_norm, max_correction, &
-            residual_norm, max_residual
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-      end subroutine default_other_solver_monitor
+   implicit none
 
+contains
 
-      end module other_solver_monitor
-      
-      
-      
-      
+   subroutine default_other_solver_monitor( &
+      id, iter, passed_tol_tests, &
+      correction_norm, max_correction, &
+      residual_norm, max_residual, ierr)
+      use star_def
+      integer, intent(in) :: id, iter
+      ! iter is the number of the iteration we have just finished
+      logical, intent(in) :: passed_tol_tests
+      real(dp), intent(in) :: correction_norm, max_correction, &
+                              residual_norm, max_residual
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+   end subroutine default_other_solver_monitor
+
+end module other_solver_monitor
+

--- a/star/other/other_solver_monitor.f90
+++ b/star/other/other_solver_monitor.f90
@@ -45,7 +45,6 @@ contains
                               residual_norm, max_residual
       integer, intent(out) :: ierr
       type(star_info), pointer :: s
-      integer :: k
       ierr = 0
       call star_ptr(id, s, ierr)
       if (ierr /= 0) return

--- a/star/other/other_split_burn.f90
+++ b/star/other/other_split_burn.f90
@@ -22,103 +22,94 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_split_burn
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_split_burn = .true.
-      ! procedure pointer: s% other_split_burn => my_routine
-      ! This also require op_split_burn = .true. as well as setting the other op_split_burn options
+module other_split_burn
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine null_other_split_burn(  &
-         id, k, net_handle, eos_handle, num_isos, num_reactions, t_start, t_end, starting_x, &
-         num_times_for_interpolation, times, log10Ts_f1, log10Rhos_f1, etas_f1, &
-         dxdt_source_term, rate_factors, &
-         weak_rate_factor, reaction_Qs, reaction_neuQs, &
-         screening_mode, &
-         stptry, max_steps, eps, odescal, &
-         use_pivoting, trace, dbg,  burner_finish_substep, &
-         ! results
-         ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
-         nfcn, njac, nstep, naccpt, nrejct, ierr)
-         use star_def
-         use net_def
-         use chem_def, only: num_categories
-         
-         integer, intent(in) :: net_handle, eos_handle, id
-         integer, intent(in) :: num_isos
-         integer, intent(in) :: num_reactions
-         real(dp), intent(in) :: t_start, t_end, starting_x(:) ! (num_isos)
-         
-         integer, intent(in) :: num_times_for_interpolation 
-            ! ending time is times(num_times); starting time is 0
-         real(dp), pointer, intent(in) :: times(:) ! (num_times) 
-         real(dp), pointer, intent(in) :: log10Ts_f1(:) ! =(4,numtimes) interpolant for log10T(time)
-         real(dp), pointer, intent(in) :: log10Rhos_f1(:) ! =(4,numtimes) interpolant for log10Rho(time)
-         real(dp), pointer, intent(in) :: etas_f1(:) ! =(4,numtimes) interpolant for eta(time)
-         real(dp), pointer, intent(in) :: dxdt_source_term(:) ! (num_isos)  or null if no source term.
-         real(dp), intent(in), pointer :: rate_factors(:) ! (num_reactions)
-         real(dp), intent(in) :: weak_rate_factor
-         real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
-         real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
-         integer, intent(in) :: screening_mode ! see screen_def
-         real(dp), intent(in) :: stptry ! try this for 1st step.  0 means try in 1 step.
-         integer, intent(in) :: max_steps ! maximal number of allowed steps.
-         real(dp), intent(in) :: eps, odescal ! tolerances.  e.g., set both to 1d-6
-         logical, intent(in) :: use_pivoting ! for matrix solves
-         logical, intent(in) :: trace, dbg
-         interface
-            include 'burner_finish_substep.inc'
-         end interface
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_split_burn = .true.
+   ! procedure pointer: s% other_split_burn => my_routine
+   ! This also require op_split_burn = .true. as well as setting the other op_split_burn options
 
-         ! These should be set for the output
-         real(dp), intent(inout) :: ending_x(:) ! (num_isos)
-         real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
-         real(dp), intent(out) :: avg_eps_nuc, eps_neu_total
-         integer, intent(out) :: nfcn    ! number of function evaluations
-         integer, intent(out) :: njac    ! number of jacobian evaluations
-         integer, intent(out) :: nstep   ! number of computed steps
-         integer, intent(out) :: naccpt  ! number of accepted steps
-         integer, intent(out) :: nrejct  ! number of rejected steps
+   implicit none
+
+contains
+
+   subroutine null_other_split_burn( &
+      id, k, net_handle, eos_handle, num_isos, num_reactions, t_start, t_end, starting_x, &
+      num_times_for_interpolation, times, log10Ts_f1, log10Rhos_f1, etas_f1, &
+      dxdt_source_term, rate_factors, &
+      weak_rate_factor, reaction_Qs, reaction_neuQs, &
+      screening_mode, &
+      stptry, max_steps, eps, odescal, &
+      use_pivoting, trace, dbg, burner_finish_substep, &
+      ! results
+      ending_x, eps_nuc_categories, avg_eps_nuc, eps_neu_total, &
+      nfcn, njac, nstep, naccpt, nrejct, ierr)
+      use star_def
+      use net_def
+      use chem_def, only: num_categories
+
+      integer, intent(in) :: net_handle, eos_handle, id
+      integer, intent(in) :: num_isos
+      integer, intent(in) :: num_reactions
+      real(dp), intent(in) :: t_start, t_end, starting_x(:) ! (num_isos)
+
+      integer, intent(in) :: num_times_for_interpolation
+      ! ending time is times(num_times); starting time is 0
+      real(dp), pointer, intent(in) :: times(:) ! (num_times)
+      real(dp), pointer, intent(in) :: log10Ts_f1(:) ! =(4,numtimes) interpolant for log10T(time)
+      real(dp), pointer, intent(in) :: log10Rhos_f1(:) ! =(4,numtimes) interpolant for log10Rho(time)
+      real(dp), pointer, intent(in) :: etas_f1(:) ! =(4,numtimes) interpolant for eta(time)
+      real(dp), pointer, intent(in) :: dxdt_source_term(:) ! (num_isos)  or null if no source term.
+      real(dp), intent(in), pointer :: rate_factors(:) ! (num_reactions)
+      real(dp), intent(in) :: weak_rate_factor
+      real(dp), pointer, intent(in) :: reaction_Qs(:) ! (rates_reaction_id_max)
+      real(dp), pointer, intent(in) :: reaction_neuQs(:) ! (rates_reaction_id_max)
+      integer, intent(in) :: screening_mode ! see screen_def
+      real(dp), intent(in) :: stptry ! try this for 1st step.  0 means try in 1 step.
+      integer, intent(in) :: max_steps ! maximal number of allowed steps.
+      real(dp), intent(in) :: eps, odescal ! tolerances.  e.g., set both to 1d-6
+      logical, intent(in) :: use_pivoting ! for matrix solves
+      logical, intent(in) :: trace, dbg
+      interface
+         include 'burner_finish_substep.inc'
+      end interface
+
+      ! These should be set for the output
+      real(dp), intent(inout) :: ending_x(:) ! (num_isos)
+      real(dp), intent(inout) :: eps_nuc_categories(:) ! (num_categories)
+      real(dp), intent(out) :: avg_eps_nuc, eps_neu_total
+      integer, intent(out) :: nfcn    ! number of function evaluations
+      integer, intent(out) :: njac    ! number of jacobian evaluations
+      integer, intent(out) :: nstep   ! number of computed steps
+      integer, intent(out) :: naccpt  ! number of accepted steps
+      integer, intent(out) :: nrejct  ! number of rejected steps
+      integer, intent(out) :: ierr
+
+      type(star_info), pointer :: s
+      integer, intent(in) :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+   contains
+
+      subroutine my_burn_finish_substep(nstp, time, y, ierr)
+         use chem_def, only: category_name
+         integer, intent(in) :: nstp
+         real(dp), intent(in) :: time, y(:)
          integer, intent(out) :: ierr
-
-         type (star_info), pointer :: s
-         integer,intent(in) :: k
+         real(dp) :: frac, step_time
+         integer :: j, i
+         include 'formats'
          ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
+         ! This routine does nothing other than set ierr = 0,
+         ! Leave this empty if you dont want to do anything otherwise
+         ! Else replace the burn_finish_substep with this routine if
+         ! passing to net_1_zone_burn
+      end subroutine my_burn_finish_substep
 
+   end subroutine null_other_split_burn
 
-         contains
+end module other_split_burn
 
-
-         subroutine my_burn_finish_substep(nstp, time, y, ierr)
-            use chem_def, only: category_name
-            integer,intent(in) :: nstp
-            real(dp), intent(in) :: time, y(:)
-            integer, intent(out) :: ierr
-            real(dp) :: frac, step_time
-            integer :: j, i
-            include 'formats'
-            ierr = 0
-            ! This routine does nothing other than set ierr = 0,
-            ! Leave this empty if you dont want to do anything otherwise
-            ! Else replace the burn_finish_substep with this routine if
-            ! passing to net_1_zone_burn
-         end subroutine my_burn_finish_substep
-
-
-      end subroutine null_other_split_burn
-
-
-      end module other_split_burn
-      
-      
-      
-      

--- a/star/other/other_split_burn.f90
+++ b/star/other/other_split_burn.f90
@@ -95,12 +95,12 @@ contains
    contains
 
       subroutine my_burn_finish_substep(nstp, time, y, ierr)
-         use chem_def, only: category_name
+         !use chem_def, only: category_name
          integer, intent(in) :: nstp
          real(dp), intent(in) :: time, y(:)
          integer, intent(out) :: ierr
-         real(dp) :: frac, step_time
-         integer :: j, i
+         !real(dp) :: frac
+         !integer :: j, i
          include 'formats'
          ierr = 0
          ! This routine does nothing other than set ierr = 0,

--- a/star/other/other_surface_pt.f90
+++ b/star/other/other_surface_pt.f90
@@ -22,56 +22,51 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_surface_PT
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_surface_PT = .true.
-      ! procedure pointer: s% other_surface_PT => my_routine
+module other_surface_PT
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_surface_PT = .true.
+   ! procedure pointer: s% other_surface_PT => my_routine
 
-      implicit none
-      
-      contains
-      
-      ! star_utils:set_phot_info sets s% Teff before this is called
-      ! see hydro_vars:set_Teff_info_for_eqns
-      
-      subroutine null_other_surface_PT(id, &
-            skip_partials, &
-            lnT_surf, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
-            lnP_surf, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap, ierr)
-         use const_def, only: dp
-         use star_def
-         !use star_lib, only: star_get_surf_PT
-         integer, intent(in) :: id
-         logical, intent(in) :: skip_partials
-         real(dp), intent(out) :: &
-            lnT_surf, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
-            lnP_surf, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap
-         integer, intent(out) :: ierr
-         lnT_surf = 0
-         dlnT_dL = 0
-         dlnT_dlnR = 0
-         dlnT_dlnM = 0
-         dlnT_dlnkap = 0
-         lnP_surf = 0
-         dlnP_dL = 0
-         dlnP_dlnR = 0
-         dlnP_dlnM = 0
-         dlnP_dlnkap = 0
-         ierr = -1
-         
-         !call star_get_surf_PT(id, &
-         !   skip_partials, &
-         !   Teff, lnT_surf, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
-         !   lnP_surf, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap, ierr)
-         
-      end subroutine null_other_surface_PT
+   implicit none
 
+contains
 
-      end module other_surface_PT
-      
+   ! star_utils:set_phot_info sets s% Teff before this is called
+   ! see hydro_vars:set_Teff_info_for_eqns
 
+   subroutine null_other_surface_PT(id, &
+                                    skip_partials, &
+                                    lnT_surf, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
+                                    lnP_surf, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap, ierr)
+      use const_def, only: dp
+      use star_def
+      !use star_lib, only: star_get_surf_PT
+      integer, intent(in) :: id
+      logical, intent(in) :: skip_partials
+      real(dp), intent(out) :: &
+         lnT_surf, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
+         lnP_surf, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap
+      integer, intent(out) :: ierr
+      lnT_surf = 0
+      dlnT_dL = 0
+      dlnT_dlnR = 0
+      dlnT_dlnM = 0
+      dlnT_dlnkap = 0
+      lnP_surf = 0
+      dlnP_dL = 0
+      dlnP_dlnR = 0
+      dlnP_dlnM = 0
+      dlnP_dlnkap = 0
+      ierr = -1
 
+      !call star_get_surf_PT(id, &
+      !   skip_partials, &
+      !   Teff, lnT_surf, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
+      !   lnP_surf, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap, ierr)
+
+   end subroutine null_other_surface_PT
+
+end module other_surface_PT
 

--- a/star/other/other_timestep_limit.f90
+++ b/star/other/other_timestep_limit.f90
@@ -22,30 +22,27 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_timestep_limit
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_timestep_limit = .true.
-      ! procedure pointer: s% other_timestep_limit => my_routine
+module other_timestep_limit
 
-      implicit none      
-            
-      contains
-      
-      integer function null_other_timestep_limit( &
-         id, skip_hard_limit, dt, dt_limit_ratio)
-         use const_def, only: dp
-         use star_def
-         integer, intent(in) :: id
-         logical, intent(in) :: skip_hard_limit
-         real(dp), intent(in) :: dt
-         real(dp), intent(inout) :: dt_limit_ratio
-         null_other_timestep_limit = keep_going
-      end function null_other_timestep_limit
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_timestep_limit = .true.
+   ! procedure pointer: s% other_timestep_limit => my_routine
 
-      end module other_timestep_limit
-      
-      
-      
-      
+   implicit none
+
+contains
+
+   integer function null_other_timestep_limit( &
+      id, skip_hard_limit, dt, dt_limit_ratio)
+      use const_def, only: dp
+      use star_def
+      integer, intent(in) :: id
+      logical, intent(in) :: skip_hard_limit
+      real(dp), intent(in) :: dt
+      real(dp), intent(inout) :: dt_limit_ratio
+      null_other_timestep_limit = keep_going
+   end function null_other_timestep_limit
+
+end module other_timestep_limit
+

--- a/star/other/other_torque.f90
+++ b/star/other/other_torque.f90
@@ -22,36 +22,30 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_torque
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_torque = .true.
-      ! procedure pointer: s% other_torque => my_routine
+module other_torque
 
-      implicit none
-      
-            
-      contains
-      
-      subroutine default_other_torque(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         ! note that can set extra_omegadot instead of extra_jdot if that is more convenient
-         ! set one or the other, not both.  set the one you are not using to 0 as in the following line.
-         s% extra_jdot(:) = 0
-         s% extra_omegadot(:) = 0
-      end subroutine default_other_torque
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_torque = .true.
+   ! procedure pointer: s% other_torque => my_routine
 
+   implicit none
 
-      end module other_torque
-      
-      
-      
-      
+contains
+
+   subroutine default_other_torque(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      ! note that can set extra_omegadot instead of extra_jdot if that is more convenient
+      ! set one or the other, not both.  set the one you are not using to 0 as in the following line.
+      s%extra_jdot(:) = 0
+      s%extra_omegadot(:) = 0
+   end subroutine default_other_torque
+
+end module other_torque
+

--- a/star/other/other_torque_implicit.f90
+++ b/star/other/other_torque_implicit.f90
@@ -22,41 +22,34 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_torque_implicit
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_torque_implicit = .true.
-      ! procedure pointer: s% other_torque_implicit => my_routine
+module other_torque_implicit
 
-      implicit none
-      
-            
-      contains
-      
-      
-      subroutine default_other_torque_implicit(id, ierr)
-         use star_def
-         integer, intent(in) :: id
-         integer, intent(out) :: ierr
-         type (star_info), pointer :: s
-         integer :: k
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         s% extra_jdot(:) = 0
-         s% extra_omegadot(:) = 0
-         s% d_extra_jdot_domega_m1(:) = 0
-         s% d_extra_omegadot_domega_m1(:) = 0
-         s% d_extra_jdot_domega_00(:) = 0
-         s% d_extra_omegadot_domega_00(:) = 0
-         s% d_extra_jdot_domega_p1(:) = 0
-         s% d_extra_omegadot_domega_p1(:) = 0
-      end subroutine default_other_torque_implicit
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_torque_implicit = .true.
+   ! procedure pointer: s% other_torque_implicit => my_routine
 
+   implicit none
 
-      end module other_torque_implicit
-      
-      
-      
-      
+contains
+
+   subroutine default_other_torque_implicit(id, ierr)
+      use star_def
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      s%extra_jdot(:) = 0
+      s%extra_omegadot(:) = 0
+      s%d_extra_jdot_domega_m1(:) = 0
+      s%d_extra_omegadot_domega_m1(:) = 0
+      s%d_extra_jdot_domega_00(:) = 0
+      s%d_extra_omegadot_domega_00(:) = 0
+      s%d_extra_jdot_domega_p1(:) = 0
+      s%d_extra_omegadot_domega_p1(:) = 0
+   end subroutine default_other_torque_implicit
+
+end module other_torque_implicit
+

--- a/star/other/other_wind.f90
+++ b/star/other/other_wind.f90
@@ -22,42 +22,36 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module other_wind
 
-      ! consult star/other/README for general usage instructions
-      ! control name: use_other_wind = .true.
-      ! procedure pointer: s% other_wind => my_routine
+module other_wind
 
+   ! consult star/other/README for general usage instructions
+   ! control name: use_other_wind = .true.
+   ! procedure pointer: s% other_wind => my_routine
 
-      ! you can add your own wind routine for use when wind scheme == 'other'
+   ! you can add your own wind routine for use when wind scheme == 'other'
 
-      implicit none
-      
-            
-      contains
-      
-      ! Note that your routine will be called before many star variables have been set.
-      ! If you rely on these, you should call the star_set_vars_in_part1 routine from star_lib
-      ! to ensure that they are set.      
-      subroutine null_other_wind(id, Lsurf, Msurf, Rsurf, Tsurf, X, Y, Z, w, ierr)
-         use star_def
-         integer, intent(in) :: id
-         real(dp), intent(in) :: Lsurf, Msurf, Rsurf, Tsurf, X, Y, Z ! surface values (cgs)
-         ! NOTE: surface is outermost cell. not necessarily at photosphere.
-         ! NOTE: don't assume that vars are set at this point.
-         ! so if you want values other than those given as args,
-         ! you should use values from s% xh(:,:) and s% xa(:,:) only.
-         ! rather than things like s% Teff or s% lnT(:) which have not been set yet.
-         real(dp), intent(out) :: w ! wind in units of Msun/year (value is >= 0)
-         integer, intent(out) :: ierr
-         w = 0
-         ierr = 0
-      end subroutine null_other_wind
+   implicit none
 
+contains
 
-      end module other_wind
-      
-      
-      
-      
+   ! Note that your routine will be called before many star variables have been set.
+   ! If you rely on these, you should call the star_set_vars_in_part1 routine from star_lib
+   ! to ensure that they are set.
+   subroutine null_other_wind(id, Lsurf, Msurf, Rsurf, Tsurf, X, Y, Z, w, ierr)
+      use star_def
+      integer, intent(in) :: id
+      real(dp), intent(in) :: Lsurf, Msurf, Rsurf, Tsurf, X, Y, Z ! surface values (cgs)
+      ! NOTE: surface is outermost cell. not necessarily at photosphere.
+      ! NOTE: don't assume that vars are set at this point.
+      ! so if you want values other than those given as args,
+      ! you should use values from s% xh(:,:) and s% xa(:,:) only.
+      ! rather than things like s% Teff or s% lnT(:) which have not been set yet.
+      real(dp), intent(out) :: w ! wind in units of Msun/year (value is >= 0)
+      integer, intent(out) :: ierr
+      w = 0
+      ierr = 0
+   end subroutine null_other_wind
+
+end module other_wind
+

--- a/star/other/pgstar_decorator.f90
+++ b/star/other/pgstar_decorator.f90
@@ -22,35 +22,33 @@
 !   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 !
 ! ***********************************************************************
- 
-      module pgstar_decorator
 
-      ! NOTE: remember to set X_use_decorator = .true. to enable this, 
-      ! where X is the name of the pgstar plot
-      ! and set s% pg% X_pgstar_decorator => your_function in your
-      ! run_star_extras.f
-      
-      ! List of pgplot routines: http://www.astro.caltech.edu/~tjp/pgplot/annlist.html
- 
-      implicit none
+module pgstar_decorator
 
-                  
-      contains
-      
-      
-      ! default does nothing
-      ! xmin, xmax, ymin, ymax: current plot boundary
-      ! plot_num: If a plot has multiple sub-panels, then this tells you which panel is being called
-      subroutine null_pgstar_decorator(id, xmin, xmax, ymin, ymax, plot_num, ierr)
-         use star_def
-         use const_def
-         integer, intent(in) :: id
-         !Not doubles
-         real,intent(in) :: xmin, xmax, ymin, ymax 
-         integer, intent(in) :: plot_num
-         integer, intent(out) :: ierr
-         ierr = 0
-      end subroutine null_pgstar_decorator
+   ! NOTE: remember to set X_use_decorator = .true. to enable this,
+   ! where X is the name of the pgstar plot
+   ! and set s% pg% X_pgstar_decorator => your_function in your
+   ! run_star_extras.f
+
+   ! List of pgplot routines: http://www.astro.caltech.edu/~tjp/pgplot/annlist.html
+
+   implicit none
+
+contains
+
+   ! default does nothing
+   ! xmin, xmax, ymin, ymax: current plot boundary
+   ! plot_num: If a plot has multiple sub-panels, then this tells you which panel is being called
+   subroutine null_pgstar_decorator(id, xmin, xmax, ymin, ymax, plot_num, ierr)
+      use star_def
+      use const_def
+      integer, intent(in) :: id
+      !Not doubles
+      real, intent(in) :: xmin, xmax, ymin, ymax
+      integer, intent(in) :: plot_num
+      integer, intent(out) :: ierr
+      ierr = 0
+   end subroutine null_pgstar_decorator
 
 ! Example function to add squares and some text to the abundance plot
 !      subroutine Abundance_pgstar_decorator(id, xmin, xmax, ymin, ymax, plot_num, ierr)
@@ -58,36 +56,33 @@
 !         use const_def
 !         integer, intent(in) :: id
 !         !Not dp
-!         real,intent(in) :: xmin, xmax, ymin, ymax 
+!         real,intent(in) :: xmin, xmax, ymin, ymax
 !         real :: xcenter,ycenter,dx,dy,a
 !         integer, intent(out) :: ierr
 !         integer :: i
 !         type (star_info), pointer :: s
-         
+
 !         ierr = 0
 !         call star_ptr(id, s, ierr)
 !         if (ierr /= 0) return
-         
+
 !         dx=(xmax-xmin)
 !         dy=(ymax-ymin)
-         
+
 !         xcenter=xmin+dx*0.5
 !         ycenter=ymin+dy*0.5
-      
+
 !         call pgsci(clr_Coral)
-         
+
 !         do i=1,4
 !            a=(i/10.0)
 !            call pgline(5, (/xcenter-a*dx,xcenter-a*dx,xcenter+a*dx,xcenter+a*dx,xcenter-a*dx/),&
 !                           (/ycenter-a*dy,ycenter+a*dy,ycenter+a*dy,ycenter-a*dy,ycenter-a*dy/))
 !         end do
-         
+
 !         call pgptxt(xcenter,ycenter, 0.0, 1.0, 'Some added text on this plot')
-         
+
 !      end subroutine Abundance_pgstar_decorator
 
-      end module pgstar_decorator
-      
-      
-      
-      
+end module pgstar_decorator
+

--- a/star/other/sample_pgstar_plot.f90
+++ b/star/other/sample_pgstar_plot.f90
@@ -207,8 +207,8 @@ contains
       real, intent(in) :: winxmin, winxmax, winymin, winymax, label_scale
       integer, intent(out) :: ierr
 
-      real :: windy, xmargin
-      real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy
+      real :: xmargin
+      real :: xmin, xmax, xleft, xright, dx, ymin, ymax, ymin2, ymax2, dy
       integer :: grid_min, grid_max, npts, nz
       real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
 
@@ -253,8 +253,7 @@ contains
          integer, intent(out) :: ierr
 
          integer :: lw, lw_sav, k
-         real :: ybot, eps, &
-                 default_ymax_left, default_ymin_left, &
+         real :: default_ymax_left, default_ymin_left, &
                  default_ymax_right, default_ymin_right
          character(len=128) :: str
 

--- a/star/other/sample_pgstar_plot.f90
+++ b/star/other/sample_pgstar_plot.f90
@@ -23,410 +23,388 @@
 !
 ! ***********************************************************************
 
-      module sample_pgstar_plot
-      
-      ! you can add your own pgstar plots in addition to the standard ones.
-      ! don't edit this file
-      ! instead copy the contents to your src/run_star_extras file and edit that.
+module sample_pgstar_plot
 
-      ! edit the extras_controls routine to set s% other_pgstar_plots_info
-         !    s% other_pgstar_plots_info => my_pgstar_plots_info
-      
+   ! you can add your own pgstar plots in addition to the standard ones.
+   ! don't edit this file
+   ! instead copy the contents to your src/run_star_extras file and edit that.
 
-      use star_lib
-      use star_def
-      use math_lib
-      use star_pgstar
+   ! edit the extras_controls routine to set s% other_pgstar_plots_info
+   !    s% other_pgstar_plots_info => my_pgstar_plots_info
 
-      implicit none
-      
-      
-      ! basics needed for every pgstar plot
-      logical :: my_win_flag, my_file_flag
-      integer :: my_file_interval
-      character (len=256) :: my_file_dir, my_file_prefix
-      real :: &
-         my_win_width, my_win_aspect_ratio, &
-         my_file_width, my_file_aspect_ratio
-         
-      ! optional extra controls
-      character (len=256) :: my_xaxis_by
-      real :: &
-         my_xmin, my_xmax, &
-         my_ymin_left, my_ymax_left, my_dymin_left, &
-         my_ymin_right, my_ymax_right, my_dymin_right
-      
-         
-      namelist /my_pgstar/ &
-         my_win_flag, my_file_flag, &
-         my_file_interval, &
-         my_file_dir, my_file_prefix, &
-         my_win_width, my_win_aspect_ratio, &
-         my_file_width, my_file_aspect_ratio, &
-         my_xaxis_by, my_xmin, my_xmax, &
-         my_ymin_left, my_ymax_left, my_dymin_left, &
-         my_ymin_right, my_ymax_right, my_dymin_right
-      
+   use star_lib
+   use star_def
+   use math_lib
+   use star_pgstar
 
-      contains
+   implicit none
 
-      
-      subroutine my_pgstar_plots_info(id, ierr)
-         integer, intent(in) :: id
+   ! basics needed for every pgstar plot
+   logical :: my_win_flag, my_file_flag
+   integer :: my_file_interval
+   character(len=256) :: my_file_dir, my_file_prefix
+   real :: &
+      my_win_width, my_win_aspect_ratio, &
+      my_file_width, my_file_aspect_ratio
+
+   ! optional extra controls
+   character(len=256) :: my_xaxis_by
+   real :: &
+      my_xmin, my_xmax, &
+      my_ymin_left, my_ymax_left, my_dymin_left, &
+      my_ymin_right, my_ymax_right, my_dymin_right
+
+   namelist /my_pgstar/ &
+      my_win_flag, my_file_flag, &
+      my_file_interval, &
+      my_file_dir, my_file_prefix, &
+      my_win_width, my_win_aspect_ratio, &
+      my_file_width, my_file_aspect_ratio, &
+      my_xaxis_by, my_xmin, my_xmax, &
+      my_ymin_left, my_ymax_left, my_dymin_left, &
+      my_ymin_right, my_ymax_right, my_dymin_right
+
+contains
+
+   subroutine my_pgstar_plots_info(id, ierr)
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+
+      integer, parameter :: num_Other_plots = 1 ! can have up to max_num_Other_plots
+      integer :: i, plot_id
+      type(pgstar_win_file_data), pointer :: p
+      type(star_info), pointer :: s
+
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      call set_my_namelist_defaults
+      call read_my_pgstar_namelist('inlist_for_my_pgstar_plots', ierr)
+      if (ierr /= 0) return
+
+      do i = 1, num_Other_plots
+         plot_id = i_Other + i - 1
+         p => s%pg%pgstar_win_file_ptr(plot_id)
+         p%plot => my_plot
+         p%id = plot_id
+         p%name = 'My_Plot'
+         p%win_flag = my_win_flag
+         p%win_width = my_win_width
+         p%win_aspect_ratio = my_win_aspect_ratio
+         p%file_flag = my_file_flag
+         p%file_dir = my_file_dir
+         p%file_prefix = my_file_prefix
+         p%file_interval = my_file_interval
+         p%file_width = my_file_width
+         p%file_aspect_ratio = my_file_aspect_ratio
+      end do
+
+   end subroutine my_pgstar_plots_info
+
+   subroutine set_my_namelist_defaults
+
+      my_win_flag = .false.
+
+      my_win_width = 7
+      my_win_aspect_ratio = 0.62 ! aspect_ratio = height/width
+
+      my_xaxis_by = 'mass' ! same choices as for main window xaxis_by
+      my_xmin = -101 ! only used if > -100
+      my_xmax = -101 ! only used if > -100
+
+      my_ymin_left = -101 ! only used if > -100
+      my_ymax_left = -101 ! only used if > -100
+      my_dymin_left = -101 ! only used if > -100
+
+      my_ymin_right = -101 ! only used if > -100
+      my_ymax_right = -101 ! only used if > -100
+      my_dymin_right = -101 ! only used if > -100
+
+      ! file output
+      my_file_flag = .false.
+      my_file_dir = 'pgstar_out'
+      my_file_prefix = 'profile'
+      my_file_interval = 5 ! output when mod(model_number,my_file_interval)==0
+      my_file_width = -1 ! negative means use same value as for window
+      my_file_aspect_ratio = -1 ! negative means use same value as for window
+
+   end subroutine set_my_namelist_defaults
+
+   subroutine read_my_pgstar_namelist(filename, ierr)
+      use utils_lib
+      character(*), intent(in) :: filename
+      integer, intent(out) :: ierr
+
+      integer :: unit
+
+      ierr = 0
+
+      open (newunit=unit, file=trim(filename), action='read', delim='quote', status='old', iostat=ierr)
+      if (ierr /= 0) then
+         write (*, '(a)') 'Failed to open control namelist file '//trim(filename)
+         return
+      end if
+      read (unit, nml=my_pgstar, iostat=ierr)
+      close (unit)
+
+      if (ierr /= 0) then
+         write (*, *)
+         write (*, *)
+         write (*, *)
+         write (*, *)
+         write (*, '(a)') &
+            'Failed while trying to read control namelist file: '//trim(filename)
+         write (*, '(a)') &
+            'Perhaps the following runtime error message will help you find the problem.'
+         write (*, *)
+         open (newunit=unit, file=trim(filename), action='read', delim='quote', status='old', iostat=ierr)
+         read (unit, nml=my_pgstar)
+         close (unit)
+         return
+      end if
+
+   end subroutine read_my_pgstar_namelist
+
+   subroutine my_plot(id, device_id, ierr)
+      integer, intent(in) :: id, device_id
+      integer, intent(out) :: ierr
+
+      real :: winxmin, winxmax, winymin, winymax, label_scale
+
+      type(star_info), pointer :: s
+
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      call pgslct(device_id)
+      call pgbbuf()
+      call pgeras()
+
+      winxmin = 0.14
+      winxmax = 0.85
+      winymin = 0.13
+      winymax = 0.92
+      label_scale = 1.2
+
+      call do_my_plot(s, device_id, &
+                      winxmin, winxmax, winymin, winymax, &
+                      label_scale, ierr)
+
+      call pgebuf()
+
+   end subroutine my_plot
+
+   subroutine do_my_plot(s, device_id, &
+                         winxmin, winxmax, winymin, winymax, label_scale, ierr)
+
+      use utils_lib
+      use const_def
+
+      type(star_info), pointer :: s
+      integer, intent(in) :: device_id
+      real, intent(in) :: winxmin, winxmax, winymin, winymax, label_scale
+      integer, intent(out) :: ierr
+
+      real :: windy, xmargin
+      real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy
+      integer :: grid_min, grid_max, npts, nz
+      real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
+
+      logical :: dbg = .false.
+
+      include 'formats'
+      ierr = 0
+      xmargin = 0
+
+      nz = s%nz
+      allocate (xvec(nz), yvec(nz), yvec2(nz), yvec3(nz))
+
+      call set_pgstar_xaxis_bounds( &
+         s, my_xaxis_by, my_xmin, my_xmax, xmargin, &
+         xvec, xmin, xmax, xleft, xright, dx, &
+         grid_min, grid_max, npts, ierr)
+      if (ierr /= 0) return
+
+      if (dbg) then
+         write (*, 1) 'my_xaxis_by '//trim(my_xaxis_by)
+         write (*, 1) 'my_xmin', my_xmin
+         write (*, 1) 'my_xmax', my_xmax
+         write (*, 2) 'grid_min', grid_min
+         write (*, 2) 'grid_max', grid_max
+         write (*, 1) 'xmin', xmin
+         write (*, 1) 'xmax', xmax
+         write (*, 1) 'xleft', xleft
+         write (*, 1) 'xright', xright
+         write (*, 1) 'dx', dx
+      end if
+
+      call plot(ierr)
+      if (ierr /= 0) return
+
+      deallocate (xvec, yvec, yvec2, yvec3)
+
+   contains
+
+      subroutine plot(ierr)
+         use rates_def, only: i_rate
+         use chem_def, only: ipp, icno
          integer, intent(out) :: ierr
-         
-         integer, parameter :: num_Other_plots = 1 ! can have up to max_num_Other_plots
-         integer :: i, plot_id
-         type (pgstar_win_file_data), pointer :: p
-         type (star_info), pointer :: s
 
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         
-         call set_my_namelist_defaults
-         call read_my_pgstar_namelist('inlist_for_my_pgstar_plots', ierr)
-         if (ierr /= 0) return
-         
-         do i = 1, num_Other_plots
-            plot_id = i_Other + i - 1
-            p => s% pg% pgstar_win_file_ptr(plot_id)
-            p% plot => my_plot
-            p% id = plot_id
-            p% name = 'My_Plot'
-            p% win_flag = my_win_flag
-            p% win_width = my_win_width
-            p% win_aspect_ratio = my_win_aspect_ratio
-            p% file_flag = my_file_flag
-            p% file_dir = my_file_dir
-            p% file_prefix = my_file_prefix
-            p% file_interval = my_file_interval
-            p% file_width = my_file_width
-            p% file_aspect_ratio = my_file_aspect_ratio
-         end do
-         
-      end subroutine my_pgstar_plots_info
-      
-      
-      subroutine set_my_namelist_defaults
-      
-         my_win_flag = .false.
+         integer :: lw, lw_sav, k
+         real :: ybot, eps, &
+                 default_ymax_left, default_ymin_left, &
+                 default_ymax_right, default_ymin_right
+         character(len=128) :: str
 
-         my_win_width = 7
-         my_win_aspect_ratio = 0.62 ! aspect_ratio = height/width
-         
-         my_xaxis_by = 'mass' ! same choices as for main window xaxis_by
-         my_xmin = -101 ! only used if > -100
-         my_xmax = -101 ! only used if > -100
-         
-         my_ymin_left = -101 ! only used if > -100
-         my_ymax_left = -101 ! only used if > -100        
-         my_dymin_left = -101 ! only used if > -100
-         
-         my_ymin_right = -101 ! only used if > -100
-         my_ymax_right = -101 ! only used if > -100        
-         my_dymin_right = -101 ! only used if > -100 
-         
-         ! file output
-         my_file_flag = .false.
-         my_file_dir = 'pgstar_out'
-         my_file_prefix = 'profile'
-         my_file_interval = 5 ! output when mod(model_number,my_file_interval)==0
-         my_file_width = -1 ! negative means use same value as for window
-         my_file_aspect_ratio = -1 ! negative means use same value as for window
-         
-      end subroutine set_my_namelist_defaults
-      
-      
-      subroutine read_my_pgstar_namelist(filename, ierr)
-         use utils_lib
-         character(*), intent(in) :: filename
-         integer, intent(out) :: ierr
-
-         integer :: unit 
-         
-         ierr = 0
-         
-         open(newunit=unit, file=trim(filename), action='read', delim='quote', status='old', iostat=ierr)
-         if (ierr /= 0) then
-            write(*,'(a)') 'Failed to open control namelist file '// trim(filename)
-            return
-         end if
-         read(unit, nml=my_pgstar, iostat=ierr)  
-         close(unit)
-         
-         if (ierr /= 0) then
-            write(*, *) 
-            write(*, *) 
-            write(*, *) 
-            write(*, *) 
-            write(*, '(a)') &
-               'Failed while trying to read control namelist file: ' // trim(filename)
-            write(*, '(a)') &
-               'Perhaps the following runtime error message will help you find the problem.'
-            write(*, *) 
-            open(newunit=unit, file=trim(filename), action='read', delim='quote', status='old', iostat=ierr)
-            read(unit, nml=my_pgstar)
-            close(unit)
-            return
-         end if
-      
-      end subroutine read_my_pgstar_namelist
-
-
-      subroutine my_plot(id, device_id, ierr)
-         integer, intent(in) :: id, device_id
-         integer, intent(out) :: ierr
-         
-         real :: winxmin, winxmax, winymin, winymax, label_scale
-
-         type (star_info), pointer :: s
-
-         ierr = 0
-         call star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         
-         call pgslct(device_id)
-         call pgbbuf()
-         call pgeras()
-
-         winxmin = 0.14
-         winxmax = 0.85
-         winymin = 0.13
-         winymax = 0.92
-         label_scale = 1.2
-         
-         call do_my_plot(s, device_id, &
-            winxmin, winxmax, winymin, winymax, &
-            label_scale, ierr)
-
-         call pgebuf()
-      
-      end subroutine my_plot
-
-
-      subroutine do_my_plot(s, device_id, &
-            winxmin, winxmax, winymin, winymax, label_scale, ierr)
-            
-         use utils_lib
-         use const_def
-
-         type (star_info), pointer :: s
-         integer, intent(in) :: device_id
-         real, intent(in) :: winxmin, winxmax, winymin, winymax, label_scale
-         integer, intent(out) :: ierr
-         
-         real :: windy, xmargin
-         real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy
-         integer :: grid_min, grid_max, npts, nz
-         real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
-         
-         logical :: dbg = .false.
-         
          include 'formats'
          ierr = 0
-         xmargin = 0
 
-         nz = s% nz
-         allocate (xvec(nz), yvec(nz), yvec2(nz), yvec3(nz))
-         
-         call set_pgstar_xaxis_bounds( &
-            s, my_xaxis_by, my_xmin, my_xmax, xmargin, &
-            xvec, xmin, xmax, xleft, xright, dx, &
-            grid_min, grid_max, npts, ierr)
+         call pgsave
+
+         lw = 6
+         call pgqlw(lw_sav)
+
+         call pgsvp(winxmin, winxmax, winymin, winymax)
+
+         ! title
+         call pgmtxt('T', 1.5, 0.5, 0.5, 'My Plot')
+
+         call pgsch(label_scale)
+         write (str, '(i9)') s%model_number
+         call pgmtxt('T', 1.8, 0.9, 0.5, str)
+
+         ! xlabel
+         call pgsci(1)
+         call pgsch(label_scale)
+         call show_pgstar_xaxis_by(s, my_xaxis_by, ierr)
          if (ierr /= 0) return
-         
-         if (dbg) then
-            write(*,1) 'my_xaxis_by ' // trim(my_xaxis_by)
-            write(*,1) 'my_xmin', my_xmin
-            write(*,1) 'my_xmax', my_xmax
-            write(*,2) 'grid_min', grid_min
-            write(*,2) 'grid_max', grid_max
-            write(*,1) 'xmin', xmin
-            write(*,1) 'xmax', xmax
-            write(*,1) 'xleft', xleft
-            write(*,1) 'xright', xright
-            write(*,1) 'dx', dx
+
+         ! left axis
+
+         default_ymax_left = 10
+         default_ymin_left = -2
+
+         yvec = s%lnd(1:nz)/ln10
+         yvec2 = s%lnT(1:nz)/ln10
+
+         if (my_ymax_left > -100) then
+            ymax = my_ymax_left
+         else
+            ymax = max(default_ymax_left, maxval(yvec(grid_min:grid_max)))
+            ymax2 = max(default_ymax_left, maxval(yvec2(grid_min:grid_max)))
+            if (ymax2 > ymax) ymax = ymax2
          end if
 
-         call plot(ierr)
-         if (ierr /= 0) return
+         if (my_ymin_left > -100) then
+            ymin = my_ymin_left
+         else
+            ymin = max(default_ymin_left, minval(yvec(grid_min:grid_max)))
+            ymin2 = max(default_ymin_left, minval(yvec2(grid_min:grid_max)))
+            if (ymin2 < ymin) ymin = ymin2
+         end if
 
-         deallocate(xvec, yvec, yvec2, yvec3)
-         
-         
-         contains
-         
-         
-         subroutine plot(ierr)
-            use rates_def, only: i_rate
-            use chem_def, only: ipp, icno
-            integer, intent(out) :: ierr
-            
-            integer :: lw, lw_sav, k
-            real :: ybot, eps, &
-               default_ymax_left, default_ymin_left, &
-               default_ymax_right, default_ymin_right
-            character (len=128) :: str
-         
-            include 'formats'
-            ierr = 0
-            
-            call pgsave
-                       
-            lw = 6
-            call pgqlw(lw_sav)
-            
-            call pgsvp(winxmin, winxmax, winymin, winymax)
-            
-            ! title
-            call pgmtxt('T',1.5,0.5,0.5,'My Plot')
-         
-            call pgsch(label_scale)
-            write(str,'(i9)') s% model_number
-            call pgmtxt('T',1.8,0.9,0.5,str)
-            
-            ! xlabel
-            call pgsci(1)
-            call pgsch(label_scale)
-            call show_pgstar_xaxis_by(s,my_xaxis_by,ierr)
-            if (ierr /= 0) return
+         dy = ymax - ymin
+         if (dy == 0) dy = 1
+         if (my_dymin_left > -100) dy = my_dymin_left
 
-            
-            ! left axis
-            
-            default_ymax_left = 10
-            default_ymin_left = -2
-         
-            yvec = s% lnd(1:nz)/ln10
-            yvec2 = s% lnT(1:nz)/ln10
+         ymax = ymax + 0.1*dy
+         ymin = ymin - 0.1*dy
 
-            if (my_ymax_left > -100) then
-               ymax = my_ymax_left
-            else
-               ymax = max(default_ymax_left,maxval(yvec(grid_min:grid_max)))
-               ymax2 = max(default_ymax_left,maxval(yvec2(grid_min:grid_max)))
-               if (ymax2 > ymax) ymax = ymax2
-            end if
-            
-            if (my_ymin_left > -100) then
-               ymin = my_ymin_left
-            else
-               ymin = max(default_ymin_left,minval(yvec(grid_min:grid_max)))
-               ymin2 = max(default_ymin_left,minval(yvec2(grid_min:grid_max)))
-               if (ymin2 < ymin) ymin = ymin2
-            end if
-            
-            dy = ymax-ymin
-            if (dy == 0) dy = 1
-            if (my_dymin_left > -100) dy = my_dymin_left
-            
-            ymax = ymax + 0.1*dy
-            ymin = ymin - 0.1*dy
-            
-            if (dbg) then
-               write(*,1) 'left axis xleft, xright', xleft, xright
-               write(*,1) 'left axis ymin, ymax, dy', ymin, ymax, dy
-            end if
+         if (dbg) then
+            write (*, 1) 'left axis xleft, xright', xleft, xright
+            write (*, 1) 'left axis ymin, ymax, dy', ymin, ymax, dy
+         end if
 
-            call pgswin(xleft, xright, ymin, ymax)
-            call pgscf(1)
-            call pgsci(1)
-            call pgsch(label_scale)
-            call pgbox('',0.0,0,'BNSTV',0.0,0)
+         call pgswin(xleft, xright, ymin, ymax)
+         call pgscf(1)
+         call pgsci(1)
+         call pgsch(label_scale)
+         call pgbox('', 0.0, 0, 'BNSTV', 0.0, 0)
 
-            call pgsci(clr_Teal)
-            call pgsch(label_scale)
-            call pgmtxt('L',3.6,0.5,0.5,'log density (g cm\u-3\d)')
-            call pgslw(lw)
-            call pgline(npts, xvec(grid_min:grid_max), yvec(grid_min:grid_max))
-            call pgslw(lw_sav)
+         call pgsci(clr_Teal)
+         call pgsch(label_scale)
+         call pgmtxt('L', 3.6, 0.5, 0.5, 'log density (g cm\u-3\d)')
+         call pgslw(lw)
+         call pgline(npts, xvec(grid_min:grid_max), yvec(grid_min:grid_max))
+         call pgslw(lw_sav)
 
-            call pgsci(clr_Coral)
-            call pgmtxt('L',5.3,0.5,0.5,'log T (K)')
-            call pgslw(lw)
-            call pgline(npts, xvec(grid_min:grid_max), yvec2(grid_min:grid_max))
-            call pgslw(lw_sav)
-            
-            
-            ! right axis
+         call pgsci(clr_Coral)
+         call pgmtxt('L', 5.3, 0.5, 0.5, 'log T (K)')
+         call pgslw(lw)
+         call pgline(npts, xvec(grid_min:grid_max), yvec2(grid_min:grid_max))
+         call pgslw(lw_sav)
 
-            lw = 8
-            
-            default_ymax_right = 0
-            default_ymin_right = -10
-            
-            do k=1,nz
-               yvec(k) = safe_log10(s% eps_nuc_categories(ipp,k))
-               yvec2(k) = safe_log10(s% eps_nuc_categories(icno,k))
-            end do
-            
-            if (my_ymax_right > -100) then
-               ymax = my_ymax_right
-            else
-               ymax = max(default_ymax_right,maxval(yvec(grid_min:grid_max)))
-               ymax2 = max(default_ymax_right,maxval(yvec2(grid_min:grid_max)))
-               if (ymax2 > ymax) ymax = ymax2
-            end if
-            if (my_ymin_right > -100) then
-               ymin = my_ymin_right
-            else
-               ymin = max(default_ymin_right,minval(yvec(grid_min:grid_max)))
-               ymin2 = max(default_ymin_right,minval(yvec2(grid_min:grid_max)))
-               if (ymin2 < ymin) ymin = ymin2
-            end if
-            
-            dy = ymax-ymin
-            if (dy == 0) dy = 1
-            if (my_dymin_right > -100) dy = my_dymin_right
-            
-            ymax = ymax + 0.1*dy
-            ymin = ymin - 0.1*dy
+         ! right axis
 
-            if (dbg) then
-               write(*,1) 'right axis xleft, xright', xleft, xright
-               write(*,1) 'right axis ymin, ymax, dy', ymin, ymax, dy
-            end if
-            
-            call pgswin(xleft, xright, ymin, ymax)
+         lw = 8
 
-            call pgscf(1)
-            call pgsci(1)
-            call pgsch(label_scale)
-            call pgbox('BCNST',0.0,0,'CMSTV',0.0,0)
-            
-            call pgsci(clr_FireBrick)
-            call pgmtxt('R',5.6,0.5,0.5,'log eps PP (erg g\u-1\d s\u-1\d)')
-            call pgslw(lw)
-            call pgline(npts, xvec(grid_min:grid_max), yvec2(grid_min:grid_max))
-            call pgslw(lw_sav)
-            
-            call pgsci(clr_RoyalBlue)
-            call pgmtxt('R',3.9,0.5,0.5,'log eps CNO (erg g\u-1\d s\u-1\d)')
-            call pgslw(lw)
-            call pgline(npts, xvec(grid_min:grid_max), yvec(grid_min:grid_max))
-            call pgslw(lw_sav)
+         default_ymax_right = 0
+         default_ymin_right = -10
 
-            call pgunsa
-            
-         end subroutine plot
-      
-         
-      end subroutine do_my_plot
-      
-      
+         do k = 1, nz
+            yvec(k) = safe_log10(s%eps_nuc_categories(ipp, k))
+            yvec2(k) = safe_log10(s%eps_nuc_categories(icno, k))
+         end do
 
-      
-      
+         if (my_ymax_right > -100) then
+            ymax = my_ymax_right
+         else
+            ymax = max(default_ymax_right, maxval(yvec(grid_min:grid_max)))
+            ymax2 = max(default_ymax_right, maxval(yvec2(grid_min:grid_max)))
+            if (ymax2 > ymax) ymax = ymax2
+         end if
+         if (my_ymin_right > -100) then
+            ymin = my_ymin_right
+         else
+            ymin = max(default_ymin_right, minval(yvec(grid_min:grid_max)))
+            ymin2 = max(default_ymin_right, minval(yvec2(grid_min:grid_max)))
+            if (ymin2 < ymin) ymin = ymin2
+         end if
 
-      end module sample_pgstar_plot
-      
-      
+         dy = ymax - ymin
+         if (dy == 0) dy = 1
+         if (my_dymin_right > -100) dy = my_dymin_right
+
+         ymax = ymax + 0.1*dy
+         ymin = ymin - 0.1*dy
+
+         if (dbg) then
+            write (*, 1) 'right axis xleft, xright', xleft, xright
+            write (*, 1) 'right axis ymin, ymax, dy', ymin, ymax, dy
+         end if
+
+         call pgswin(xleft, xright, ymin, ymax)
+
+         call pgscf(1)
+         call pgsci(1)
+         call pgsch(label_scale)
+         call pgbox('BCNST', 0.0, 0, 'CMSTV', 0.0, 0)
+
+         call pgsci(clr_FireBrick)
+         call pgmtxt('R', 5.6, 0.5, 0.5, 'log eps PP (erg g\u-1\d s\u-1\d)')
+         call pgslw(lw)
+         call pgline(npts, xvec(grid_min:grid_max), yvec2(grid_min:grid_max))
+         call pgslw(lw_sav)
+
+         call pgsci(clr_RoyalBlue)
+         call pgmtxt('R', 3.9, 0.5, 0.5, 'log eps CNO (erg g\u-1\d s\u-1\d)')
+         call pgslw(lw)
+         call pgline(npts, xvec(grid_min:grid_max), yvec(grid_min:grid_max))
+         call pgslw(lw_sav)
+
+         call pgunsa
+
+      end subroutine plot
+
+   end subroutine do_my_plot
+
+end module sample_pgstar_plot
 
 ! inlist_for_my_pgstar_plots
 
 ! remove the leading !'s to use this
-
 
 !&my_pgstar
 !
@@ -434,11 +412,11 @@
 !
 !         my_win_width = 7
 !         my_win_aspect_ratio = 0.62 ! aspect_ratio = height/width
-!         
+!
 !         my_xaxis_by = 'mass' ! same choices as for main window xaxis_by
 !         my_xmin = -101 ! only used if > -100
 !         my_xmax = -101 ! only used if > -100
-!         
+!
 !         ! file output
 !         my_file_flag = .false.
 !         my_file_dir = 'pgstar_out'
@@ -449,4 +427,4 @@
 !
 !
 !/ ! end of my_pgstar namelist
-      
+

--- a/star/private/adjust_mass.f90
+++ b/star/private/adjust_mass.f90
@@ -186,12 +186,11 @@
          integer, intent(out) :: ierr
 
          real(dp) :: &
-            dt, delta_m, old_mstar, new_mstar, old_J, new_J, factor, total, &
-            frac, env_mass, mmax, alfa, new_xmstar, old_xmstar, removed, &
+            dt, delta_m, old_mstar, new_mstar, total, &
+            frac, env_mass, mmax, new_xmstar, old_xmstar, removed, &
             q_for_just_added, xq_for_CpT_absMdot_div_L, sum_dq, dm, sumx
 
-         real(dp), dimension(species) :: &
-            xaccrete, mtot_init, mtot_final
+         real(dp), dimension(species) :: xaccrete, mtot_init
          real(dp), dimension(:), allocatable :: &
             rxm_old, rxm_new, old_cell_mass, new_cell_mass, &
             oldloc, newloc, oldval, newval, xm_old, xm_new, &
@@ -537,7 +536,7 @@
             ! when call this, s% j_rot is still for old mass
             integer, intent(out) :: ierr
             integer :: k
-            real(dp) :: r2, dmm1, dm00, dm, dm_sum, dm_lost
+            real(dp) :: dmm1, dm00, dm, dm_sum, dm_lost
             include 'formats'
             ierr = 0
             J = 0
@@ -621,12 +620,12 @@
          real(dp), intent(in) :: old_xmstar, new_xmstar, delta_m
          integer, intent(out) :: k_const_mass, ierr
 
-         integer :: k, kA, kB, j00, jp1, k_check
-         real(dp) :: lnTlim_A, lnTlim_B, sumdq, sumdq1, sumdq2, sumdq3, &
-            min_xq_const_mass, min_q_for_kB, mold_o_mnew, lnTmax, lnT_A, lnT_B, &
+         integer :: k, kA, kB, j00, jp1
+         real(dp) :: lnTlim_A, lnTlim_B, sumdq, &
+            mold_o_mnew, lnTmax, lnT_A, lnT_B, &
             xqA, xqB_old, xqB_new, qfrac, frac, dqacc
          real(dp) :: xq(nz)
-         real(qp) :: qfrac_qp, frac_qp, mold_o_mnew_qp, q1, q2, q3, q4
+         real(qp) :: qfrac_qp, frac_qp, mold_o_mnew_qp, q1, q2
          real(qp) :: adjust_mass_outer_frac, adjust_mass_mid_frac, adjust_mass_inner_frac
          integer, parameter :: min_kA = 5
          logical :: dbg, flag
@@ -889,7 +888,6 @@
             old_cell_xbdy, new_cell_xbdy, mmax, old_cell_mass, new_cell_mass, ierr)
          ! set new values for s% xa(:,k)
          use num_lib, only: binary_search
-         use chem_def, only: chem_isos
          type (star_info), pointer :: s
          integer, intent(in) :: k, nz, species
          real(dp), intent(in) :: mmax
@@ -1139,11 +1137,10 @@
             old_xout, new_xout, old_dmbar, new_dmbar, old_j_rot, extra_work
          integer, intent(out) :: ierr
 
-         integer :: k, k0, op_err, old_k, new_k, k_uniform
+         integer :: k, k0, op_err
          logical :: okay
-         real(dp) :: old_j_tot, new_j_tot, goal_total_added, actual_total_added, &
-            f, jtot_bdy, goal_total, bdy_j, bdy_total, inner_total, outer_total, &
-            msum, isum, jsum, omega_uniform
+         real(dp) :: old_j_tot, goal_total_added, actual_total_added, &
+            goal_total, bdy_j, bdy_total, inner_total, outer_total
 
          include 'formats'
 
@@ -1249,7 +1246,7 @@
          integer, intent(in) :: k, k_below_just_added
          logical, intent(in) :: jrot_known
 
-         real(dp) :: r00, r003, ri, ro, rp13, rm13
+         real(dp) :: r00
          real(dp) :: w_div_wcrit_roche
 
          r00 = get_r_from_xh(s,k)
@@ -1284,7 +1281,7 @@
 
          real(dp) :: xm_outer, xm_inner, j_tot, xm0, xm1, new_point_dmbar, &
             dm_sum, dm
-         integer :: kk, k_outer, j
+         integer :: kk, k_outer
 
          integer, parameter :: k_dbg = -1
 

--- a/star/private/adjust_mesh.f90
+++ b/star/private/adjust_mesh.f90
@@ -59,7 +59,7 @@
             num_gvals, j, cid, cid_max, unchanged, split, merged, revised
          type (star_info), target :: copy_info
          type (star_info), pointer :: c, prv
-         real(dp) :: delta_coeff, LH, sum_L_other, sum_L_other_limit, A_max, &
+         real(dp) :: delta_coeff, sum_L_other, sum_L_other_limit, A_max, &
             mesh_max_allowed_ratio, tmp, J_tot1, J_tot2, center_logT, alfa, beta, &
             d_dlnR00, d_dlnRp1, d_dv00, d_dvp1
          real(dp), pointer, dimension(:) :: &
@@ -71,7 +71,6 @@
          character (len=32) :: gval_names(max_allowed_gvals)
          logical, dimension(max_allowed_gvals) :: &
             gval_is_xa_function, gval_is_logT_function
-         logical :: changed_mesh
          logical, parameter :: dbg = .false.
 
          real(dp), parameter :: max_sum_abs = 10d0
@@ -528,7 +527,7 @@
          subroutine set_types_of_new_cells(cell_type, ierr)
             integer, pointer :: cell_type(:)
             integer, intent(out) :: ierr
-            integer :: k, k_old, k_old_prev, new_type
+            integer :: k, k_old, new_type
 
             include 'formats'
             ierr = 0

--- a/star/private/adjust_mesh_split_merge.f90
+++ b/star/private/adjust_mesh_split_merge.f90
@@ -86,16 +86,15 @@
 
 
       subroutine amr(s,ierr)
-         use chem_def, only: ih1
          use hydro_rotation, only: w_div_w_roche_jrot, update1_i_rot_from_xh
          use star_utils, only: get_r_from_xh
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         real(dp) :: TooBig, TooSmall, MaxTooBig, MaxTooSmall, dr, minE
-         real(dp) :: grad_xa(s% species), cell_time, test_dr, new_xa(s% species), &
+         real(dp) :: TooBig, TooSmall, MaxTooBig, MaxTooSmall
+         real(dp) :: grad_xa(s% species), new_xa(s% species), &
             tau_center, r00
-         integer :: iTooBig, iTooSmall, iter, k, k0, species, &
-            nz, i_h1, num_split, num_merge, nz_old
+         integer :: iTooBig, iTooSmall, iter, k, species, &
+            nz, num_split, num_merge, nz_old
          include 'formats'
          species = s% species
          nz_old = s% nz
@@ -254,13 +253,13 @@
          real(dp), intent(out) :: TooBig, TooSmall
          integer, intent(out) :: iTooBig, iTooSmall
          real(dp) :: &
-            oversize_ratio, undersize_ratio, abs_du_div_cs, outer_fraction, &
+            oversize_ratio, undersize_ratio, abs_du_div_cs, &
             xmin, xmax, dx_actual, xR, xL, dq_min, dq_max, dx_baseline, &
             outer_dx_baseline, inner_dx_baseline, inner_outer_q, r_core_cm, &
             target_dr_core, target_dlnR_envelope, target_dlnR_core, target_dr_envelope
          logical :: hydrid_zoning, flipped_hydrid_zoning, log_zoning, logtau_zoning, &
             du_div_cs_limit_flag
-         integer :: nz, nz_baseline, k, kmin, nz_r_core
+         integer :: nz, nz_baseline, k, nz_r_core
          real(dp), pointer :: v(:), r_for_v(:)
 
          include 'formats'
@@ -484,18 +483,15 @@
          real(dp), intent(inout) :: new_xa(species)
          integer, intent(out) :: ierr
          logical :: merge_center
-         integer :: i, ip, i0, im, k, q, nz, qi_max, qim_max, op_err
-         real(dp) :: max_lgT_diff, max_lgrho_diff
+         integer :: i, ip, i0, im, q, nz, qi_max, qim_max
          real(dp) :: &
-            rR, rL, drR, drL, rC, rho, P, v, &
-            dm, dm_i, dm_ip, m_old, star_PE0, star_PE1, &
-            cell_mom, cell_ie, cell_etrb, min_IE, d_IE, d_KE, d_Esum, &
+            drR, drL, v, &
+            dm, dm_i, dm_ip, star_PE0, star_PE1, &
+            cell_ie, cell_etrb, &
             Esum_i, KE_i, PE_i, IE_i, Etrb_i, &
             Esum_ip, KE_ip, PE_ip, IE_ip, Etrb_ip, &
-            Esum, KE, PE, IE, Esum1, KE1, PE1, IE1, &
-            Etot0, KEtot0, PEtot0, IEtot0, &
-            Etot1, KEtot1, PEtot1, IEtot1, &
-            vt_i, vt_ip, j_rot_new, j_rot_p1_new, J_old, &
+            KE, &
+            j_rot_new, j_rot_p1_new, J_old, &
             dmbar_old, dmbar_p1_old, dmbar_p2_old, &
             dmbar_new, dmbar_p1_new
          include 'formats'
@@ -700,7 +696,7 @@
          type (star_info), pointer :: s
          real(dp), intent(in) :: star_PE0, star_PE1
          integer :: k
-         real(dp) :: frac, r, star_PE, new_frac
+         real(dp) :: frac
          include 'formats'
          if (star_PE1 == 0d0 .or. star_PE0 == star_PE1) return
          frac = star_PE1/star_PE0
@@ -821,19 +817,17 @@
          real(dp) :: tau_center, grad_xa(species), new_xa(species)
          integer, intent(out) :: ierr
          integer :: i, ip, j, jp, q, nz, nz_old, &
-            iR, iC, iL, imin, imax, op_err
+            iR, iC, iL
          real(dp) :: &
             cell_Esum_old, cell_KE_old, cell_PE_old, cell_IE_old, cell_Etrb_old, &
             rho_RR, rho_iR, rR, rL, dr, dr_old, rC, dV, dVR, dVL, dM, dML, dMR, rho, &
             v, v2, energy, v2_R, energy_R, rho_R, v2_C, energy_C, rho_C, v2_L, energy_L, rho_L, &
             dLeft, dRght, dCntr, grad_rho, grad_energy, grad_v2, &
-            sumx, sumxp, new_xaL, new_xaR, star_PE0, star_PE1, got_cell_Esum, &
-            got_cell_Esum_R, got_cell_KE_R, got_cell_PE_R, got_cell_IE_R, &
-            got_cell_Esum_L, got_cell_KE_L, got_cell_PE_L, got_cell_IE_L, &
+            sumx, sumxp, new_xaL, new_xaR, star_PE0, star_PE1, &
             grad_alpha, f, new_alphaL, new_alphaR, v_R, v_C, v_L, min_dm, &
             mlt_vcL, mlt_vcR, tauL, tauR, etrb, etrb_L, etrb_C, etrb_R, grad_etrb, &
             j_rot_new, dmbar_old, dmbar_p1_old, dmbar_new, dmbar_p1_new, dmbar_p2_new, J_old
-         logical :: okay, done, use_new_grad_rho
+         logical :: done, use_new_grad_rho
          include 'formats'
 
          ierr = 0
@@ -1332,7 +1326,7 @@
          integer, intent(in) :: i, species
          real(dp) :: new_xa(species)
          integer, intent(out) :: ierr
-         real(dp) :: rho, logRho, new_lnT, revised_energy, xsum
+         real(dp) :: rho, logRho, new_lnT, revised_energy
          integer :: q
          include 'formats'
          ierr = 0
@@ -1399,7 +1393,6 @@
       real(dp) function total_KE(s)
          type (star_info), pointer :: s
          integer :: k
-         real(dp) :: v0, v1
          include 'formats'
          total_KE = 0
          if (s% u_flag) then
@@ -1437,7 +1430,7 @@
       real(dp) function total_IE(s)
          type (star_info), pointer :: s
          integer :: k
-         real(dp) :: specific_ie, egas
+         real(dp) :: specific_ie
          total_IE = 0
          do k=1,s% nz
             specific_ie = s% energy(k)

--- a/star/private/adjust_mesh_support.f90
+++ b/star/private/adjust_mesh_support.f90
@@ -56,11 +56,11 @@
          logical, intent(out), dimension(max_allowed_gvals) :: &
             gval_is_xa_function, gval_is_logT_function
 
-         integer :: j, k, other_ierr
+         integer :: j, k
          logical, parameter :: dbg = .false.
          real(dp), allocatable, dimension(:) :: src
          real(dp) :: eps_min_for_delta, &
-               dlog_eps_dlogP_full_off, dlog_eps_dlogP_full_on, alfa_czb
+               dlog_eps_dlogP_full_off, dlog_eps_dlogP_full_on
          real(dp), dimension(:,:), pointer :: gvals
 
          gvals(1:nz,1:num_gvals) => gvals1(1:nz*num_gvals)

--- a/star/private/adjust_xyz.f90
+++ b/star/private/adjust_xyz.f90
@@ -160,7 +160,6 @@
             real(dp), pointer :: xa_new(:,:)
             real(dp), parameter :: max_sum_abs = 10d0
             real(dp), parameter :: xsum_tol = 1d-2
-            integer :: k, i
             allocate(xa_new(species, nz + nz_alloc_extra), stat=ierr)
             if (ierr /= 0) return
             call set_x_new( &
@@ -254,7 +253,7 @@
          real(dp) :: &
             total_neut, total_h, total_he, total_c, total_n, total_o, &
             total_ne, total_mg, total_si, total_s, total_ar, total_ca, &
-            total_fe, total_co, total_ni, other, &
+            total_fe, total_co, other, &
             old_total_neut, old_total_h, old_total_he, old_total_c, old_total_n, old_total_o, &
             old_total_ne, old_total_mg, old_total_si, old_total_s, old_total_ar, old_total_ca, &
             old_total_fe, old_total_co, old_total_ni, old_other, &
@@ -643,8 +642,7 @@
          real(dp), intent(in) :: y
          integer, intent(out) :: ierr
 
-         real(dp) :: xh1, xhe3, xhe4, z, ratio, desired_xh1, desired_xhe4, &
-            new_xh1, new_xhe3, new_xhe4, new_z, new_ratio
+         real(dp) :: xh1, xhe3, xhe4, z, ratio, desired_xh1, desired_xhe4
          include 'formats'
 
          ierr = 0

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -82,7 +82,6 @@
       integer :: num_allocs, num_deallocs
 
 
-
       contains
 
       
@@ -469,8 +468,7 @@
          integer, intent(in) :: action_in
          integer, intent(out) :: ierr
 
-         integer :: nz, species, num_reactions, &
-            nvar, nvar_hydro, nvar_chem, sz_new, psz_new, action
+         integer :: nz, species, num_reactions, nvar, nvar_hydro, nvar_chem, sz_new, action
          type (star_info), pointer :: c
          character (len=128) :: null_str
 
@@ -1416,7 +1414,6 @@
 
          subroutine do1_ad(ptr, other)
             type(auto_diff_real_star_order1), dimension(:), pointer :: ptr, other
-            type(auto_diff_real_star_order1), dimension(:), pointer :: tmp
             if (action == do_fill_arrays_with_NaNs) then
                call fill_ad_with_NaNs(ptr,1,-1)
             else if (action == do_copy_pointers_and_resize) then
@@ -1444,7 +1441,6 @@
 
          subroutine do1(ptr, other)
             real(dp), dimension(:), pointer :: ptr, other
-            real(dp), dimension(:), pointer :: tmp
             if (action == do_fill_arrays_with_NaNs) then
                call fill_with_NaNs(ptr)
             else if (action == do_copy_pointers_and_resize) then
@@ -1475,7 +1471,6 @@
 
          subroutine do1_neq(ptr, other)
             real(dp), dimension(:), pointer :: ptr, other
-            real(dp), dimension(:), pointer :: tmp
             if (action == do_fill_arrays_with_NaNs) then
                call fill_with_NaNs(ptr)
             else if (action == do_copy_pointers_and_resize) then
@@ -1504,7 +1499,6 @@
 
          subroutine do1_integer(ptr, other)
             integer, dimension(:), pointer :: ptr, other
-            integer, dimension(:), pointer :: tmp
             if (action == do_copy_pointers_and_resize) then
                ptr => other
                if (nz <= size(ptr,dim=1)) return
@@ -1522,7 +1516,6 @@
          subroutine do2_integer(ptr, other, sz1)
             integer, dimension(:,:), pointer :: ptr, other
             integer, intent(in) :: sz1
-            real(dp), dimension(:,:), pointer :: tmp
             if (action == do_copy_pointers_and_resize) then
                ptr => other
                if (sz1 == size(ptr, dim=1) .and. nz <= size(ptr, dim=2)) return
@@ -1539,7 +1532,6 @@
 
          subroutine do1_logical(ptr, other)
             logical, dimension(:), pointer :: ptr, other
-            logical, dimension(:), pointer :: tmp
             if (action == do_copy_pointers_and_resize) then
                ptr => other
                if (nz <= size(ptr,dim=1)) return
@@ -1558,7 +1550,6 @@
             real(dp), dimension(:,:), pointer :: ptr, other
             integer, intent(in) :: sz1
             character (len=*), intent(in) :: str
-            real(dp), dimension(:,:), pointer :: tmp
             include 'formats'
             if (action == do_fill_arrays_with_NaNs) then
                call fill_with_NaNs_2d(ptr)
@@ -1589,7 +1580,6 @@
          subroutine do3(ptr, other, sz1, sz2)
             real(dp), dimension(:,:,:), pointer :: ptr, other
             integer, intent(in) :: sz1, sz2
-            real(dp), dimension(:,:,:), pointer :: tmp
             if (action == do_fill_arrays_with_NaNs) then
                call fill_with_NaNs_3d(ptr)
             elseif (action == do_copy_pointers_and_resize) then
@@ -1622,7 +1612,6 @@
          subroutine do2_quad(ptr, other, sz1)
             real(qp), dimension(:,:), pointer :: ptr, other
             integer, intent(in) :: sz1
-            real(qp), dimension(:,:), pointer :: tmp
             if (action == do_copy_pointers_and_resize) then
                ptr => other
                if (sz1 == size(ptr, dim=1) .and. nz <= size(ptr, dim=2)) return
@@ -1889,7 +1878,6 @@
          integer, intent(in) :: sz1, sz2, action
          integer, intent(out) :: ierr
          real(qp), dimension(:,:), pointer :: ptr2
-         real(qp) :: nan
          integer :: old_sz2, j, i
          ierr = 0
          select case(action)
@@ -2968,7 +2956,6 @@
 
          logical function return1(itry)
             integer, intent(in) :: itry
-            integer, pointer :: p(:)
             if (associated(int_work_pointers(itry)% p)) then
                return1 = .false.
                return
@@ -3073,7 +3060,6 @@
 
          logical function return1(itry)
             integer, intent(in) :: itry
-            logical, pointer :: p(:)
             if (associated(logical_work_pointers(itry)% p)) then
                return1 = .false.
                return
@@ -3087,8 +3073,6 @@
 
       
       subroutine shutdown_alloc ()
-
-         integer :: i
 
          call free_work_arrays()
 
@@ -3230,8 +3214,4 @@
       end subroutine non_crit_return_work_array
 
 
-
-
       end module alloc
-
-

--- a/star/private/atm_support.f90
+++ b/star/private/atm_support.f90
@@ -73,9 +73,6 @@ contains
     integer, intent(out)      :: ierr
 
     real(dp) :: kap
-    real(dp) :: tau
-    real(dp) :: r_surf
-    real(dp) :: L_surf
     
     if (is_bad(tau_surf)) then
        write(*,*) 'tau_surf', tau_surf
@@ -517,7 +514,6 @@ contains
     real(dp) :: dlnP_dlnM_b
     real(dp) :: dlnP_dlnkap_b
     real(dp) :: kap_a
-    real(dp) :: tau_b
 
     include 'formats'
 
@@ -1256,8 +1252,6 @@ contains
     real(dp) :: Pgas
     real(dp) :: rho, gamma, energy
     real(dp) :: logRho, logRho_guess
-    real(dp) :: dlnRho_dlnPgas
-    real(dp) :: dlnRho_dlnT
     real(dp) :: dres_dxa(num_eos_basic_results,s% species)
 
     T = exp(lnT)

--- a/star/private/brunt.f90
+++ b/star/private/brunt.f90
@@ -37,7 +37,6 @@
       logical, parameter :: dbg = .false.
 
 
-
       contains
 
 
@@ -50,7 +49,7 @@
          type (star_info), pointer :: s
          integer, intent(in) :: nzlo, nzhi
          integer, intent(out) :: ierr
-         integer :: nz, k, i
+         integer :: nz, k
          real(dp), allocatable, dimension(:) :: smoothing_array
 
          include 'formats'
@@ -126,7 +125,7 @@
          real(dp), allocatable, dimension(:) :: &
             rho_P_chiT_chiRho, rho_P_chiT_chiRho_face
 
-         integer :: nz, k, i
+         integer :: nz, k
 
          include 'formats'
 
@@ -200,8 +199,7 @@
 
 
          real(dp), allocatable, dimension(:) :: T_face, rho_face, chiT_face, chiRho_face
-         real(dp) :: brunt_B
-         integer :: nz, species, k, i, op_err
+         integer :: nz, species, k, op_err
          logical, parameter :: dbg = .false.
 
          include 'formats'
@@ -344,4 +342,3 @@
 
 
       end module brunt
-

--- a/star/private/create_initial_model.f90
+++ b/star/private/create_initial_model.f90
@@ -40,7 +40,6 @@
       real(dp) :: X, Z, Y, G, abar, zbar, z2bar, z53bar, ye
       real (dp) :: Tmin,eps,R_try
 
-
       integer, parameter :: max_species=1000
       real(dp) :: xa(max_species)
       integer, pointer, dimension(:) :: net_iso, chem_id
@@ -74,7 +73,6 @@
          cs => create_star_handles(id)
          ierr = 0
       end subroutine get_create_star_ptr
-
 
 
       subroutine build_initial_model(s, ierr)
@@ -255,13 +253,13 @@
       end subroutine build_initial_model
 
 
-
       ! output
       !errvec(1)=(mass-M)/M
       !errvec(2)=(radius-R)/R
       subroutine PSerrfunc(id,Pcguess,Sguess,M,R,errvec)
          integer, intent(in) :: id
-         real(dp) :: Pcguess,Sguess,M,R,errvec(2)
+         real(dp), intent(in) :: Pcguess,Sguess,M,R
+         real(dp), intent(out) :: errvec(2)
 
          integer :: ierr
          real(dp) :: rhoc,Tc,Pc,S
@@ -401,7 +399,6 @@
       end subroutine PSerrfunc
 
 
-
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
@@ -411,7 +408,8 @@
 
       subroutine derivs(cs,P,S,y,dydP)
          type (create_star_info), pointer :: cs
-         real(dp) :: P,S,y(3),dydP(3)
+         real(dp), intent(in) :: P,S,y(3)
+         real(dp), intent(out) :: dydP(3)
          real(dp) :: r,m,T,rho,intdmT
 
          r=y(1)
@@ -433,7 +431,8 @@
          use kap_def, only: num_kap_fracs
          use kap_lib
          type (create_star_info), pointer :: cs
-         real(dp) :: logrho,logT,kap
+         real(dp), intent(in) :: logrho,logT
+         real(dp), intent(out) :: kap
          real(dp) :: lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT
          real(dp) :: eta, d_eta_dlnRho, d_eta_dlnT
          real(dp) :: dlnkap_dlnRho, dlnkap_dlnT
@@ -473,7 +472,8 @@
          use eos_lib
          use eos_def
          type (create_star_info), pointer :: cs
-         real(dp) :: P,S,T,rho
+         real(dp), intent(in) :: P,S
+         real(dp), intent(out) :: T,rho
 
          real(dp) :: logT_result,log10Rho,dlnRho_dlnPgas_const_T,dlnRho_dlnT_const_Pgas
          real(dp), dimension(num_eos_basic_results) :: &

--- a/star/private/create_initial_model.f90
+++ b/star/private/create_initial_model.f90
@@ -86,7 +86,7 @@
 
          integer :: initial_zfracs, i_lum, i, j, k, itry, max_try, id0, id1, id2
          real(dp) :: M, R, initial_y, initial_h1, initial_h2, initial_he3, initial_he4, &
-            S0, Pc0, rhoc0, e0(2), S1, Pc1, e1(2), S2, Pc2, e2(2), det, dPc, dS, safefac, &
+            S0, Pc0, e0(2), S1, Pc1, e1(2), S2, Pc2, e2(2), det, dPc, dS, safefac, &
             initial_z, xsol_he3, xsol_he4, mass_correction, mat(2,2), minv(2,2), sumx
          type (create_star_info), pointer :: cs
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -639,7 +639,6 @@
  integer, intent(in) :: level
  integer, intent(out) :: ierr
  logical, dimension(max_extra_inlists) :: read_extra
- character (len=strlen) :: message
  character (len=strlen), dimension(max_extra_inlists) :: extra
  integer :: unit, i
 

--- a/star/private/diffusion.f90
+++ b/star/private/diffusion.f90
@@ -103,12 +103,12 @@
          integer, intent(inout) ::  nzlo, nzhi !upper and lower bounds on region
 
          integer :: i, j, k, num_iters, idiag, n, neqs, ku, kl, &
-            ldab, ldafb, ldb, ldx, kmax, h1, he4, nbound, bad_j, bad_k, &
+            ldab, ldafb, ldb, ldx, h1, he4, nbound, bad_j, bad_k, &
             retry_count, max_retries, ierr_dealloc
          real(dp) :: &
-            dt, dt_next, min_dt, time, mstar, mtotal, sum_mass_nzlo_nzhi, xtotal_init(nc), &
-            xtotal(nc), mass_init(nc), frac, err, bad_X, bad_sum, bad_Xsum, &
-            dx_max, dx_avg, tol_correction_max, tol_correction_norm, remaining_time, &
+            dt, min_dt, time, mstar, mtotal, sum_mass_nzlo_nzhi, xtotal_init(nc), &
+            mass_init(nc), bad_X, bad_sum, bad_Xsum, &
+            tol_correction_max, tol_correction_norm, remaining_time, &
             sumx, tmp, timescale, min_lambda, upwind_limit, lambda, max_del, avg_del
 
          integer, parameter :: min_nz_lo = 5
@@ -143,16 +143,14 @@
          real(dp), dimension(:,:), pointer :: rhs, del
          real(dp), dimension(:,:,:), pointer :: em1, e00, ep1
          integer, pointer :: ipiv1(:)
-         integer :: lrd, lid, j_bad, k_bad, kmax_rad_accel, min_num_substeps, &
+         integer :: lrd, lid, kmax_rad_accel, min_num_substeps, &
             iter_dbg, j_dbg, k_dbg, k_max
          integer(8) :: time0, time1, clock_rate
          integer, pointer :: ipar_decsol(:)
          real(dp), pointer :: rpar_decsol(:)
-         real(dp), dimension(species) :: xa_total_before, xa_total_after
-         real(dp), dimension(m) :: A, C_face, Z_face
-         real(dp) :: X_total_atol, X_total_rtol, b_bad, flow_out, flow_in, &
-            vc_target, vc, vc_old, dt_old, &
-            max_timestep_factor, min_timestep_factor
+         real(dp), dimension(species) :: xa_total_before
+         real(dp), dimension(m) :: A
+         real(dp) :: X_total_atol, X_total_rtol, vc_old, dt_old
          logical :: have_changed_matrix_coeffs, trace, last_step, &
             solved, do_timing, use_isolve
 
@@ -456,7 +454,7 @@
             integer, intent(out) :: ierr
 
             integer :: &
-               i, k, nsteps, lout, iout, idid, ijac, max_steps, &
+               i, k, lout, iout, idid, ijac, max_steps, &
                imas, mlmas, mumas, itol, &
                nzmax, lrd, lid, isparse, &
                liwork, lwork, caller_id, which_solver, which_decsol
@@ -1231,7 +1229,7 @@
          integer, intent(out) :: i_t, k_t
          real(dp), intent(out) :: dt
          integer :: i, j, k
-         real(dp) :: xdm, f, flow_in, flow_out, dt1, dxdt, coeff, &
+         real(dp) :: f, flow_in, flow_out, dt1, dxdt, coeff, &
             flow_in_GT, flow_out_GT, flow_in_SIG, flow_out_SIG, &
             flow_in_max, flow_out_max, &
             flow_in_GT_max, flow_out_GT_max, &
@@ -1557,7 +1555,7 @@
          real(dp), intent(inout), dimension(:,:) :: dX_dt ! (nc,nz)
          real(dp), intent(inout), dimension(:,:) :: rhs ! (nc,nz)
          real(dp), intent(inout), dimension(:,:,:) :: em1, e00, ep1 ! (nc,nc,nz)
-         integer :: k, j
+         integer :: k
          ! lhs(i,k) := X(i,k) - (flow(i,k) - flow(i,k-1))*dt/cell_dm(k)
          ! rhs(i,k) := X_prev(i,k)
          ! em1(i,j,k) = d(lhs(i,k))/d(X(j,k-1))
@@ -1591,10 +1589,9 @@
          real(dp), intent(inout), dimension(:) :: dX_dt ! (nc)
          real(dp), intent(inout), dimension(:,:) :: rhs ! (nc,nz)
          real(dp), intent(inout), dimension(:,:,:) :: em1, e00, ep1 ! (nc,nc,nz)
-         integer :: i, j, jj
+         integer :: i, j
          real(dp) :: alfa, beta, c, coeff, dC_dXj00, dC_dXjm1, dC_dXjp1, &
-            dC, dcoeff_dXjm1, dcoeff_dXj00, dcoeff_dXjp1, max_coeff, &
-            dt_div_dm
+            dC, dcoeff_dXjm1, dcoeff_dXj00, dcoeff_dXjp1, dt_div_dm
 
          include 'formats'
 
@@ -1748,7 +1745,7 @@
          real(dp), pointer :: rpar_decsol(:)
          integer, intent(out) :: ierr
 
-         integer :: i, j, k, caller_id, ierr2
+         integer :: caller_id, ierr2
          integer, pointer :: ipiv1_n(:)
          real(dp), pointer, dimension(:) :: rhs1_n, lblk1_n, dblk1_n, ublk1_n
          real(dp), pointer, dimension(:,:,:) :: lblk, dblk, ublk
@@ -1904,7 +1901,7 @@
          integer, intent(out) :: class_chem_id(:) ! (nc)
          character (len=8), intent(out) :: class_name(:) ! (nc)
          real(dp) :: A
-         integer :: i, j
+         integer :: i
          integer, parameter :: c_h = 1, c_he = 2, c_o = 3, c_fe = 4
          class_name(c_h) = 'c_h'
          class_name(c_he) = 'c_he'

--- a/star/private/diffusion_procs.f90
+++ b/star/private/diffusion_procs.f90
@@ -58,11 +58,8 @@
          real(dp), intent(out) :: bad_X, bad_sum, bad_Xsum
          integer, intent(out) :: bad_j, bad_k, ierr
 
-         integer :: i, j, jj, k, k1, op_err, rep, num_extreme, &
-            j_max, k_max, k_lo, k_hi, kk, cnt, maxcnt, nsmooth_x_in_fixup
-         real(dp) :: max_lnT_for_smooth, sum_m, m_00, dm, source_mass, frac, err, &
-            max_abs_dx, xm1, x00, xp1, m0, sum0, m1, sum1, x_new, xtotal_new, &
-            sum_m1, sum_00, sum_p1, m_m1, m_p1, xavg, dm_m1, dm_p1, x1
+         integer :: j, k, op_err, nsmooth_x_in_fixup
+         real(dp) :: max_lnT_for_smooth
 
          logical :: dbg
 
@@ -710,7 +707,7 @@
 
          integer :: k_source, max_iters, k, i, j
          real(dp) :: source_cell_mass, remaining_source_mass, cell_dm_k, &
-            remaining_needed_mass, frac, sumX, total_source, total_moved, &
+            remaining_needed_mass, sumX, total_source, total_moved, &
             dm0, dm1, old_sum, new_sum, mtotal, err, dm, diff_dm
          logical :: okay, dbg
 
@@ -1078,7 +1075,7 @@
          real(dp), dimension(:), intent(out) :: xm_face
          integer, intent(out) :: kmax_rad_accel, ierr
 
-         integer :: i, k, j, op_err, kmax
+         integer :: i, k, j, kmax
 
          logical, parameter :: dbg = .false.
 
@@ -1242,13 +1239,11 @@
             log10_g_rad, g_rad, rad_accel_face
          integer, intent(out) :: ierr
 
-         integer :: iZ(nc), iZ_rad(nc), n, i, j, k, kk, kmax, op_err, sz, offset, &
-            nptot, ipe, nrad, thread_num, k1, k2, dk
+         integer :: iZ(nc), iZ_rad(nc), i, j, k, kk, kmax, op_err, k1, k2, dk
          real(dp) :: alfa, beta, X_face(nc), blend_fac(-15:15)
 
 
-         integer :: np = 28016
-         real(dp) :: fk(17), fk_all(ngp,17), delta, blend
+         real(dp) :: fk(17), delta, blend
          character(len=4) :: e_name
 
          logical, parameter :: dbg = .false.
@@ -1401,7 +1396,7 @@
          integer, intent(out) :: ierr
 
          integer :: i, ii
-         real(dp) :: tot, logT, logRho, flux
+         real(dp) :: logT, logRho
          real(dp), dimension(17) ::lgrad, fk
          integer :: iZ_rad2(17)
          character(len=4) :: e_name

--- a/star/private/diffusion_support.f90
+++ b/star/private/diffusion_support.f90
@@ -79,8 +79,8 @@
          real(dp), dimension(:,:,:), intent(out) :: SIG_face, sigma_lnC
          integer, intent(out) :: ierr
          
-         integer :: i, j, jj, k, op_err, im
-         real(dp) :: dv_im, alfa, beta, cc, tmp, tinyX, dlamch, sfmin, &
+         integer :: i, j, k, op_err
+         real(dp) :: tmp, tinyX, dlamch, sfmin, &
             AD_dm_full_on, AD_dm_full_off, AD_boost_factor, sum_dm, &
             Vlimit_dm_full_on, Vlimit_dm_full_off, Vlimit, sigmax, &
             SIG_factor, GT_factor
@@ -283,7 +283,6 @@
          real(dp), intent(inout) :: sigma_lnC(:,:) ! (nc,nc)
          integer, intent(out) :: ierr
          
-         integer :: i, j
          real(dp), dimension(m) :: AP, AT, AR
          real(dp), dimension(m,m) :: kappa_st, Zdiff, Zdiff1, Zdiff2, AX
          
@@ -387,7 +386,7 @@
          real(dp) :: ac, ni, cz, xij, ne, ao, lambdad, lambda, alfa, Gamlo, Gamhi
          real(dp), dimension(m) :: charge, na
          real(dp), dimension(m,m) :: cl, Ath, Ddiff, Kdiff, Kdiff2
-         real(dp) :: Gamma, ai, lam_e, kappa, kappa_SM, Abar, Zbar, omegap
+         real(dp) :: Gamma, kappa_SM
          real(dp) :: Ddiff_Caplan(nc)
             
          do i = 1, nc
@@ -770,7 +769,7 @@
          real(dp), intent(inout) :: SIG_face(:,:) ! (nc,nc)
          
          integer :: i, j
-         real(dp) :: c, boost
+         real(dp) :: c
          
          include 'formats'
 
@@ -859,8 +858,8 @@
          real(dp), intent(inout) :: g_ap, g_at, g_ar, g_ax(:) ! (m)
          integer, intent(out) :: ierr
 
-         integer :: i, j, l, indx(n), nmax
-         real(dp) :: aamax, cc, ac, temp, ko, d, f
+         integer :: i, j, l, indx(n)
+         real(dp) :: cc, ac, ko, f
          real(dp), dimension(m,m) :: xx, y, yy, k
          real(dp), dimension(n) :: alpha, nu, ga, beta
          real(dp), dimension(n,n) :: delta, gamma
@@ -1085,7 +1084,7 @@
         real(dp), intent(inout) :: e_ap, e_at, e_ar, e_ax(:)
         integer, intent(out) :: ierr
 
-        integer :: i,j,l,indx(n),nmax
+        integer :: i,j,l,indx(n)
         real(dp), dimension(n) :: alpha, beta, nu, ga
         ! Add in beta later for rad lev. ga is the temp holder for the
         ! columns of gamm when doing matrix solve one column at a time.
@@ -1252,7 +1251,7 @@
         real(dp), intent(inout) :: e_ap, e_at, e_ar, e_ax(:)
         integer, intent(out) :: ierr
 
-        integer :: i,j,l,indx(n),nmax, rightshift, downshift
+        integer :: i,j,l,indx(n), rightshift, downshift
         real(dp), dimension(n) :: alpha, beta, nu, ga
         ! Add in beta later for rad lev. ga is the temp holder for the
         ! columns of gamm when doing matrix solve one column at a time.
@@ -1478,7 +1477,7 @@
         ! Fitting coefficients from Stanton & Murillo
         real(dp), dimension(2,3) :: a1,a2,a3,a4,a5,b0,b1,b2,b3,b4
         real(dp) :: lambda ! The screening length
-        integer :: i,j,k,facmo,no,mo ! Last two are used for different orders of collisions.
+        integer :: i,j,facmo,no,mo ! Last two are used for different orders of collisions.
 
         real(dp) :: lgp, gp1, gp2, gp3, gp4, gp5, kbT32, tmp
 

--- a/star/private/do_one_utils.f90
+++ b/star/private/do_one_utils.f90
@@ -120,7 +120,7 @@
       
       subroutine do_show_terminal_header(s)
          type (star_info), pointer :: s
-         integer :: id, ierr, io
+         integer :: ierr, io
          call output_terminal_header(s,terminal_iounit)
          if (len_trim(s% extra_terminal_output_file) > 0) then
             ierr = 0
@@ -234,7 +234,7 @@
       
       subroutine do_terminal_summary(s)
          type (star_info), pointer :: s
-         integer :: id, ierr, io
+         integer :: ierr, io
          call output_terminal_summary(s,terminal_iounit)
          if (len_trim(s% extra_terminal_output_file) > 0) then
             ierr = 0
@@ -574,13 +574,13 @@
          use star_utils
          integer, intent(in) :: id
          type (star_info), pointer :: s
-         integer :: ierr, i, j, k, cid, k_burn, k_omega, nz, max_abs_vel_loc, &
+         integer :: ierr, i, j, k, cid, k_omega, nz, max_abs_vel_loc, &
             period_number, max_period_number
          real(dp) :: log_surface_gravity, log_surface_temperature, log_surface_density, &
             log_surface_pressure, v_div_csound_max, remnant_mass, ejecta_mass, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, logQ, max_logQ, min_logQ, &
             envelope_fraction_left, avg_x, v_surf, csound_surf, delta_nu, v_surf_div_v_esc, &
-            ratio, dt_C, peak_burn_vconv_div_cs, min_pgas_div_p, v_surf_div_v_kh, GREKM_avg_abs, &
+            peak_burn_vconv_div_cs, min_pgas_div_p, v_surf_div_v_kh, GREKM_avg_abs, &
             max_omega_div_omega_crit, omega_div_omega_crit, log_Teff, Lnuc_div_L, max_abs_vel, &
             species_mass_for_min_limit, species_mass_for_max_limit, center_gamma
             
@@ -1480,7 +1480,7 @@
          real(dp), parameter :: log_he_temp = 7.8d0
          real(dp), parameter :: d_tau_min = 1d-2, d_tau_max = 1d0
          real(dp), parameter :: little_step_factor = 10d0, little_step_size = 10d0
-         real(dp) :: v, surf_grav, power_he_burn, power_z_burn, &
+         real(dp) :: v, power_he_burn, power_z_burn, &
             power_neutrinos
          integer :: model, profile_priority, ierr
          integer, parameter :: tau_ramp = 50

--- a/star/private/element_diffusion.f90
+++ b/star/private/element_diffusion.f90
@@ -42,7 +42,7 @@
 
       subroutine do_element_diffusion(s, dt_in, ierr)
          ! return ierr /= 0 if cannot satisfy accuracy requirements
-         use chem_def, only: chem_isos, ihe4, ih1
+         use chem_def, only: chem_isos
          use chem_lib, only: chem_get_iso_id
          use star_utils, only: start_time, update_time
          use diffusion, only: &
@@ -52,16 +52,14 @@
          integer, intent(out) :: ierr
 
          integer :: i, j, k, kk, nc, m, nzlo, nzhi, nz, species, iounit, &
-            steps_used, total_num_iters, total_num_retries, cid, he4
+            steps_used, total_num_iters, total_num_retries, cid
          integer(8) :: time0
-         real(dp) :: s1, s2, dqsum, dist, r, Hp, dt, total, &
+         real(dp) :: s1, s2, dqsum, dt, total, &
             gradT_mid, gradRho_mid, alfa, gradRho_face, chiRho_face, chiT_face
-         real(dp) :: rho, Pgas, T, &
-            logRho, dlnRho_dlnPgas, dlnRho_dlnT, &
-            e, de, e_with_xa, Amass, Zcharge, min_D_mix
+         real(dp) :: Amass, Zcharge, min_D_mix
 
          integer, dimension(:), allocatable :: &
-            class, class_chem_id, mixing_type, mixing_type_arg
+            class, class_chem_id, mixing_type
          real(dp), dimension(:), allocatable :: &
             gamma, free_e, &
             dlnPdm_face, dlnT_dm_face, dlnRho_dm_face, &
@@ -74,7 +72,7 @@
          character (len=8), allocatable :: class_name(:)
 
 
-         logical :: dumping, okay
+         logical :: dumping
 
          include 'formats'
 
@@ -470,8 +468,6 @@
             use utils_lib
             use chem_def, only: chem_isos
             integer :: i, k, ierr
-            real(dp) :: alfa, rho_face, chiT_face, chiRho_face, &
-               dm_dr, gradRho, dlnRho_dm
 
             ierr = 0
             write(*, *)

--- a/star/private/eos_support.f90
+++ b/star/private/eos_support.f90
@@ -75,9 +75,7 @@ contains
     real(dp), intent(out) :: dres_dxa(num_eos_d_dxa_results,s% species)
     integer, intent(out) :: ierr
 
-    real(dp), dimension(num_eos_basic_results) :: dres_dabar, dres_dzbar
     integer :: j
-    logical :: off_table
 
     include 'formats'
 
@@ -229,7 +227,6 @@ contains
     integer, intent(out) :: ierr
 
     integer :: eos_calls
-    real(dp) :: eos_x, eos_z
 
     include 'formats'
 
@@ -273,7 +270,6 @@ contains
     integer, intent(out) :: ierr
 
     integer :: eos_calls
-    real(dp) :: eos_x, eos_z
 
     include 'formats'
 
@@ -411,8 +407,7 @@ contains
     real(dp), intent(out) :: dres_dxa(num_eos_d_dxa_results,s% species)
     integer, intent(out) :: ierr
 
-    real(dp) :: rho_guess, logRho_guess, gamma, &
-         dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas
+    real(dp) :: rho_guess, logRho_guess, gamma
 
     ! compute composition info
     real(dp) :: Y, Z, X, abar, zbar, z2bar, z53bar, ye, mass_correction, sumx

--- a/star/private/eps_grav.f90
+++ b/star/private/eps_grav.f90
@@ -223,7 +223,7 @@
          integer, intent(out) :: ierr
 
          real(dp) :: entropy_start
-         type(auto_diff_real_star_order1) :: entropy, T, eps_grav_composition_term
+         type(auto_diff_real_star_order1) :: entropy, T
 
          include 'formats'
          ierr = 0
@@ -274,7 +274,7 @@
          integer, intent(in) :: k
          type(auto_diff_real_star_order1), intent(out) :: eps_grav_composition_term
          integer, intent(out) :: ierr
-         real(dp) :: Rho, logRho, &
+         real(dp) :: &
             e, e_start, de, d_de_dlnd, d_de_dlnT, &
             e_with_xa_start, d_e_with_xa_start_dlnd, d_e_with_xa_start_dlnT, &
             e_with_DT_start, Pgas_with_DT_start

--- a/star/private/eps_mdot.f90
+++ b/star/private/eps_mdot.f90
@@ -185,14 +185,11 @@
          real(dp), dimension(:) :: eps_mdot_per_total_mass, accumulated, leak_frac
 
          ! Intermediates
-         integer :: i, j, k
-         integer :: i0, i1
+         integer :: j
          integer :: i_start, i_end
          integer, dimension(:), allocatable :: i_min, i_max, j_min, j_max
-         logical :: do_now
          real(qp) delta_m
          real(dp) sgn
-         real(dp), dimension(:), allocatable :: excess
          type(non_rect_array), dimension(:), allocatable :: pf
 
          !!! High-level explanation
@@ -345,7 +342,7 @@
 
 
          ! Intermediates
-         integer :: i, j, k, direction, ii
+         integer :: i, j, direction
          real(qp) pass_frac, next, pass_mass
          real(dp), dimension(:), allocatable :: excess
 
@@ -470,18 +467,17 @@
          
          ! Intermediates
          logical :: dbg = .false.
-         integer :: nz, j, k, l, n
-         real(dp) delta_m, sgn, change_sum, leak_sum, err, abs_err, mdot_adiabatic_surface, gradT_mid
+         integer :: nz, j
+         real(dp) delta_m, change_sum, leak_sum, err, abs_err, mdot_adiabatic_surface, gradT_mid
          real(dp), dimension(:), allocatable :: &
-            p_bar, rho_bar, te_bar, te, curr_m, &
+            p_bar, rho_bar, te_bar, te, &
             leak_frac, thermal_energy, density_weighted_flux, eps_mdot_per_total_mass,&
             accumulated, grad_r_sub_grad_a
          real(qp), dimension(:), allocatable :: change_in_dm, mass_flux, dm, prev_mesh_dm,&
              total_mass_through_cell
          type(accurate_real) sum
          integer, dimension(:,:), allocatable :: ranges
-         real(qp), dimension(:), allocatable :: remainders, mesh_intersects
-         real(qp) m
+         real(qp), dimension(:), allocatable :: mesh_intersects
 
          if (s% mstar_dot == 0d0 .or. dt <= 0d0) then
             s% eps_mdot(1:s%nz) = 0d0

--- a/star/private/evolve_support.f90
+++ b/star/private/evolve_support.f90
@@ -157,7 +157,6 @@
          use hydro_rotation, only: use_xh_to_update_i_rot
          use utils_lib
          type (star_info), pointer :: s
-         real(dp), pointer :: p1(:)
          integer :: j, k, ierr
 
          include 'formats'
@@ -287,7 +286,7 @@
          integer, intent(in) :: id
          integer, intent(out) :: ierr
 
-         integer :: iounit, k
+         integer :: iounit
          type (star_info), pointer :: s
          character(len=strlen) :: iomsg
 

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -3285,7 +3285,7 @@ contains
       integer :: i, c, int_val, ierr, n, t, j, iounit
       real(dp) :: val, epsnuc_out(12), v_surf, csound_surf, envelope_fraction_left
       logical :: is_int_val, special_case
-      character (len = strlen) :: buffer, string
+      character (len = strlen) :: string
 
       include 'formats'
       ierr = 0

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -64,7 +64,6 @@ contains
       use utils_lib, only : integer_dict_create_hash, integer_dict_free, mkdir, folder_exists
       use chem_def, only : category_name
       use math_lib, only : math_backend
-      use rates_def, only : rates_reaction_id_max
       use net_def, only : Net_General_Info, get_net_ptr
       type (star_info), pointer :: s
 
@@ -477,7 +476,6 @@ contains
 
       subroutine do_extra_col(pass, j, col_offset)
          integer, intent(in) :: pass, j, col_offset
-         integer :: int_val
          include 'formats'
          if (pass == 1) then
             if (write_flag) write(io, fmt = int_fmt, advance = 'no') j + col_offset
@@ -815,7 +813,7 @@ contains
          use num_lib, only : find0
          integer, intent(in) :: k
          integer :: bv, bv0, bv1
-         real(dp) :: eps, eps0, eps1, d0, d1, q0, q1
+         real(dp) :: eps, eps0, eps1, d0, d1
          include 'formats'
          if (k <= 0) then
             val = -1; return
@@ -1007,7 +1005,7 @@ contains
          integer, intent(in) :: c
          integer :: i, ii, k, int_val
          logical :: is_int_val
-         real(dp) :: val, val1, Ledd, power_photo, frac
+         real(dp) :: val, frac
          int_val = 0; val = 0; is_int_val = .false.
 
          if (c > burn_relr_offset) then
@@ -1188,8 +1186,7 @@ contains
       integer, intent(out) :: ierr
 
       integer :: k, i, min_k, k2
-      real(dp) :: Ledd, L_rad, phi_Joss, power_photo, tmp, r, m_div_h, w_div_w_Kep, &
-         min_gamma1, deltam
+      real(dp) :: Ledd, phi_Joss, power_photo, tmp, r, m_div_h, w_div_w_Kep, deltam
       real(dp), pointer :: v(:)
       logical :: v_flag
 
@@ -2951,7 +2948,6 @@ contains
 
       real(dp) function max_eps_nuc_log_x(j)
          integer, intent(in) :: j
-         real(dp) :: sum_x, sum_dq
          integer :: k
          max_eps_nuc_log_x = 0
          if (j == 0) return
@@ -2963,7 +2959,6 @@ contains
 
       real(dp) function cz_top_max_log_x(j)
          integer, intent(in) :: j
-         real(dp) :: sum_x, sum_dq
          integer :: k
          cz_top_max_log_x = 0
          if (s% largest_conv_mixing_region == 0) return
@@ -2975,7 +2970,6 @@ contains
 
       real(dp) function cz_max_log_x(j)
          integer, intent(in) :: j
-         real(dp) :: sum_x, sum_dq
          integer :: k
          cz_max_log_x = 0
          if (s% largest_conv_mixing_region == 0) return
@@ -3022,7 +3016,7 @@ contains
       real(dp), intent(in) :: nu_factor
 
       real(dp) :: integral, cs2, r2, n2, sl2, omega2, &
-         L2, kr2, dr, r0_outer, r0_inner, sl2_next, xh1
+         L2, kr2, dr, r0_outer, r0_inner, xh1
       integer :: k, k1, k_inner, k_outer, h1
 
       logical :: dbg
@@ -3282,10 +3276,8 @@ contains
       real(dp), intent(inout) :: values(:)
       logical, intent(out) :: failed_to_find_value(:)
 
-      integer :: i, c, int_val, ierr, n, t, j, iounit
-      real(dp) :: val, epsnuc_out(12), v_surf, csound_surf, envelope_fraction_left
-      logical :: is_int_val, special_case
-      character (len = strlen) :: string
+      integer :: i, c, ierr
+      real(dp) :: epsnuc_out(12), v_surf, csound_surf, envelope_fraction_left
 
       include 'formats'
       ierr = 0

--- a/star/private/history_specs.f90
+++ b/star/private/history_specs.f90
@@ -95,10 +95,10 @@
          logical, intent(in) :: report
          integer, intent(out) :: ierr
 
-         integer :: iounit, n, i, t, id, j, k, cnt, ii, nxt_spec, spec_err
+         integer :: iounit, n, i, t, j, cnt, ii, nxt_spec, spec_err
          character (len=strlen) :: buffer, string, filename
          integer, parameter :: max_level = 20
-         logical :: bad_item, special_case, exists
+         logical :: special_case, exists
          logical, parameter :: dbg = .false.
 
          include 'formats'

--- a/star/private/hydro_alpha_rti_eqns.f90
+++ b/star/private/hydro_alpha_rti_eqns.f90
@@ -41,7 +41,6 @@
 
       subroutine do1_dalpha_RTI_dt_eqn(s, k, nvar, ierr)
          use star_utils, only: em1, e00, ep1
-         use chem_def, only: ih1, ihe4
 
          type (star_info), pointer :: s
          integer, intent(in) :: k, nvar
@@ -52,13 +51,12 @@
          type(auto_diff_real_4var_order1) :: source_minus, source_plus, dadt_source, dadt_actual
          type(auto_diff_real_4var_order1) :: dadt_mix, dadt_expected, resid
 
-         integer :: nz, i_alpha_RTI, i_dalpha_RTI_dt, j, kk
+         integer :: nz, i_alpha_RTI, i_dalpha_RTI_dt
          real(dp), pointer, dimension(:) :: sig
-         logical :: okay
          real(dp) :: &
-            dq, dm, dr, d_dadt_mix_dap1, sig00, sigp1, &
+            dq, dm, sig00, sigp1, &
             eqn_scale, dPdr_drhodr, instability2, instability, RTI_B, &
-            r00, rp1, drho, rho, rmid, cs, fac
+            r00, rho, rmid, cs, fac
          logical :: test_partials
 
          include 'formats'

--- a/star/private/hydro_chem_eqns.f90
+++ b/star/private/hydro_chem_eqns.f90
@@ -60,24 +60,23 @@
 
          use chem_def
          use net_lib, only: show_net_reactions, show_net_params
-         use rates_def, only: reaction_Name, i_rate
+         use rates_def, only: i_rate
          use star_utils, only: em1, e00, ep1
 
          type (star_info), pointer :: s
          integer, intent(in) :: k, nvar
          integer, intent(out) :: ierr
 
-         integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
+         !integer, pointer :: reaction_id(:) ! maps net reaction number to reaction id
          integer :: nz, j, i, jj, ii, species
          real(dp) :: &
             dxdt_expected_dxa, dxdt_expected, dxdt_actual, &
-            dxdt_expected_dlnd, dxdt_expected_dlnT, &
             dq, dm, dequ, dxdt_nuc, dxdt_mix, max_abs_residual, &
-            sum_dxdt_nuc, dx_expected_dlnd, dx_expected_dlnT, &
+            sum_dxdt_nuc, &
             d_dxdt_mix_dx00, d_dxdt_mix_dxm1, d_dxdt_mix_dxp1, &
             sum_dx_burning, sum_dx_mixing, residual, &
-            dxdt_factor, alpha, eqn_scale, d_dxdt_dx, &
-            dequ_dlnd, dequ_dlnT, dequ_dlnPgas_const_T, dequ_dlnT_const_Pgas
+            dxdt_factor, eqn_scale, &
+            dequ_dlnd, dequ_dlnT
          logical :: test_partials, doing_op_split_burn
          logical, parameter :: checking = .false.
 

--- a/star/private/hydro_energy.f90
+++ b/star/private/hydro_energy.f90
@@ -544,12 +544,11 @@
             d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1
          integer, intent(out) :: ierr
             
-         real(dp) :: work_00, work_p1, dm, dV
+         real(dp) :: work_00, work_p1
          real(dp), dimension(s% species) :: &
             d_work_00_dxa00, d_work_00_dxam1, &
-            d_work_p1_dxap1, d_work_p1_dxa00, d_Ptot_dxa
-         type(auto_diff_real_star_order1) :: work_00_ad, work_p1_ad, &
-            Ptot_ad, dV_ad, rho_ad
+            d_work_p1_dxap1, d_work_p1_dxa00
+         type(auto_diff_real_star_order1) :: work_00_ad, work_p1_ad
          logical :: test_partials
          integer :: j
          include 'formats'
@@ -597,12 +596,12 @@
          real(dp), dimension(s% species), intent(out) :: &
             d_work_dxa00, d_work_dxam1
          integer, intent(out) :: ierr
-         real(dp) :: alfa, beta, P_theta, Peos_face, Av_face
+         real(dp) :: alfa, beta, P_theta, Av_face
          real(dp), dimension(s% species) :: d_Pface_dxa00, d_Pface_dxam1
          type(auto_diff_real_star_order1) :: &
             P_face_ad, A_times_v_face_ad, mlt_Pturb_ad, &
             PtrbR_ad, PtrbL_ad, PvscL_ad, PvscR_ad, Ptrb_div_etrb, PL_ad, PR_ad, &
-            Peos_ad, Ptrb_ad, Pvsc_ad, inv_R2, extra_P
+            Peos_ad, Ptrb_ad, Pvsc_ad, extra_P
          logical :: test_partials
          integer :: j
          include 'formats'

--- a/star/private/hydro_eqns.f90
+++ b/star/private/hydro_eqns.f90
@@ -71,16 +71,16 @@
          integer, intent(out) :: ierr
 
          integer :: &
-            i_dv_dt, i_du_dt, i_du_dk, i_equL, i_dlnd_dt, i_dlnE_dt, i_dlnR_dt, &
+            i_dv_dt, i_du_dt, i_equL, i_dlnd_dt, i_dlnE_dt, i_dlnR_dt, &
             i_dalpha_RTI_dt, i_equ_w_div_wc, i_dj_rot_dt, i_detrb_dt, &
             i, k, j, nvar_hydro, nz, op_err
          integer :: &
-            i_lnd, i_lnR, i_lnT, i_lum, i_v, i_u, i_du, i_w_div_wc, i_j_rot, &
-            i_alpha_RTI, i_xh1, i_xhe4, kmax_equ(nvar), species
-         real(dp) :: max_equ(nvar), L_phot_old
+            i_lnd, i_lnR, i_lnT, i_lum, i_v, i_u, i_w_div_wc, i_j_rot, &
+            i_alpha_RTI, i_xh1, i_xhe4, species
+         real(dp) :: L_phot_old
          real(dp), dimension(:), pointer :: &
             L, lnR, lnP, lnT, energy
-         logical :: v_flag, u_flag, cv_flag, w_div_wc_flag, j_rot_flag, dump_for_debug, &
+         logical :: v_flag, u_flag, dump_for_debug, &
             do_chem, do_mix, do_dlnd_dt, do_dv_dt, do_du_dt, do_dlnR_dt, &
             do_alpha_RTI, do_w_div_wc, do_j_rot, do_dlnE_dt, do_equL, do_detrb_dt
 
@@ -318,7 +318,7 @@
          contains
 
          subroutine dump_equ
-            integer :: k, j, k0, k1
+            integer :: k, j
             include 'formats'
             do k=1,s% nz
                do j=1,nvar
@@ -602,7 +602,7 @@
          integer, intent(in) :: k, nvar
          integer, intent(out) :: ierr
          integer :: i_equ_w_div_wc, i_w_div_wc
-         real(dp) :: wwc, dimless_rphi, dimless_rphi_given_wwc, w1, w2
+         real(dp) :: wwc
          real(dp) :: jr_lim1, jr_lim2, A, C
          type(auto_diff_real_star_order1) :: &
             w_d_wc00, r00, jrot00, resid_ad, A_ad, C_ad, &
@@ -825,10 +825,9 @@
                dlnT_bc_dlnd, dlnT_bc_dlnT, dlnT_bc_dlnR, &
                dlnT_bc_dL, dlnP_bc_dlnd, dlnP_bc_dlnT, dlnP_bc_dL, dlnP_bc_dlnR, &
                dlnkap_dlnd, dlnkap_dlnT, dPinv_dlnd, dPinv_dlnT, dP0, dT0, &
-               P_surf, T_surf, dlnP_bc_dlnPsurf, P_rad, &
+               P_surf, T_surf, dlnP_bc_dlnPsurf, &
                dlnT_bc_dlnTsurf, P_bc, T_bc, lnT_bc, lnP_bc, &
                dP0_dlnR, dT0_dlnR, dT0_dlnT, dT0_dlnd, dT0_dL, dlnP_bc_dP0, dlnT_bc_dT0, &
-               dlnP_dlnE_c_Rho, &
                d_gradT_dlnR, d_gradT_dlnT00, d_gradT_dlnd00, d_gradT_dL, &
                dlnR00, dlnT00, dlnd00
             logical, parameter :: skip_partials = .false.

--- a/star/private/hydro_momentum.f90
+++ b/star/private/hydro_momentum.f90
@@ -86,7 +86,6 @@
       subroutine get1_momentum_eqn( &
             s, k, P_surf_ad, nvar, &
             d_dm1, d_d00, d_dp1, ierr)
-         use chem_def, only: chem_isos
          use accurate_sum_auto_diff_star_order1
          use auto_diff_support
 
@@ -101,7 +100,7 @@
          real(dp), dimension(s% species) :: &
             d_dPtot_dxam1, d_dPtot_dxa00, d_iPtotavg_dxam1, d_iPtotavg_dxa00, &
             d_residual_dxam1, d_residual_dxa00
-         integer :: nz, j, i_dv_dt, i_lum, i_v
+         integer :: nz, i_dv_dt, i_lum, i_v
          logical :: test_partials
          
          type(auto_diff_real_star_order1) :: resid1_ad, resid_ad, &
@@ -389,7 +388,7 @@
          integer, intent(out) :: ierr
          type(auto_diff_real_star_order1) :: extra_ad, v_00, &
             drag
-         real(dp) :: accel, d_accel_dv, fraction_on
+         real(dp) :: accel, d_accel_dv
          logical :: test_partials, local_v_flag
 
          include 'formats'
@@ -553,8 +552,8 @@
          integer, intent(in) :: k, nvar
          integer, intent(out) :: ierr
          type(auto_diff_real_star_order1) :: &
-            v00, r_actual, r_expected, dxh_lnR, resid_ad, &
-            dr_div_r0_actual, dr_div_r0_expected, dr
+            v00, dxh_lnR, resid_ad, &
+            dr_div_r0_actual, dr_div_r0_expected
          logical :: test_partials, force_zero_v
          include 'formats'
          !test_partials = (k == s% solver_test_partials_k)
@@ -606,4 +605,3 @@
 
 
       end module hydro_momentum
-

--- a/star/private/hydro_riemann.f90
+++ b/star/private/hydro_riemann.f90
@@ -87,7 +87,7 @@
          integer, intent(in) :: nvar
          integer, intent(out) :: ierr
       
-         integer :: j, nz, i_du_dt, i_u
+         integer :: nz, i_du_dt
          type(auto_diff_real_star_order1) :: &
             flux_in_ad, flux_out_ad, diffusion_source_ad, &
             geometry_source_ad, gravity_source_ad, &

--- a/star/private/hydro_rotation.f90
+++ b/star/private/hydro_rotation.f90
@@ -216,7 +216,7 @@
       subroutine set_i_rot(s, skip_w_div_w_crit_roche)
          type (star_info), pointer :: s
          logical, intent(in) :: skip_w_div_w_crit_roche
-         integer :: k, nz
+         integer :: k
          include 'formats'
 
 !$OMP PARALLEL DO PRIVATE(k) SCHEDULE(dynamic,2)
@@ -292,7 +292,7 @@
       subroutine update1_i_rot_from_xh(s, k)
          type (star_info), pointer :: s
          integer, intent(in) :: k
-         real(dp) :: r00, r003, rp1, rp13, rm1, rm13, r_in, r_out
+         real(dp) :: r00
          include 'formats'
 
          r00 = get_r_from_xh(s,k)
@@ -477,7 +477,6 @@
          type (star_info), pointer :: s
          logical, intent(in) :: skip_w_div_w_crit_roche
          integer, intent(out) :: ierr
-         integer :: k
          include 'formats'
          ierr = 0
 
@@ -507,7 +506,7 @@
          real(dp) :: &
             dm, dmsum, omega_sum, omega_crit_sum, omega_div_omega_crit_sum, &
             v_rot_sum, v_crit_sum, v_div_v_crit_sum, Lrad_div_Ledd_sum, &
-            kap_face, Ledd, gamma_factor, omega_crit, omega, kap_sum, &
+            gamma_factor, omega_crit, omega, kap_sum, &
             j_rot_sum, j_rot, v_rot, v_crit, Lrad_div_Ledd, dtau, tau, &
             cgrav, kap, mmid, Lmid, rmid, logT_sum, logRho_sum
          integer :: k, ierr
@@ -682,8 +681,7 @@
 
          logical :: dbg
 
-         type(auto_diff_real_1var_order1) :: A_omega,fp_numerator, ft_numerator, w, w2, w3, w4, w5, w6, lg_one_sub_w4, &
-            d_A_omega_dw, d_fp_numerator_dw, d_ft_numerator_dw, fp_temp, ft_temp
+         type(auto_diff_real_1var_order1) :: A_omega,fp_numerator, ft_numerator, w, w2, w3, w4, w5, w6, lg_one_sub_w4, fp_temp, ft_temp
 
          include 'formats'
 

--- a/star/private/hydro_rsp2.f90
+++ b/star/private/hydro_rsp2.f90
@@ -235,7 +235,6 @@
             r_00, Peos_00, d_00, Peos_m1, d_m1, Peos_div_rho, &
             d_face, Peos_face, alt_Hp_face, A
          real(dp) :: alfa, beta
-         integer :: j
          include 'formats'         
          ierr = 0
          if (k > s% nz) then
@@ -289,15 +288,14 @@
          type (star_info), pointer :: s
          integer, intent(in) :: k, nvar
          integer, intent(out) :: ierr         
-         integer :: j
          ! for OLD WAY
          type(auto_diff_real_star_order1) :: &
             d_turbulent_energy_ad, Ptrb_dV_ad, dt_C_ad, dt_Eq_ad
-         type(auto_diff_real_star_order1) :: xi0, xi1, xi2, A0, Af, w_00
+         type(auto_diff_real_star_order1) :: w_00
          type(auto_diff_real_star_order1) :: tst, resid_ad, dt_dLt_dm_ad
          type(accurate_auto_diff_real_star_order1) :: esum_ad
          logical :: non_turbulent_cell, test_partials
-         real(dp) :: residual, atol, rtol, scal
+         real(dp) :: residual, scal
          include 'formats'
          !test_partials = (k == s% solver_test_partials_k)
          test_partials = .false.
@@ -374,8 +372,8 @@
 
          subroutine setup_dt_dLt_dm_ad(ierr) ! erg g^-1
             integer, intent(out) :: ierr            
-            type(auto_diff_real_star_order1) :: Lt_00, Lt_p1, dLt_ad
-            real(dp) :: Lt_00_start, Lt_p1_start, L_theta
+            type(auto_diff_real_star_order1) :: Lt_00, Lt_p1
+            real(dp) :: L_theta
             include 'formats'
             ierr = 0
             if (s% using_velocity_time_centering .and. &
@@ -629,10 +627,8 @@
          integer, intent(in) :: k
          integer, intent(out) :: ierr
          type(auto_diff_real_star_order1) :: Hp_cell
-         type(auto_diff_real_star_order1) :: &
-            d_00, Peos_00, rmid
+         type(auto_diff_real_star_order1) :: d_00, Peos_00, rmid
          real(dp) :: mmid, cgrav_mid
-         integer :: j
          include 'formats'         
          ierr = 0
          
@@ -769,7 +765,7 @@
          type(auto_diff_real_star_order1) :: &
             w_00, T_00, d_00, Peos_00, Cp_00, chiT_00, chiRho_00, QQ_00, &
             Hp_face_00, Hp_face_p1, PII_face_00, PII_face_p1, PII_div_Hp_cell, &
-            grad_ad_00, P_QQ_div_Cp
+            P_QQ_div_Cp
          include 'formats'
          ierr = 0
          w_00 = wrap_w_00(s, k)
@@ -922,7 +918,6 @@
          type (star_info), pointer, intent(in) :: s
          integer, intent(in) :: k
          type(auto_diff_real_star_order1), intent(out) :: L, Lr, Lc, Lt
-         real(dp) :: L_val
          integer, intent(out) :: ierr         
          include 'formats'
          ierr = 0
@@ -1115,7 +1110,7 @@
       subroutine set_etrb_start_vars(s, ierr)
          type (star_info), pointer :: s
          integer, intent(out) :: ierr         
-         integer :: k, op_err
+         integer :: k
          type(auto_diff_real_star_order1) :: Y_face, Lt
          include 'formats'
          ierr = 0
@@ -1138,8 +1133,8 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr    
          real(dp) :: PII_div_Hp, QQ, SOURCE, Hp_cell, DAMP, POM, POM2, DAMPR, del, soln
-         type(auto_diff_real_star_order1) :: x
-         integer :: k, op_err
+         !type(auto_diff_real_star_order1) :: x
+         integer :: k
          include 'formats'         
          ierr = 0
          if (s% mixing_length_alpha == 0d0) return

--- a/star/private/hydro_rsp2_support.f90
+++ b/star/private/hydro_rsp2_support.f90
@@ -52,8 +52,7 @@
          type (star_info), pointer :: s      
          integer, intent(out) :: ierr    
          integer :: k, j, nz_old, nz
-         real(dp) :: xm_anchor, P_surf, T_surf, &
-            old_logT_cntr, old_logT_1, old_L1, old_r1
+         real(dp) :: xm_anchor, P_surf, T_surf, old_L1, old_r1
          real(dp), allocatable, dimension(:) :: &
             xm_old, xm, xm_mid_old, xm_mid, v_old, v_new
          real(dp), pointer :: work1(:) ! =(nz_old+1, pm_work_size)
@@ -197,7 +196,7 @@
          end subroutine find_xm_anchor         
          
          subroutine set_xm_new ! sets xm, dm, m, dq, q
-            integer :: nz_outer, n_inner, iter, k, j
+            integer :: nz_outer, k
             real(dp) :: dq_1_factor, dxm_outer, lnx, dlnx
             include 'formats'
             nz_outer = s% RSP2_nz_outer
@@ -348,7 +347,7 @@
                kap_fracs(num_kap_fracs), kap, dlnkap_dlnRho, dlnkap_dlnT, &
                old_kap, new_P_surf, new_T_surf
             real(dp), dimension(num_eos_basic_results) :: &
-               res, d_dlnd, d_dlnT, d_dabar, d_dzbar
+               res, d_dlnd, d_dlnT
             real(dp) :: dres_dxa(num_eos_d_dxa_results,s% species)
             include 'formats'
             ierr = 0

--- a/star/private/hydro_temperature.f90
+++ b/star/private/hydro_temperature.f90
@@ -59,7 +59,7 @@
             kap_00, kap_m1, kap_face, d_P_rad_expected_ad, T_m1, T4_m1, T_00, T4_00, &
             P_rad_m1, P_rad_00, d_P_rad_actual_ad, resid
          
-         integer :: i_equL, i
+         integer :: i_equL
          logical :: dbg
          logical :: test_partials
 

--- a/star/private/hydro_vars.f90
+++ b/star/private/hydro_vars.f90
@@ -108,7 +108,7 @@
             skip_mixing_info, &
             skip_set_cz_bdy_mass, &
             skip_mlt
-         integer :: nz, ierr1, k, i
+         integer :: nz, k
          
          include 'formats'
          
@@ -178,8 +178,6 @@
          real(dp), intent(in) :: dt
          integer, intent(out) :: ierr
 
-         integer(8) :: time0, clock_rate
-         real(dp) :: total
          logical, parameter :: skip_other_cgrav = .false.
          logical, parameter :: skip_basic_vars = .false.
          logical, parameter :: skip_micro_vars = .false.
@@ -496,7 +494,7 @@
             skip_mixing_info, skip_set_cz_bdy_mass, skip_mlt
          integer, intent(out) :: ierr
 
-         integer :: nz, num_nse, k, T_tau_id
+         integer :: nz, k, T_tau_id
          integer(8) :: time0
          logical, parameter :: dbg = .false.
          real(dp) :: total
@@ -683,13 +681,12 @@
 
 
       subroutine set_basic_vars(s, nzlo, nzhi, ierr)
-         use chem_def, only: ini56
          use star_utils, only: set_rv_info, set_rmid
          type (star_info), pointer :: s
          integer, intent(in) :: nzlo, nzhi
          integer, intent(out) :: ierr
          integer :: j, k, species, nz
-         real(dp) :: twoGmrc2, r2, alfa, beta, sum_xa, v, u00, um1, du
+         real(dp) :: twoGmrc2, sum_xa
 
          include 'formats'
 
@@ -1115,7 +1112,6 @@
             use star_utils, only: weighed_smoothing, threshold_smoothing
             logical, parameter :: preserve_sign = .false.
             real(dp), pointer, dimension(:) :: work
-            integer :: k
             include 'formats'
             ierr = 0
             work => dlnd

--- a/star/private/init.f90
+++ b/star/private/init.f90
@@ -117,8 +117,6 @@
          character (len=*), intent(in) :: color_file_names(:)
          integer , intent(in):: color_num_colors(:)
          integer, intent(out) :: ierr
-         integer :: iam, nprocs, nprow, npcol, i, n
-         integer, dimension(:), allocatable :: seed
          include 'formats'
          ierr = 0
          if (have_done_starlib_init) return
@@ -176,7 +174,6 @@
 
 
       subroutine alloc_star_data(id, ierr)
-         use rates_def, only: rates_reaction_id_max
          use chem_def, only: num_categories
          use net, only: default_set_rate_factors, &
             default_set_op_mono_factors
@@ -849,12 +846,11 @@
          integer, intent(out) :: ierr
 
          type (star_info), pointer :: s
-         real(dp) :: initial_mass, initial_z, dlgm_per_step
+         real(dp) :: initial_mass, initial_z
          real(dp), parameter :: lg_max_abs_mdot = -1000 ! use default
          real(dp), parameter :: change_mass_years_for_dt = 1
          real(dp), parameter :: min_mass_for_create_pre_ms = 0.03d0
-         logical :: restore_at_end
-         real(dp) :: xm, total_radiation, warning_limit_for_max_residual
+         real(dp) :: total_radiation, warning_limit_for_max_residual
          integer :: k, num_trace_history_values
          real(dp) :: save_Pextra_factor
          character (len=256):: save_atm_option, &

--- a/star/private/init_model.f90
+++ b/star/private/init_model.f90
@@ -273,7 +273,6 @@
             use read_model, only: read_properties
             integer :: year_month_day_when_created, iprop
             real(dp) :: dprop, initial_z, initial_y
-            character (len=net_name_len) :: net_name
             read(iounit, *, iostat=ierr) ! skip blank line before property list
             include 'formats'
             if (ierr /= 0) return

--- a/star/private/kap_support.f90
+++ b/star/private/kap_support.f90
@@ -236,7 +236,7 @@ contains
          get_op_mono_args, kap_get_op_mono, kap_get, &
          call_compute_kappa_mombarg
 
-    use chem_def, only: ih1, ihe3, ihe4, chem_isos
+    use chem_def, only: chem_isos
     use star_utils, only: get_XYZ, lookup_nameofvar
 
     type (star_info), pointer :: s
@@ -256,21 +256,18 @@ contains
     type(auto_diff_real_2var_order1) :: beta, lnkap, lnkap_op
     real(dp) :: kap_op, dlnkap_op_dlnRho, dlnkap_op_dlnT, &
        Z, xh, xhe, xc, xn, xo, xne, &
-       kap_ross_cell, log_kap_rad, fk(17), delta
+       log_kap_rad, fk(17)
 
     character(len=4) :: e_name
 
-    !real(dp), pointer :: xa(:)
     integer, pointer :: net_iso(:)
     real, pointer :: &
          umesh(:), semesh(:), ff(:,:,:,:), rs(:,:,:)
     integer :: nel, izzp(s% species)
-    real(dp) :: fap(s% species), fac(s% species), gp1(s% species)
+    real(dp) :: fap(s% species), fac(s% species)
     logical :: screening
     real(dp), parameter :: &
          eps = 1d-6, minus_eps = -eps, one_plus_eps = 1d0 + eps
-
-    integer :: i_var
 
     include 'formats'
 

--- a/star/private/mesh_adjust.f90
+++ b/star/private/mesh_adjust.f90
@@ -68,7 +68,7 @@
          integer, dimension(:) :: cell_type, comes_from
          real(dp), dimension(:), pointer :: &
             dq_old, xq_old, dq, xq, energy_old, eta_old, &
-            lnd_old, lnPgas_old, mlt_vc_old, lnT_old, w_old, Hp_face_old, &
+            lnd_old, lnPgas_old, mlt_vc_old, lnT_old, w_old, &
             specific_PE_old, specific_KE_old, &
             old_m, old_r, old_rho, dPdr_dRhodr_info_old, &
             j_rot_old, omega_old, D_omega_old, D_mix_old
@@ -77,11 +77,10 @@
          real(dp), dimension(:,:), pointer :: xh, xa
          integer, intent(out) :: ierr
 
-         real(dp) :: dxa, xmstar, mstar, sumx, remove1, remove2, &
+         real(dp) :: dxa, xmstar, mstar, sumx, &
             total_internal_energy1, total_internal_energy2, err
          character (len=strlen) :: message
-         integer :: k, from_k, j, op_err, nzlo, nzhi, nzlo_old, nzhi_old, species
-         logical :: found_bad_one
+         integer :: k, j, op_err, nzlo, nzhi, nzlo_old, nzhi_old, species
          real(dp), pointer :: work(:)
          real(dp), dimension(:), allocatable :: &
             dqbar, dqbar_old, new_r, Vol_new, xq_old_plus1, &
@@ -895,7 +894,7 @@
 
          real(dp), pointer, dimension(:) :: &
             mid_xq_new, mid_xq_old_plus1
-         integer :: n, i, j, k
+         integer :: n, i, k
 
          ierr = 0
          n = nzhi - nzlo + 1
@@ -993,7 +992,7 @@
             interp_Vol_new, interp_xq, density_init
          integer, intent(out) :: ierr
 
-         integer :: k, from_k, kk, n, interp_lo, interp_hi, interp_n, num_revise
+         integer :: k, from_k, n, interp_lo, interp_hi, interp_n
          real(dp) :: Vol_min, Vol_max, cell_Vol, Vol_center, Vm1, V00, Vp1
 
          logical, parameter :: dbg = .false., trace_PE_residual = .false.
@@ -1350,13 +1349,12 @@
             specific_PE_old, specific_KE_old, w_old, density_new, energy_new
          integer, intent(out) :: ierr
 
-         integer :: k_old, k_old_last, lnT_order, energy_order
+         integer :: k_old
          real(dp) :: &
             Rho, logRho, xq_outer, cell_dq, avg_energy, avg_PE, avg_KE, &
             new_PE, new_KE, max_delta_energy, delta_energy, revised_energy, &
             sum_lnT, avg_lnT, new_lnT, sum_energy, new_xa(species), &
             d_dlnR00, d_dlnRp1, d_dv00, d_dvp1
-         logical :: dbg_get_integral
 
          include 'formats'
 
@@ -1661,11 +1659,10 @@
          integer, intent(out) :: ierr
 
          real(dp) :: &
-            X, Y, Z, T, logT, res(num_eos_basic_results), &
+            logT, res(num_eos_basic_results), &
             d_dlnd(num_eos_basic_results), d_dlnT(num_eos_basic_results), &
             d_dxa(num_eos_d_dxa_results, s% species), &
             logT_tol, logE_tol
-         integer :: j
 
          include 'formats'
 
@@ -1947,8 +1944,7 @@
             xout_old, xout_new, old_dqbar, new_dqbar
          real(dp), intent(in) :: xh(:,:)
          integer, intent(out) :: ierr
-         integer :: k, op_err, old_k, new_k
-         real(dp) :: old_j_tot, new_j_tot
+         integer :: k, op_err
          include 'formats'
          ierr = 0
 
@@ -1977,7 +1973,7 @@
          integer, intent(out) :: ierr
 
          real(dp) :: xq_outer, xq_inner, j_tot, xq0, xq1, new_point_dqbar, dq_sum, dq, r00
-         integer :: kk, k_outer, j
+         integer :: kk, k_outer
 
          integer, parameter :: k_dbg = -1
 
@@ -2139,7 +2135,7 @@
          real(dp), dimension(:,:) :: xh, xh_old
          integer, intent(out) :: ierr
 
-         integer :: k, j, op_err, old_k, new_k, i_v
+         integer :: k, op_err, i_v
          real(dp) :: old_ke_tot, new_ke_tot, xmstar, err
 
          include 'formats'
@@ -2208,7 +2204,7 @@
 
          real(dp) :: xq_outer, xq_inner, ke_sum, &
             xq0, xq1, new_point_dqbar, dq_sum, dq
-         integer :: kk, k_outer, j
+         integer :: kk, k_outer
 
          integer, parameter :: k_dbg = -1
 
@@ -2396,7 +2392,7 @@
          real(dp), dimension(:,:) :: xh, xh_old
          integer, intent(out) :: ierr
 
-         integer :: k, j, op_err, old_k, new_k, i_u
+         integer :: k, op_err, i_u
          real(dp) :: old_ke_tot, new_ke_tot, xmstar, err
 
          include 'formats'
@@ -2457,7 +2453,7 @@
 
          real(dp) :: xq_outer, xq_inner, ke_sum, &
             xq0, xq1, new_cell_dq, dq_sum, dq
-         integer :: kk, k_outer, j
+         integer :: kk, k_outer
 
          integer, parameter :: k_dbg = -1
 
@@ -2688,7 +2684,7 @@
          real(dp), dimension(:,:) :: xh, xh_old
          integer, intent(out) :: ierr
 
-         integer :: k, j, op_err, old_k, new_k, i_w
+         integer :: k, op_err, i_w
          real(dp) :: old_eturb_tot, new_eturb_tot, xmstar, err
 
          include 'formats'
@@ -2749,7 +2745,7 @@
 
          real(dp) :: xq_outer, xq_inner, eturb_sum, &
             xq0, xq1, new_cell_dq, dq_sum, dq
-         integer :: kk, k_outer, j
+         integer :: kk, k_outer
 
          integer, parameter :: k_dbg = -1
 

--- a/star/private/mesh_plan.f90
+++ b/star/private/mesh_plan.f90
@@ -86,7 +86,7 @@
          integer :: j, k, k_old, k_new, nz, new_capacity, iounit, species, &
             max_num_merge_surface_cells, max_k_old_for_split, min_k_old_for_split
          real(dp) :: D_mix_cutoff, next_xq, next_dq, max_dq_cntr, &
-            dq_sum, tmp, min_dq, min_dq_for_xa, min_dq_for_logT
+            dq_sum, min_dq, min_dq_for_xa, min_dq_for_logT
 
          logical, parameter :: write_plan_debug = .false.
 
@@ -473,7 +473,7 @@
          logical function okay_to_split1(k_old, dq_new, remaining_dq_old)
             integer, intent(in) :: k_old
             real(dp), intent(in) :: dq_new, remaining_dq_old
-            real(dp) :: dlnR_old, dr_old, min_dr, rR, rL, dlnR_new
+            real(dp) :: dr_old, min_dr, rR, rL, dlnR_new
             logical :: dbg
 
             include 'formats'
@@ -612,7 +612,7 @@
             integer, intent(out) :: ierr
 
             logical :: dbg, force_merge_with_one_more
-            real(dp) :: dqsum, prev_dq, dq_limit, maxval_delta_xa, next_dq_max, beta_limit, &
+            real(dp) :: maxval_delta_xa, next_dq_max, beta_limit, &
                remaining_dq_old, min_dr
             integer :: kk, k_old_init, k_old_next, k_old_next_max, j00, jm1, i, max_merge
 

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -73,7 +73,7 @@ contains
     logical, intent(in) :: skip_eos, skip_net, skip_neu, skip_kap
     integer, intent(out) :: ierr
 
-    integer :: j, k, op_err, k_bad, res, i
+    integer :: k, op_err, i
     integer(8) :: time0
     real(dp) :: total, alfa, beta
     character(len=4) :: e_name
@@ -323,14 +323,11 @@ contains
     integer, intent(in) :: k
     integer, intent(out) :: ierr
 
-    real(dp), dimension(num_eos_basic_results) :: &
-         res, res_a, res_b, d_dlnd, d_dlnT
+    real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT
     real(dp), dimension(num_eos_d_dxa_results,s% species) :: d_dxa
-    real(dp) :: &
-         sumx, dx, dxh_a, dxh_b, &
-         Rho, logRho, lnd, lnE, logT, T, logPgas, energy, logQ, frac
+    real(dp) :: sumx, logRho, logT, logPgas
     integer, pointer :: net_iso(:)
-    integer :: j, species, i_var, i_var_sink
+    integer :: species
     real(dp), parameter :: epsder = 1d-4, Z_limit = 0.5d0
     real(dp), parameter :: LOGRHO_TOL = 1d-8, LOGPGAS_TOL = 1d-8
 
@@ -588,22 +585,13 @@ contains
     integer, intent(in) :: k
     integer, intent(out) :: ierr
 
-    integer, pointer :: net_iso(:)
-    integer :: i, iz, kh
     real(dp) :: &
-         log10_rho, log10_T, dlnkap_dlnd, dlnkap_dlnT, &
-         opacity_max, opacity_max0, opacity_max1, zbar, &
+         log10_rho, log10_T, dlnkap_dlnd, dlnkap_dlnT, zbar, &
          lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT, &
-         eta, d_eta_dlnRho, d_eta_dlnT, &
-         log_r, log_r_in, log_r_out, log_r_frac, frac, min_cno_for_kap_limit, &
-         P, Prad, Pgas, Ledd_factor, Ledd_kap, Ledd_log, &
-         a, b, da_dlnd, da_dlnT, db_dlnd, db_dlnT, opacity_factor
-         !kap_ross_cell, log_kap_rad, fk(17), delta
+         eta, d_eta_dlnRho, d_eta_dlnT, opacity_factor
 
     real(dp), dimension(num_kap_fracs) :: kap_fracs
-    !character(len=4) :: e_name
 
-    character (len=100) :: message
     real(dp), pointer :: xa(:)
     logical :: test_partials
 

--- a/star/private/mix_info.f90
+++ b/star/private/mix_info.f90
@@ -56,8 +56,8 @@
          logical, intent(in) :: skip_set_cz_bdy_mass
          integer, intent(out) :: ierr
 
-         integer :: nz, i, k, max_conv_bdy, max_mix_bdy, k_Tmax, i_h1, i_he4, i_c12
-         real(dp) :: c, rho_face, f, Tmax, conv_vel, min_conv_vel_for_convective_mixing_type, &
+         integer :: nz, k, max_conv_bdy, max_mix_bdy, k_Tmax, i_h1, i_he4, i_c12
+         real(dp) :: rho_face, f, Tmax, min_conv_vel_for_convective_mixing_type, &
             region_bottom_q, region_top_q, L_val
          real(dp), allocatable, dimension(:) :: eps_h, eps_he, eps_z, cdc_factor
 
@@ -426,7 +426,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
 
-         integer :: k, mt, mt1, mt2, nz
+         integer :: k, mt1, mt2, nz
          real(dp) :: dg0, dg1
 
          include 'formats'
@@ -537,8 +537,7 @@
 
          logical :: in_convective_region
          integer :: k, k_bot, i, j, iounit, max_conv_bdy
-         real(dp) :: dgrad00, dgradp1, turnover_time, &
-            bot_Hp, bot_r, top_Hp, top_r, dr
+         real(dp) :: turnover_time, bot_Hp, bot_r, top_Hp, top_r, dr
 
          logical :: dbg
          logical, parameter :: write_debug = .false.
@@ -654,7 +653,7 @@
 
 
          subroutine end_of_convective_region()
-            integer :: max_logT_loc, kk, op_err, mix_type
+            integer :: max_logT_loc, kk
             real(dp) :: max_logT, max_X, max_Y, Hp, max_eps
             logical :: end_dbg
 
@@ -800,7 +799,7 @@
          integer, intent(out) :: ierr
 
          logical :: in_mixing_region
-         integer :: k, k_bot, i, j, iounit, max_mix_bdy, nz
+         integer :: k, k_bot, i, max_mix_bdy, nz
 
          logical, parameter :: dbg = .false.
 
@@ -1113,7 +1112,7 @@
          real(dp), intent(in) :: min_gap
          integer, intent(out) :: ierr
 
-         integer :: k, kk, nz
+         integer :: k, nz
          logical :: in_region, dbg
          real(dp) :: rtop, rbot, Hp
          integer :: ktop, kbot ! k's for gap
@@ -1279,7 +1278,7 @@
 
 
          subroutine clean_region
-            integer :: kbot1, ktop1, kk
+            integer :: kbot1, ktop1
             include 'formats'
             if (dbg) write(*,3) 'clean_region semiconvective', kbot, ktop
             ! move top to below top convective region
@@ -1380,7 +1379,6 @@
 
 
       subroutine get_convection_sigmas(s, dt, ierr)
-         use chem_def, only: chem_isos
          type (star_info), pointer :: s
          real(dp), intent(in) :: dt
          integer, intent(out) :: ierr
@@ -1389,10 +1387,8 @@
          real(dp) :: sig_term_limit ! sig_term_limit is used to help convergence
 
          real(dp) :: siglim, xmstar, dq00, dqm1, cdcterm, dmavg, rho_face, &
-            cdc, max_sig, D, xm1, x00, xp1, dm, dX, X, cushion, limit, &
-            Tc, full_off, full_on, X_lim, dX_lim, qbot, qtop, &
-            f1, f, df_dlnd00, df_dlndm1, df_dlnR, df_d_rho_face, alfa, beta
-         logical :: in_convective_region
+            cdc, max_sig, D, xm1, x00, dm, dX, X, cushion, limit, &
+            Tc, full_off, full_on, qbot, qtop, f1, f, alfa
          real(dp), dimension(:), pointer :: sig, D_mix
 
          include 'formats'
@@ -1564,7 +1560,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
 
-         integer :: k, nz, k0
+         integer :: k, nz
          logical :: set_min_am_nu_non_rot, okay
          real(dp) :: &
             am_nu_visc_factor, &
@@ -1943,13 +1939,13 @@
 
 
       subroutine set_RTI_mixing_info(s, ierr)
-         use chem_def, only: ih1, ihe4
+         use chem_def, only: ih1
          use star_utils, only: get_shock_info
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
          real(dp) :: &
             C, alpha_face, f, v, &
-            am1, a00, ap1, min_dm, alfa0, alfa, cs, r, shock_mass_start, &
+            min_dm, alfa, cs, r, shock_mass_start, &
             log_max_boost, m_full_boost, m_no_boost, max_boost, &
             dm_for_center_eta_nondecreasing, min_eta
          integer :: k, nz, i_h1
@@ -2115,11 +2111,10 @@
       subroutine set_dPdr_dRhodr_info(s, ierr)
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         real(dp) :: rho, r00, alfa00, beta00, P_face00, rho_face00, &
-            rp1, alfap1, betap1, dr_m1, dr_00, &
-            c, d, am1, a00, ap1, v, rmid
+         real(dp) :: rho, r00, alfa00, beta00, &
+            dr_m1, dr_00, c, d, am1, a00, ap1, v, rmid
          real(dp), allocatable, dimension(:) :: dPdr, drhodr, P_face, rho_face
-         integer :: k, nz, width
+         integer :: k, nz
          logical, parameter :: do_slope_limiting = .false.
          include 'formats'
          ierr = 0
@@ -2236,7 +2231,7 @@
          integer, intent(in) :: number_iterations
          real(dp) :: val(:)
          integer, intent(out) :: ierr
-         integer :: nz, iter, k_center, k_inner, k_outer, j, k
+         integer :: nz, iter, k_center, k_inner, k_outer, k
          real(dp) :: mlo, mhi, mmid, smooth_m, v, dm_half, mtotal, mass_from_cell
          real(dp), allocatable :: work(:)
          include 'formats'

--- a/star/private/net.f90
+++ b/star/private/net.f90
@@ -50,10 +50,9 @@
          integer, intent(out) :: ierr
 
          logical, parameter :: use_omp = .true.
-         integer :: k, op_err, j, jj, cnt, kmax
-         integer(8) :: time0, clock_rate
+         integer :: k, op_err
+         integer(8) :: time0
          real(dp) :: total
-         integer, pointer :: ks(:)
          logical, parameter :: only_dlnT = .false.
          logical :: okay, check_op_split_burn
 
@@ -134,14 +133,13 @@
 
       subroutine do1_net(s, k, species, &
             num_reactions, check_op_split_burn, ierr)
-         use rates_def, only: std_reaction_Qs, std_reaction_neuQs, i_rate, &
-            star_debugging_rates_flag, rates_test_partials_val, rates_test_partials_dval_dx
+         use rates_def, only: std_reaction_Qs, std_reaction_neuQs, i_rate
          use net_def, only: Net_Info, net_test_partials, &
             net_test_partials_val, net_test_partials_dval_dx, net_test_partials_i, &
             net_test_partials_iother, get_net_ptr
          use net_lib, only: net_get
          use star_utils, only: lookup_nameofvar
-         use chem_def, only: chem_isos, category_name, i_ni56_co56, i_co56_fe56, &
+         use chem_def, only: category_name, i_ni56_co56, i_co56_fe56, &
             num_categories, iphoto, category_name
          use eos_def, only : i_eta
          use utils_lib,only: realloc_double, realloc_double3
@@ -151,10 +149,9 @@
          integer, intent(out) :: ierr
 
          integer :: i, j, kk, screening_mode, sz, i_var, i_var_sink
-         real(dp) :: log10_rho, log10_T, T, alfa, beta, eps_nuc_factor, &
-            d_eps_nuc_dRho, d_eps_nuc_dT, cat_factor, tau_gamma, eps_cat_sum
+         real(dp) :: log10_rho, log10_T, T, alfa, eps_nuc_factor, &
+            d_eps_nuc_dRho, d_eps_nuc_dT, tau_gamma, eps_cat_sum
          type (Net_Info) :: n
-         character (len=100) :: message
          real(dp), pointer :: reaction_neuQs(:)
          logical :: clipped_T
 
@@ -441,9 +438,7 @@
          real(dp) :: log10_Rho, log10_T
          real(dp), pointer :: v(:)
          integer, pointer :: index(:)
-         real(dp), pointer, dimension(:) :: &
-            rate_screened, rate_screened_dT, rate_screened_dRho, &
-            rate_raw, rate_raw_dT, rate_raw_dRho
+         real(dp), pointer, dimension(:) :: rate_screened, rate_raw
 
          include 'formats'
 
@@ -605,10 +600,8 @@
          character (len=*), intent(in) :: new_net_name
          integer, intent(out) :: ierr
 
-         integer :: i, ir
          integer :: old_num_reactions, old_nvar_chem, old_species
          integer, parameter :: num_lowT_rates = 10
-         integer, pointer :: net_reaction_ptr(:)
 
          include 'formats'
 

--- a/star/private/neu.f90
+++ b/star/private/neu.f90
@@ -38,8 +38,6 @@
       contains
 
 
-
-
       subroutine do_clear_neu_for_cell(s,k,ierr)
          type (star_info), pointer :: s
          integer, intent(in) :: k
@@ -59,8 +57,7 @@
       subroutine do_neu_for_cell(s,k,ierr)
          use neu_def
          use neu_lib
-         use chem_def, only: chem_isos
-         use const_def,only:ln10
+         use const_def, only:ln10
          type (star_info), pointer :: s
          integer, intent(in) :: k
          integer, intent(out) :: ierr
@@ -70,7 +67,6 @@
          real(dp) :: log10_rho, log10_T
          real(dp), parameter :: log10_Tlim = 7.5d0
          logical :: flags(num_neu_types) ! true if should include the type of loss
-         integer :: j
 
          include 'formats'
 
@@ -137,7 +133,6 @@
          end if
 
       end subroutine do_neu_for_cell
-
 
 
       end module neu

--- a/star/private/overshoot_utils.f90
+++ b/star/private/overshoot_utils.f90
@@ -134,7 +134,6 @@ contains
 
     integer  :: k
     real(dp) :: r
-    real(dp) :: w
     real(dp) :: x0
     real(dp) :: x1
     real(dp) :: x2

--- a/star/private/pgstar_abundance.f90
+++ b/star/private/pgstar_abundance.f90
@@ -100,11 +100,10 @@
             xaxis_reversed, panel_flag, xaxis_numeric_labels_flag
          integer, intent(out) :: ierr
 
-         character (len=strlen) :: str
          real, allocatable, dimension(:) :: xvec, yvec
          real :: xmin, xmax, xleft, xright, dx, dylbl, chScale, windy, xmargin, &
             ymin, ymax, legend_xmin, legend_xmax, legend_ymin, legend_ymax
-         integer :: lw, lw_sav, grid_min, grid_max, npts, i, nz
+         integer :: lw, lw_sav, grid_min, grid_max, npts, nz
          integer, parameter :: num_colors = 14
          integer :: colors(num_colors)
          integer, parameter :: max_num_labels = 30
@@ -153,11 +152,10 @@
             use rates_def
             integer, intent(out) :: ierr
 
-            integer :: ii, jj, i, k, xaxis_id
+            integer :: i, k
             logical, parameter :: dbg = .false.
-            logical :: found_shock
-            real(dp) :: xshock, photosphere_logxm
-            real :: lgz, x, y, ybot
+            real(dp) :: photosphere_logxm
+            real :: lgz, x, ybot
 
             include 'formats'
             ierr = 0
@@ -281,7 +279,7 @@
 
          subroutine do_all(legend_flag)
             logical, intent(in) :: legend_flag
-            integer :: cnt, num_to_show, i, j, k, jmax
+            integer :: cnt, num_to_show, i, j, jmax
             real(dp) :: max_abund(s% species)
             include 'formats'
             cnt = 0
@@ -386,8 +384,8 @@
          integer function abundance_line_legend(cnt, str)
             integer, intent(in) :: cnt
             character (len=*), intent(in) :: str
-            real :: ymx, dx, dyline, ypos, xpts(2), ypts(2)
-            integer :: iclr, max_cnt
+            real :: dx, dyline, ypos, xpts(2), ypts(2)
+            integer :: max_cnt
             max_cnt = min(max_num_labels, s% pg% Abundance_legend_max_cnt)
             if (cnt >= max_cnt) then
                abundance_line_legend = cnt

--- a/star/private/pgstar_color_magnitude.f90
+++ b/star/private/pgstar_color_magnitude.f90
@@ -635,24 +635,21 @@
          integer, intent(out) :: ierr
          procedure(pgstar_decorator_interface), pointer :: color_pgstar_decorator
 
-         character (len=strlen) :: yname, other_yname
          character (len=strlen) :: yname1,yname2, &
             other_yname1,other_yname2
          real, allocatable, dimension(:) :: xvec1,xvec2, yvec1,yvec2,&
             other_yvec1,other_yvec2
          real, allocatable, dimension(:) :: xvec, yvec, other_yvec
 
-         integer :: i, ii, n, j, k, max_width, step_min, step_max, &
-            y_color, other_y_color, yaxis_id, other_yaxis_id, &
-            clr_sav, npts, yfile_data_len, other_yfile_data_len
-         real :: color_xmin, xmin, xmax, dx, xleft, xright, &
+         integer :: i, n, j, step_min, step_max, &
+            y_color, other_y_color
+         real :: color_xmin, xleft, xright, &
             ymargin, panel_dy, panel_ytop, panel_ybot, &
-            ymin, ymax, dy, ybot, ytop, &
-            other_ymin, other_ymax, other_ybot, other_ytop
+            ybot, ytop, &
+            other_ybot, other_ytop
          logical :: have_yaxis1, have_other_yaxis1,have_yaxis2, have_other_yaxis2,have_xaxis2
          logical :: have_yaxis,have_other_yaxis
 
-         integer :: grid_min,grid_max
          integer :: ix1,ix2
 
          include 'formats'

--- a/star/private/pgstar_ctrls_io.f90
+++ b/star/private/pgstar_ctrls_io.f90
@@ -3092,7 +3092,6 @@
          integer, intent(in) :: level
          integer, intent(out) :: ierr
          logical, dimension(max_extra_inlists) :: read_extra
-         character (len=strlen) :: message
          character (len=strlen), dimension(max_extra_inlists) :: extra
          integer :: unit, i
 

--- a/star/private/pgstar_dynamo.f90
+++ b/star/private/pgstar_dynamo.f90
@@ -128,8 +128,8 @@
             Dyn_reverse_xaxis, panel_flag, xaxis_numeric_labels_flag
          integer, intent(out) :: ierr
 
-         real :: windy, xmargin
-         real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy
+         real :: xmargin
+         real :: xmin, xmax, xleft, xright, dx, ymin, ymax, ymin2, ymax2, dy
          integer :: grid_min, grid_max, npts, nz
          real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
 
@@ -169,10 +169,9 @@
             integer, intent(out) :: ierr
 
             integer :: lw, lw_sav, k
-            real :: ybot, eps, &
+            real :: ybot, &
                default_ymax_left, default_ymin_left, &
                default_ymax_right, default_ymin_right
-            character (len=128) :: str
 
             include 'formats'
             ierr = 0

--- a/star/private/pgstar_full.f90
+++ b/star/private/pgstar_full.f90
@@ -1289,7 +1289,6 @@ contains
       logical, intent(in) :: must_write_files
       integer, intent(out) :: ierr
 
-      integer :: i
       integer(8) :: time0, time1, clock_rate
       logical :: pause
 
@@ -1353,7 +1352,6 @@ contains
       use chem_def
       use net_def
       use net_lib, only : get_net_reaction_table
-      use rates_def, only : rates_reaction_id_max
       use const_def, only : Msun, Rsun
 
       type (star_info), pointer :: s
@@ -1476,7 +1474,7 @@ contains
       type (star_info), pointer :: s
       integer, intent(out) :: ierr
 
-      integer :: iounit, i, n
+      integer :: iounit, n
       character (len = 1024) :: fname
       type (pgstar_hist_node), pointer :: pg
 
@@ -1523,7 +1521,7 @@ contains
       integer, intent(out) :: ierr
 
       logical :: fexist
-      integer :: iounit, i, n
+      integer :: iounit, n
       character (len = 1024) :: fname
       type (pgstar_hist_node), pointer :: pg
 
@@ -1583,7 +1581,7 @@ contains
       type (star_info), pointer :: s
       integer, intent(out) :: ierr
 
-      integer :: num, i
+      integer :: num
       type (pgstar_hist_node), pointer :: pg
 
       include 'formats'

--- a/star/private/pgstar_hist_track.f90
+++ b/star/private/pgstar_hist_track.f90
@@ -648,11 +648,10 @@
          integer, intent(out) :: ierr
          procedure(pgstar_decorator_interface), pointer :: pgstar_decorator
 
-         real :: xmin, xmax, ymin, ymax, xleft, xright, ybot, ytop
-         integer :: i, j, j_min, j_max, step_min, step_max
+         real :: xleft, xright, ybot, ytop
+         integer :: j, j_min, j_max, step_min, step_max
          real :: dx, dy, xplus, xminus, yplus, yminus
          real, dimension(:), allocatable :: xvec, yvec
-         character (len=strlen) :: str
          integer :: k, n
          integer :: ix, iy
          integer :: file_data_len

--- a/star/private/pgstar_history_panels.f90
+++ b/star/private/pgstar_history_panels.f90
@@ -615,7 +615,6 @@
          use chem_def
          use net_def
          use net_lib, only: get_net_reaction_table
-         use rates_def, only: rates_reaction_id_max
          use const_def, only: Msun, Rsun
 
          type (star_info), pointer :: s
@@ -643,15 +642,14 @@
          real, allocatable, dimension(:) :: yfile_xdata, other_yfile_xdata
          real, allocatable, dimension(:) :: yfile_ydata, other_yfile_ydata
          integer :: i, ii, n, j, k, max_width, step_min, step_max, &
-            y_color, other_y_color, yaxis_id, other_yaxis_id, &
-            clr_sav, npts, yfile_data_len, other_yfile_data_len
-         real :: hist_xmin, xmin, xmax, dx, xleft, xright, &
+            y_color, other_y_color, &
+            yfile_data_len, other_yfile_data_len
+         real :: hist_xmin, xleft, xright, &
             ymargin, panel_dy, panel_ytop, panel_ybot, &
-            ymin, ymax, dy, ybot, ytop, xpt, ypt, errpt, &
-            other_ymin, other_ymax, other_ybot, other_ytop
+            ybot, ytop, xpt, ypt, errpt, &
+            other_ybot, other_ytop
          logical :: have_yaxis, have_other_yaxis
 
-         integer :: grid_min, grid_max
          integer :: ix, iounit, ishape, num_pts
 
          include 'formats'

--- a/star/private/pgstar_kipp.f90
+++ b/star/private/pgstar_kipp.f90
@@ -73,7 +73,7 @@
          character (len=*), intent(in) :: title
          integer, intent(out) :: ierr
 
-         integer :: i, ii, n, step_min, step_max
+         integer :: i, n, step_min, step_max
          real :: xmin, xmax, ymin_L_axis, ymax_L_axis, &
             ymin_mass_axis, ymax_mass_axis, dx, burn_type_cutoff
          real, allocatable, dimension(:) :: xvec, &
@@ -517,7 +517,7 @@
 
 
          subroutine plot_L_lines
-            integer :: i, cnt, n
+            integer :: cnt, n
             real :: coords(4), fjusts(4)
 
             logical, parameter :: dbg = .false.
@@ -607,7 +607,6 @@
 
 
          subroutine plot_mass_lines
-            integer :: i
 
             include 'formats'
 

--- a/star/private/pgstar_mixing_ds.f90
+++ b/star/private/pgstar_mixing_ds.f90
@@ -150,8 +150,8 @@
             MixDs_xaxis_reversed, panel_flag, xaxis_numeric_labels_flag
          integer, intent(out) :: ierr
 
-         real :: chScale, windy, xmargin
-         real :: xmin, xmax, xleft, xright, dx, tmp, ymin, ymax, ymin2, ymax2, dy, &
+         real :: chScale, xmargin
+         real :: xmin, xmax, xleft, xright, dx, ymin, ymax, ymin2, ymax2, dy, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax
          integer :: grid_min, grid_max, npts, nz, number_of_legend_lines
          real, allocatable, dimension(:) :: &
@@ -197,8 +197,7 @@
 
             integer :: lw, lw_sav
             real :: val
-            character (len=128) :: str
-            integer :: i, ii, k, cnt
+            integer :: k, cnt
             logical :: rotation
             real(dp) :: &
                D_visc_factor, &

--- a/star/private/pgstar_mode_prop.f90
+++ b/star/private/pgstar_mode_prop.f90
@@ -97,11 +97,10 @@
             xaxis_reversed, panel_flag, xaxis_numeric_labels_flag
          integer, intent(out) :: ierr
 
-         character (len=strlen) :: str
          real, allocatable, dimension(:) :: xvec, log_brunt_nu, &
             log_lamb_Sl1, log_lamb_Sl2, log_lamb_Sl3, temp_vec
          real :: xmin, xmax, xleft, xright, dx, chScale, windy, &
-            ymin, ymax, exp10_ymin, xmargin, &
+            ymin, ymax, xmargin, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax
          integer :: lw, lw_sav, grid_min, grid_max, npts, nz
          integer, parameter :: num_colors = 20
@@ -157,7 +156,7 @@
             use rates_def
             integer, intent(out) :: ierr
 
-            integer :: ii, jj, i, cnt, k
+            integer :: cnt, k
             logical, parameter :: dbg = .false.
             real :: ybot, nu_max, lg_nu_max, lg_2pt0_nu_max, lg_0pt5_nu_max, lg_nu_max_obs
             real, parameter :: teff_sun = 5777.0, nu_max_sun = 3100.0

--- a/star/private/pgstar_network.f90
+++ b/star/private/pgstar_network.f90
@@ -94,10 +94,7 @@
          logical, intent(in) :: subplot
          integer, intent(out) :: ierr
 
-         character (len=strlen) :: str
-         real :: xmin, xmax, xleft, xright, dx, dylbl, chScale, windy, xmargin, &
-            ymin, ymax
-         integer :: lw, lw_sav, grid_min, grid_max, npts, i, nz
+         real :: xleft, xright, chScale, xmargin
 
          include 'formats'
          ierr = 0
@@ -114,13 +111,12 @@
             use chem_def
             integer, intent(out) :: ierr
 
-            integer :: lw, lw_sav, k,i,j
-            real :: ybot, eps
+            integer :: i, j
 
             integer :: z,n,zmax,zmin,nmin,nmax
-            integer :: base_z,base_n,clr,mid_map
+            integer :: clr,mid_map
             real :: abun,xhigh,xlow
-            real :: ymin,ymax,r,g,b,log10_min_abun,log10_max_abun
+            real :: ymin,ymax,log10_min_abun,log10_max_abun
             real,parameter :: pad=2.5,step=0.5
 
             include 'formats'
@@ -247,7 +243,7 @@
          real,intent(in) :: winxmin, winxmax, winymin, winymax,abun_min,abun_max
          real :: legend_xmin,legend_xmax,legend_ymin,legend_ymax
          real :: xmin,xmax,ymin,ymax
-         real :: ymx, dx, dyline, ypos, xpts(2),yt,yb,text
+         real :: dx, dyline, xpts(2),yt,yb,text
          character(len=16) :: str
          
          integer :: i,j,clr,mid_map,num_cms

--- a/star/private/pgstar_power.f90
+++ b/star/private/pgstar_power.f90
@@ -101,7 +101,6 @@
             xaxis_reversed, panel_flag, xaxis_numeric_labels_flag
          integer, intent(out) :: ierr
 
-         character (len=strlen) :: str
          real, allocatable, dimension(:) :: xvec, yvec
          real :: xmin, xmax, xleft, xright, dx, chScale, windy, &
             ymin, ymax, exp10_ymin, xmargin, &
@@ -152,7 +151,7 @@
             use rates_def
             integer, intent(out) :: ierr
 
-            integer :: ii, jj, i, j, cnt
+            integer :: i, j, cnt
             logical, parameter :: dbg = .false.
             real(dp) :: max_power(num_categories), max_power_copy(num_categories)
             real :: ybot
@@ -241,7 +240,7 @@
 
          integer function power_line(cnt, icat)
             integer, intent(in) :: cnt, icat
-            real :: ymx, xpos, dx, ypos, xpts(2), ypts(2)
+            real :: ymx
             integer :: iclr, k
             power_line = cnt
             ymx = maxval(s% eps_nuc_categories(icat,grid_min:grid_max))

--- a/star/private/pgstar_production.f90
+++ b/star/private/pgstar_production.f90
@@ -88,17 +88,13 @@
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id
-         real, intent(in) :: &
-            winxmin, winxmax, winymin, winymax
+         real, intent(in) :: winxmin, winxmax, winymin, winymax
          character (len=*), intent(in) :: title
          real, intent(in) :: txt_scale
          logical, intent(in) :: subplot
          integer, intent(out) :: ierr
 
-         character (len=strlen) :: str
-         real :: xmin, xmax, xleft, xright, dx, dylbl, chScale, windy, xmargin, &
-            ymin, ymax
-         integer :: lw, lw_sav, grid_min, grid_max, npts, i, nz
+         real :: xleft, xright, chScale, xmargin
          integer, parameter :: num_colors = 14
          integer :: colors(num_colors)
 
@@ -124,18 +120,16 @@
             use adjust_xyz, only: get_xa_for_standard_metals
             integer, intent(out) :: ierr
 
-            integer :: lw, lw_sav, k,i,j
-            real :: ybot, eps
+            integer :: i, j
 
-            integer :: amin,amax,z,n,a,plot_a,zmin,zmax
-            integer :: min_zone,max_zone,alternate,skip_cnt
-            real :: xhigh,xlow,extra_pad
+            integer :: amin,amax,z,n,a,zmin,zmax
+            integer :: min_zone,max_zone,alternate
+            real :: extra_pad
             real :: min_mass,max_mass,yloc
             real,parameter :: point_size=0.1
-            real :: ymin,ymax,r,g,b,log10_min_abun,log10_max_abun
+            real :: ymin, ymax
             real,parameter :: pad=1.0
-            real :: last_x,last_y,log_sa
-            logical :: z_in_use
+            real :: last_x,last_y
             real(dp),dimension(1:solsiz) :: scaled_abun,scaled_abun_init
             real(dp),dimension(:),allocatable :: init_comp,abun
 

--- a/star/private/pgstar_profile_panels.f90
+++ b/star/private/pgstar_profile_panels.f90
@@ -588,16 +588,16 @@
          procedure(pgstar_decorator_interface), pointer :: pgstar_decorator
 
          integer :: &
-            j, k, k0, k_max, i, nz, kmin, kmax, cnt, y_color, clr_sav, id, &
+            j, k, nz, y_color, clr_sav, id, &
             other_y_color, grid_min, grid_max, npts, yaxis_id, other_yaxis_id, ishape
-         real :: del, xpos, ypos, panel_dy, panel_ybot, panel_ytop, &
-            dx, dy, xpos0, dxpos, dypos, dxval, other_ytop, other_ybot, &
-            ybot, ytop, xmin, xmax, xleft, xright, xwidth, panels_xmargin, &
+         real :: panel_dy, panel_ybot, panel_ytop, &
+            dx, other_ytop, other_ybot, &
+            ybot, ytop, xmin, xmax, xleft, xright, panels_xmargin, &
             panels_xmin, panels_xmax, xwidth_left_frac, xwidth_right_frac, &
             xwidth_left_of_shock, xwidth_right_of_shock, shock_xmin, shock_xmax, &
             xshock_sp
-         real(dp) :: cs, x00, xp1, ms, photosphere_logxm, xshock
-         character (len=strlen) :: str, xname, yname, other_yname
+         real(dp) :: photosphere_logxm, xshock
+         character (len=strlen) :: xname, yname, other_yname
          logical :: found_shock
          real, allocatable, dimension(:) :: xvec, yvec, other_yvec, unshifted_xvec
          real, allocatable, dimension(:) :: yfile_xdata, other_yfile_xdata

--- a/star/private/pgstar_summary_burn.f90
+++ b/star/private/pgstar_summary_burn.f90
@@ -74,7 +74,7 @@
          real, intent(in) :: txt_scale
          integer, intent(out) :: ierr
 
-         character (len=strlen) :: yname, xaxis_name, str
+         character (len=strlen) :: xaxis_name, str
          logical :: xaxis_reversed
          real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
          real :: xmin, xmax, xleft, xright, dx, windy, dy, &
@@ -129,7 +129,7 @@
 
             integer :: j, ii, jj, i, cnt, k
             logical, parameter :: dbg = .false.
-            real :: ybot, yvec_min, yvec_max
+            real :: ybot
 
             include 'formats'
 

--- a/star/private/pgstar_summary_history.f90
+++ b/star/private/pgstar_summary_history.f90
@@ -78,7 +78,7 @@
 
          character (len=strlen) :: yname
          real, allocatable, dimension(:) :: xvec, yvec
-         real :: xmin, xmax, windy, ymin, ymax, xmargin, &
+         real :: xmin, xmax, windy, ymin, ymax, &
             legend_xmin, legend_xmax, legend_ymin, legend_ymax
          integer :: lw, lw_sav, num_lines, &
             npts, step_min, step_max
@@ -148,7 +148,7 @@
             use rates_def
             integer, intent(out) :: ierr
 
-            integer :: j, ii, jj, i, cnt, k, yaxis_id
+            integer :: j, cnt, k
             logical :: show(num_lines)
             logical, parameter :: dbg = .false.
             real :: ybot, yvec_min, yvec_max

--- a/star/private/pgstar_summary_profile.f90
+++ b/star/private/pgstar_summary_profile.f90
@@ -156,7 +156,7 @@
             use profile_getval, only : get_profile_val,get_profile_id
             integer, intent(out) :: ierr
 
-            integer :: j, ii, jj, i, cnt, k, yaxis_id
+            integer :: j, cnt, k, yaxis_id
             logical :: show(num_lines)
             logical, parameter :: dbg = .false.
             real :: ybot, yvec_min, yvec_max

--- a/star/private/pgstar_support.f90
+++ b/star/private/pgstar_support.f90
@@ -72,7 +72,7 @@ contains
    subroutine add_to_pgstar_hist(s, pg_hist_new)
       type (star_info), pointer :: s
       type (pgstar_hist_node), pointer :: pg_hist_new
-      type (pgstar_hist_node), pointer :: pg_hist => null(), next => null()
+      type (pgstar_hist_node), pointer :: next => null()
       integer :: step
       step = pg_hist_new% step
       do
@@ -97,7 +97,7 @@ contains
 
    subroutine pgstar_clear(s)
       type (star_info), pointer :: s
-      integer :: i, id, num
+      integer :: i
       type (pgstar_win_file_data), pointer :: p
       type (pgstar_hist_node), pointer :: pg_hist => null(), next => null()
       pg_hist => s% pg% pgstar_hist
@@ -244,8 +244,8 @@ contains
       integer, intent(out) :: id
       integer, intent(out) :: ierr
 
-      integer :: pgopen, system
-      character (len = strlen) :: dir, cmd
+      integer :: pgopen
+      character (len = strlen) :: dir
       logical :: white_on_black_flag
       real :: width, ratio
 
@@ -922,7 +922,7 @@ contains
       integer, intent(in) :: step_min, step_max, numpts
       real, intent(out) :: vec(:)
       integer, intent(out) :: ierr
-      integer :: i, n
+      integer :: i
       type (pgstar_hist_node), pointer :: pg
       ierr = 0
       if (numpts == 0) return
@@ -969,7 +969,7 @@ contains
       integer, intent(in) :: step_min, step_max, numpts, index
       real, intent(out) :: vec(:)
       integer, intent(out) :: ierr
-      integer :: i, n
+      integer :: i
       type (pgstar_hist_node), pointer :: pg => null()
       include 'formats'
       if (numpts == 0) return
@@ -1187,7 +1187,6 @@ contains
       real, intent(in) :: dymin
       real, intent(out) :: ybot, ytop
 
-      integer :: k
       real :: dy, ymax, ymin, ymargin
       logical :: use_given_ymin, use_given_ymax
       real, parameter :: dymin_min = 1d-34
@@ -1310,7 +1309,6 @@ contains
 
       integer :: k, nz, xaxis_id
       real :: win_xmin, win_xmax
-      real(dp) :: dmsum
 
       include 'formats'
 
@@ -1959,7 +1957,7 @@ contains
       character (len = 32) :: age_str, units_str
       real(dp) :: age
       real :: ch
-      integer :: len, i, j, iE, n
+      integer :: len, i, j, iE
       if (.not. s% pg% pgstar_show_age) return
       age = s% star_age
       if (s% pg% pgstar_show_age_in_seconds) then

--- a/star/private/pgstar_trho_profile.f90
+++ b/star/private/pgstar_trho_profile.f90
@@ -72,9 +72,8 @@
 
          integer :: nz, k
          real :: xmin, xmax, ymin, ymax, xpos, ypos, dx, dy, &
-            txt_scale, vpxmin, vpxmax, vpymin, vpymax, vpymargin, vpwinheight, lgT1, lgT2
+            txt_scale, lgT1, lgT2
          real, allocatable, dimension(:) :: xvec, yvec
-         character (len=128) :: str
          real, parameter :: lgrho1 = -8, lgrho2 = 5
 
          include 'formats'
@@ -264,7 +263,7 @@
 
 
          subroutine do_kap_regions
-            real :: logT_lo, logT_hi, logT_max, logR, logRho_lo, logRho_hi, logRho_min
+            real :: logT_lo, logT_hi, logT_max
             real, parameter :: min_logR_for_freedman = 1
             real, parameter :: freg_blend_logT2 = 4.10
             real, parameter :: freg_blend_logT1 = 3.93
@@ -329,7 +328,6 @@
 
 
          subroutine do_eos_regions
-            integer :: ierr
             real :: logRho0, logRho1, logRho2, logRho3, logRho4, logRho5, logRho6
             real :: logT1, logT2, logT3, logT4, logT5, logT6
 

--- a/star/private/phase_separation.f90
+++ b/star/private/phase_separation.f90
@@ -58,7 +58,7 @@
       end subroutine do_phase_separation
 
       subroutine do_2component_phase_separation(s, dt, components, ierr)
-         use chem_def, only: chem_isos, ic12, io16, ine20
+         use chem_def, only: ic12, io16, ine20
          use chem_lib, only: chem_get_iso_id
          type (star_info), pointer :: s
          real(dp), intent(in) :: dt
@@ -150,7 +150,7 @@
       end subroutine do_2component_phase_separation
 
       subroutine move_one_zone(s,k,components)
-        use chem_def, only: chem_isos, ic12, io16, ine20
+        use chem_def, only: ic12, io16, ine20
         use chem_lib, only: chem_get_iso_id
         type(star_info), pointer :: s
         integer, intent(in) :: k

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -46,9 +46,8 @@
          integer, intent(out) :: ierr
 
          integer :: iounit, i, j, k, version, part_number, &
-            len_history_col_spec, nz, kk
+            len_history_col_spec, nz
          logical, parameter :: dbg = .false.
-         real(dp) :: xx
 
          include 'formats'
 

--- a/star/private/profile.f90
+++ b/star/private/profile.f90
@@ -60,7 +60,7 @@
          logical, intent(in) :: report
          integer, intent(out) :: ierr
 
-         integer :: iounit, n, i, t, id, j, k, num, nxt_spec, spec_err
+         integer :: iounit, n, i, t, j, k, nxt_spec, spec_err
          character (len=strlen) :: buffer, string, filename
          integer, parameter :: max_level = 20
 
@@ -379,9 +379,9 @@
          logical, pointer :: is_int(:)
          integer, intent(out) :: ierr
 
-         real(dp) :: msum, mstar, dt, Lnuc, frac
+         real(dp) :: mstar, dt
          integer :: io, i, j, jj, nz, col, k, kk, n, species, &
-            h1, he4, num_specs, numcols, num_extra_cols, num_extra_header_items, num_digits
+            num_specs, numcols, num_extra_cols, num_extra_header_items, num_digits
          integer, pointer :: chem_id(:)
          logical, parameter :: dbg = .false.
          character (len=strlen) :: fname1, dbl_fmt, int_fmt, txt_fmt, fname_out, fstring, str
@@ -807,7 +807,7 @@
             use profile_getval, only: getval_for_profile
             integer, intent(in) :: pass, j, jj, k
             integer :: i, c, int_val, ir
-            real(dp) :: val, cno, z, dr, eps, eps_alt
+            real(dp) :: val
             logical :: int_flag
             character (len=128) :: col_name
             logical, parameter :: dbg = .false.
@@ -911,7 +911,7 @@
          subroutine do_abundance_col(pass, j, jj, k)
             integer, intent(in) :: pass, j, jj, k
             real(dp) :: val
-            logical :: int_flag, log_abundance
+            logical :: log_abundance
             character (len=128) :: col_name
             logical, parameter :: dbg = .false.
             include 'formats'
@@ -952,7 +952,7 @@
          integer, intent(out) :: ierr
 
          integer, pointer, dimension(:) :: model_numbers, model_priorities, model_logs
-         integer :: nz, max_num_mods, num_models, model_profile_number, k
+         integer :: nz, max_num_mods, num_models, model_profile_number
          character (len=strlen) :: fname
          integer :: model_priority
 
@@ -1169,8 +1169,7 @@
          ! sets s% model_profile_filename and s% model_controls_filename
          type (star_info), pointer :: s
          integer, intent(in) :: model_profile_number
-         character (len=strlen) :: &
-            profile_prefix, controls_prefix, model_prefix, num_str, fstring
+         character (len=strlen) :: profile_prefix, controls_prefix, model_prefix, fstring
          integer :: num_digits
 
          profile_prefix = trim(s% log_directory) // '/' // trim(s% profile_data_prefix)

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -252,7 +252,7 @@
       real(dp) function get_profile_val(s, id, k)
          type (star_info), pointer :: s
          integer, intent(in) :: id, k
-         integer :: ii, int_val
+         integer :: int_val
          logical :: int_flag
          if (id > max_profile_offset) then ! get from extras
             get_profile_val = s% extra_profile_col_vals(k, id - max_profile_offset)
@@ -276,13 +276,12 @@
          integer, intent(out) :: int_val
          logical, intent(inout) :: int_flag
 
-         real(dp) :: cno, z, x, frac, eps, eps_alt, L_rad, L_edd, Pbar_00, Pbar_p1, &
-            P_face, rho_face, dr, v, r00, rp1, v00, vp1, A00, Ap1, Amid, &
-            r00_start, rp1_start, dr3, dr3_start, d_drL, d_drR, flxR, mmid, &
+         real(dp) :: cno, z, x, L_rad, L_edd, &
+            r00, rp1, v00, vp1, Ap1, &
+            r00_start, rp1_start, dr3, dr3_start, &
             d_dlnR00, d_dlnRp1, d_dv00, d_dvp1
-         integer :: j, nz, ionization_k, klo, khi, i, ii, kk, ierr
-         real(dp) :: ionization_res(num_ion_vals)
-         real(dp) :: f, lgT, full_on, full_off, am_nu_factor, Lconv, conv_vel
+         integer :: j, nz, ionization_k, klo, khi, i, ii
+         real(dp) :: f, lgT, full_on, full_off, am_nu_factor
          logical :: rsp_or_w
          include 'formats'
 
@@ -2358,7 +2357,7 @@
          real(dp) function get_dlogX_dlogP(j, k)
             integer, intent(in) :: j, k
             integer :: ii, i
-            real(dp) :: val, x00, xm1, dlogP, dlogX
+            real(dp) :: x00, xm1, dlogP, dlogX
             include 'formats'
             get_dlogx_dlogp = 0
             if (k > 1) then
@@ -2381,7 +2380,7 @@
          real(dp) function get_dlog_eps_dlogP(cat, k)
             integer, intent(in) :: cat, k
             integer :: ii
-            real(dp) :: val, eps, epsm1, dlogP, dlog_eps
+            real(dp) :: eps, epsm1, dlogP, dlog_eps
             get_dlog_eps_dlogP = 0
             if (k > 1) then
                ii = k

--- a/star/private/pulse_cafein.f90
+++ b/star/private/pulse_cafein.f90
@@ -299,7 +299,6 @@ contains
       real(dp) :: rho
       real(dp) :: P
       real(dp) :: T
-      real(dp) :: g
       real(dp) :: kap_rho
       real(dp) :: kap_T
       real(dp) :: kap_ad

--- a/star/private/pulse_fgong.f90
+++ b/star/private/pulse_fgong.f90
@@ -537,8 +537,6 @@ contains
       integer, intent(in) :: j
       integer, intent(in) :: k_a
       integer, intent(in) :: k_b
-
-      real(dp) :: dq_center
       
       ! Store data for the center into the point_data array at position j
 

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -88,8 +88,7 @@
          type (star_info), pointer :: s
          logical, intent(in) :: restart
          integer, intent(out) :: ierr
-         integer :: k, i, j,  nz
-         real(dp) :: u00, um1, xm, total_radiation
+         integer :: k, nz
          include 'formats'
          ierr = 0
          nz = s% nz
@@ -218,12 +217,12 @@
          character (len=*), intent(in) :: filename
          integer, intent(out) :: ierr
 
-         integer :: iounit, n, i, k, t, file_type, &
+         integer :: iounit, n, i, t, file_type, &
             year_month_day_when_created, nz, species, nvar, count
          logical :: do_read_prev, no_L
          real(dp) :: initial_mass, initial_z, initial_y, &
             tau_factor, Tsurf_factor, opacity_factor, mixing_length_alpha
-         character (len=strlen) :: buffer, string, message
+         character (len=strlen) :: buffer, string
          character (len=net_name_len) :: net_name
          character(len=iso_name_length), pointer :: names(:) ! (species)
          integer, pointer :: perm(:) ! (species)
@@ -469,7 +468,6 @@
          subroutine read_prev_properties
             character (len=132) :: line
             real(dp) :: tmp, skip_val
-            integer :: i
             include 'formats'
             
             ierr = 0
@@ -540,7 +538,6 @@
             i_Et_RSP, i_erad_RSP, i_Fr_RSP, i_v, i_u, i_alpha_RTI, ii
          real(dp), target :: vec_ary(species + nvar_hydro + max_increment)
          real(dp), pointer :: vec(:)
-         real(dp) :: r00, rm1
          integer :: nvec
 
          include 'formats'

--- a/star/private/remove_shells.f90
+++ b/star/private/remove_shells.f90
@@ -166,7 +166,7 @@
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          integer :: j, jj, k, species, nz, co56, ni56
-         real(dp) :: mtotal, dm56, alfa_co56, dm56_new, dm56_old, x56_new, x56_old, xsum
+         real(dp) :: mtotal, dm56, alfa_co56, dm56_new, dm56_old, x56_new, x56_old
          include 'formats'
          call get_star_ptr(id, s, ierr)
          if (ierr /= 0) then
@@ -245,7 +245,7 @@
          integer, intent(in) :: id
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: k, k0, k1, nz
+         integer :: k, k0, nz
          real(dp) :: ie, ke, pe, rR, rL, rC, m_cntr, &
             sum_total_energy, speed_limit
          real(dp), pointer :: v(:)
@@ -385,7 +385,7 @@
          real(dp), intent(in) :: logP_limit
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: k, k0
+         integer :: k
          real(dp) :: lnP_limit
          include 'formats'
          call get_star_ptr(id, s, ierr)
@@ -554,7 +554,6 @@
          integer, intent(in) :: id
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: k
          call get_star_ptr(id, s, ierr)
          if (ierr /= 0) then
             write(*,*) 'do_remove_fe_core: get_star_ptr ierr', ierr
@@ -833,7 +832,7 @@
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          integer :: k, k_vesc
-         real(dp) :: vesc, vesc_m1
+         real(dp) :: vesc
          real(dp), dimension(:), pointer :: v
          include 'formats'
          call get_star_ptr(id, s, ierr)
@@ -888,8 +887,6 @@
          real(dp), intent(in) :: density
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: k
-         real(dp) :: avg_rho
          ierr = 0
          include 'formats'
          call get_star_ptr(id, s, ierr)
@@ -1158,10 +1155,9 @@
             initial_z, initial_y, initial_mass, &
             cumulative_energy_error, cumulative_extra_heating
 
-         real(dp), pointer :: interp_work(:), conv_vel_interp(:)
          real(dp), pointer :: q(:), xq(:), xa(:,:), j_rot(:), entropy(:)
-         real(dp) :: conv_vel_temp, time
-         integer :: num_pts, k, k0, species
+         real(dp) :: time
+         integer :: num_pts, k0, species
          logical :: save_have_mlt_vc
          logical :: dbg = .false.
 

--- a/star/private/report.f90
+++ b/star/private/report.f90
@@ -145,19 +145,14 @@
 
       subroutine do_report(s, ierr)
          use rates_def, only: &
-            i_rate, i_rate_dRho, i_rate_dT, std_reaction_Qs, std_reaction_neuQs
+            i_rate, i_rate_dRho, i_rate_dT
          use star_utils, only: get_phot_info
          use hydro_rotation, only: set_surf_avg_rotation_info
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
 
-         integer :: k, i, j, ic, nz, kcore, &
-            h1, h2, he3, he4, c12, n14, o16, ne20, si28, co56, ni56, k_min
-         real(dp) :: w1, radius, dr, dm, hpc, cur_m, cur_r, prev_r, tau_conv, &
-            twoGmrc2, cur_h, prev_h, cur_he, non_fe_core_mass, nu_for_delta_Pg, &
-            prev_he, cur_c, prev_c, v, mstar, pdg, pdg_prev, luminosity, &
-            prev_m, cell_mass, wf, conv_time, mv, bminv, uminb, eps_nuc_sum, eps_cat_sum,&
-            mass_sum
+         integer :: k, nz, h1, h2, he3, he4, c12, n14, o16, ne20, si28, co56, ni56, k_min
+         real(dp) :: radius, dr, non_fe_core_mass, nu_for_delta_Pg, v, mstar, luminosity, mass_sum
          logical, parameter :: new_only = .false.
          integer, pointer :: net_iso(:)
          real(dp), pointer :: velocity(:) => null()
@@ -500,7 +495,6 @@
             use interp_1d_def
             use interp_1d_lib
             real(dp), intent(in) :: q
-            real(dp) :: vp2, vp1, v00, vm1
             integer, parameter :: n_old = 4, n_new = 1, nwork = pm_work_size
             real(dp) :: qlo, x_old(n_old), v_old(n_old), x_new(n_new), v_new(n_new)
             integer :: k, nz, k00, ierr
@@ -853,7 +847,7 @@
          real(dp), pointer, intent(in) :: cell_masses(:)
          integer, intent(out) :: ierr
 
-         integer :: k, nz, j, nzlo, nzhi, kbdy, nzlo_prev
+         integer :: k, nz, j
          real(dp) :: cell_mass
          integer, pointer :: net_iso(:)
 
@@ -1216,7 +1210,7 @@
             core_m, core_r, core_lgT, core_lgRho, core_L, core_v, &
             core_omega, core_omega_div_omega_crit
 
-         integer :: j, jm1, j00
+         integer :: jm1, j00
          real(dp) :: dm1, d00, qm1, q00, core_q, &
             core_lgP, core_g, core_X, core_Y, &
             core_scale_height, core_dlnX_dr, core_dlnY_dr, core_dlnRho_dr
@@ -1271,8 +1265,8 @@
             bdy_scale_height, bdy_dlnX_dr, bdy_dlnY_dr, bdy_dlnRho_dr, &
             bdy_omega, bdy_omega_div_omega_crit
 
-         real(dp) :: x, x0, x1, x2, alfa, beta, bdy_omega_crit
-         integer :: k, ii, klo, khi
+         real(dp) :: x, x0, x1, x2, alfa, bdy_omega_crit
+         integer :: k, klo, khi
 
          include 'formats'
 

--- a/star/private/rotation_mix_info.f90
+++ b/star/private/rotation_mix_info.f90
@@ -79,10 +79,9 @@
          real(dp), allocatable :: smooth_work(:,:), saved(:,:)
          logical, allocatable :: unstable(:,:) ! (num_instabilities, nz)
 
-         integer :: nz, i, j, k, k0, which, op_err
-         real(dp) :: alfa, beta, growth_limit, age_fraction, &
-            D_omega_source, max_replacement_factor, &
-            dgtau, angsml, angsmt, out_q, prev_out_q, prev_out_q_m1, prev_q, prev_q_m1
+         integer :: nz, k, k0, which, op_err
+         real(dp) :: alfa, growth_limit, age_fraction, &
+            D_omega_source, dgtau, angsml, angsmt, prev_out_q, prev_out_q_m1, prev_q, prev_q_m1
 
          include 'formats'
 
@@ -447,7 +446,7 @@
                eps_nucm1, eps_nuc00, scale_height2, dlnRho_dlnP, dlnT_dlnP, &
                kap, dlnkap_dlnRho, dlnkap_dlnT
 
-            integer :: i, k, j
+            integer :: i, k
 
             include 'formats'
 
@@ -836,7 +835,7 @@
             use chem_def
             integer, intent(out) :: ierr
             integer :: i, k, kbot, ktop
-            real(dp) :: qe3, qe4, lambda, dynvisc, Prandtl, radcon, D
+            real(dp) :: qe3, qe4, dynvisc, Prandtl, radcon, D
             include 'formats'
 
             ierr = 0
@@ -921,7 +920,7 @@
          subroutine set_D_ES(ierr)
             integer, intent(out) :: ierr
             integer :: i, k, kbot, ktop
-            real(dp) :: instability_height, D, v, dln_v_es
+            real(dp) :: instability_height, D, v
             include 'formats'
             ierr = 0
 
@@ -1154,9 +1153,9 @@
             N2, N2_mu, opacity, kap_cond, scale_height
          integer, intent(out) :: ierr
 
-         integer :: nz, k, j, kk
+         integer :: nz, k, kk
          real(dp) :: xmagfmu, xmagft, xmagfdif, xmagfnu, &
-            xkap, xgamma, xlg, xsig1, xsig2, xsig3, xxx, ffff, xsig, &
+            xkap, xgamma, xsig, &
             xeta, xmagn, xmagnmu, xmagnt, xmagw, xmagdn, xmagtn, xmagrn, xmag4pd, &
             dlnomega_dlnr, xmagq, xmager2w, &
             xmagnn, xmagwn, xmagq0, xmagwa0, xmags0, xmagbphi0, xmagbr0, xmageta0, &

--- a/star/private/rsp.f90
+++ b/star/private/rsp.f90
@@ -79,7 +79,6 @@
          use const_def, only: Lsun, Rsun, Msun
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         integer :: i, j, k
          include 'formats'
          NSTART = 1
          s% nz = s% RSP_nz         
@@ -231,11 +230,8 @@
          type (star_info), pointer :: s
          logical, intent(in) :: restart
          integer, intent(out) :: ierr
-         type (star_info), target :: copy_info
-         type (star_info), pointer :: c, prv
          real(dp) :: tau_surf, kap_guess, T_surf, Psurf, kap_surf, Teff_atm, Y
-         integer :: i, k
-         logical :: okay
+         integer :: k
          include 'formats'
          ierr = 0
          if (s% RSP_use_atm_grey_with_kap_for_Psurf .and. &
@@ -311,13 +307,7 @@
          type (star_info), pointer :: s
          logical, intent(in) :: restart
          integer, intent(out) :: ierr
-         integer :: i, j, k, species, nz, op_err
-         real(dp), allocatable :: w_avg(:)
-         real(dp) :: &
-            dFr_dr_out, dFr_dr_in, dFr_dr_00, &
-            dFr_dT_out, dFr_dT_00, dFr_dVol_00, &
-            Lr, Lc, POM
-         logical :: okay
+         integer :: nz
          include 'formats'
          if (restart) then
             call finish_rsp_photo_in(s)
@@ -422,7 +412,7 @@
          type (star_info), pointer :: s      
          integer, intent(out) :: ierr    
          integer :: k, j, k_max_abs_rel_hse_err
-         real(dp) :: rand, hse_err, max_abs_rel_hse_err
+         real(dp) :: hse_err, max_abs_rel_hse_err
          logical :: restart
          
          include 'formats'
@@ -513,7 +503,7 @@
          subroutine add_to_map
             use profile_getval, only: get_profile_val
             integer :: i, k, NPCH1, NPCH2, IP, n, io
-            real(dp) :: ph_x, FASE
+            real(dp) :: FASE
             character (len=256) :: fname
             include 'formats'
             NPCH1 = s% RSP_map_first_period
@@ -780,7 +770,6 @@
          !     s% rsp_GREKM, s% rsp_GREKM_avg_abs, s% rsp_DeltaR, s% rsp_DeltaMAG
          type (star_info), pointer :: s
          logical :: cycle_complete
-         integer :: i, k
          include 'formats'
          if(s% L(1)/SUNL>LMAX) LMAX=s% L(1)/SUNL
          if(s% L(1)/SUNL<LMIN) LMIN=s% L(1)/SUNL      

--- a/star/private/rsp_build.f90
+++ b/star/private/rsp_build.f90
@@ -39,7 +39,7 @@
       public :: do_rsp_build
 
       real(dp) :: PREC,FSUB,TIN,CFIDDLE,ALF, &
-         HHFAC,DdmFAC,SVEL,EFL02,EMR,ELR, &
+         HHFAC,DdmFAC,EFL02,EMR,ELR, &
          E_0,E_1,T_0,T_1,V_0,V_1,P_0,P_1,QQ_0,QQ_1, &
          CP_0,CP_1,OP_0,OP_1,R_1,M_0,dm_bar_0
       real(dp), dimension(15) :: PERS,ETO
@@ -60,28 +60,17 @@
       real(dp) :: H,dmN
       integer :: NMODES            ! ilosc modow rozwazanych (N=NMODES)
       integer :: NDIM1,NDIM2       ! maks. ilosc modow/warstw 
-      real(dp) :: VEL0(15)
-      character (len=10) PARA
-      character (len=30) HEAD
-      character (len=72) HEAD2      
-      integer :: I,J,kk,NSEQ,NIT
-      real(dp) ::  GEFF,MBOL,DU,TET
-      integer :: IARG
-      character (len=8) II1,II2,II3,II4,II5
-      character (len=15) PROGNAME
+      real(dp) :: VEL0(15) 
+      integer :: I,J,kk,NSEQ
+      real(dp) ::  GEFF,MBOL
       character (len=250) FILENAME
-      integer :: IFROZEN,IRELAX,ICASTOR
       
-      integer :: IO,II,IX,iter
-      real(dp) :: SS,AA,BB,XX
+      integer :: IO,II
+      real(dp) :: SS, AA, BB
       real(dp), allocatable :: TA(:), VEL(:,:), TEMP(:)
-      real(dp) :: TAUTEFF,TAUATTEFF
+      real(dp) :: TAUTEFF, TAUATTEFF
       logical RELAX
-      complex(8) xC
-      real(dp) :: X1,X2,Y1,Y2,amix1,amix2
-      integer :: ISTAT
-      type (star_info), target :: copy_info
-      type (star_info), pointer :: c, prv
+      real(dp) :: amix1, amix2
       
       ierr = 0
    
@@ -333,14 +322,12 @@
          integer, intent(out) :: ierr
       
          real(dp) :: dmN,dm_0,H,Psurf,DDT
-         real(dp) :: OPVV,OPTT,POM
          real(dp) :: GPF
-         real(dp) :: DTN,DTLAST,RS00,RIN
-         real(dp) :: F2,F1,D,HH,TT,RAMA,dmL
-         real(dp) :: T4_1,RM,T4_0,WE,TNL,dmNL
+         real(dp) :: F2,F1,D,HH,TT,dmL
+         real(dp) :: T4_1,RM,T4_0,WE,dmNL
          real(dp) :: FACQ,HH1,HH2
-         integer :: N,N1,N2,I,ITIN,dmN_cnt,NCHANG,IG,H_cnt
-         real(dp) :: HP_0,HP_1,IGR_0,IGR_1,PII,w_0
+         integer :: N,N1,I,ITIN,dmN_cnt,NCHANG,IG,H_cnt
+         real(dp) :: HP_0,HP_1,IGR_0,IGR_1,w_0
          real(dp) :: Lr_0,Lc_0,SVEL_0,HSTART,tau_sum,TH0_tol,TIN_tol, &
             dmN_too_large, dmN_too_small, H_too_large, H_too_small
          logical :: adjusting_dmN, in_photosphere, in_outer_env, &
@@ -680,10 +667,8 @@
          use num_lib, only: safe_root_with_brackets
          real(dp) :: Tmax, epsx, epsy, residual, lnT, &
             lnT_min, lnT_max, resid_T_min, resid_T_max, dfdx
-         integer :: i, n, ierr
+         integer :: n, ierr
          integer, parameter :: lrpar=1, lipar=1, imax=50
-         real(dp), target :: rpar_target(lrpar)
-         integer, target :: ipar_target(lipar)
          real(dp), pointer :: rpar(:)
          integer, pointer :: ipar(:)
          include 'formats'
@@ -861,9 +846,9 @@
       subroutine ZNVAR(s,H,dmN,L,TE,M,ierr)
       type (star_info), pointer :: s
       integer, intent(out) :: ierr
-      real(dp) :: H,dmN,L,TE,M,ha,Psurf
-      real(dp) :: T0,R,TAU0,Pdm,CKP,P,PZ,V,OP,DU1,DU2,CP,QQ, &
-         dtau, kap, alfa, G_M_dtau_div_R2, Prad, Pgas_0, Pgas_1, &
+      real(dp) :: H,dmN,L,TE,M,Psurf
+      real(dp) :: T0,R,TAU0,P,V, &
+         dtau, kap, alfa, G_M_dtau_div_R2, Prad, Pgas_0, &
          dP_dV, dkap_dV, xx, residual, d_residual_dlnV, &
          dkap_dlnV, dlnV, dP_dlnV, lnV
       integer :: I

--- a/star/private/rsp_def.f90
+++ b/star/private/rsp_def.f90
@@ -406,7 +406,7 @@
          type (star_info), pointer :: s
          integer, intent(in) :: iounit
          integer, intent(out) :: ierr
-         integer :: n, k, i
+         integer :: n
          include 'formats'
          call init_def(s) 
          ierr = 0
@@ -447,7 +447,7 @@
       
       subroutine finish_after_build_model(s)
          type (star_info), pointer :: s
-         integer :: k, ierr
+         integer :: k
          ! restore bit-for-bit erad = crad*T**4*Vol
          include 'formats'
          do k = 1, NZN
@@ -522,7 +522,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
          real(dp) :: sum_dm
-         integer :: i, k
+         integer :: k
          include 'formats'
          ierr = 0
          sum_dm = 0d0         
@@ -658,7 +658,6 @@
          type (star_info), pointer :: s      
          character (len=*), intent(in) :: str
          integer :: k
-         real(dp) :: V
          include 'formats'
          do k=s% nz,1,-1
             if (k == s% nz) then

--- a/star/private/rsp_eval_eos_and_kap.f90
+++ b/star/private/rsp_eval_eos_and_kap.f90
@@ -48,7 +48,6 @@
       
       subroutine restart_rsp_eos_and_kap(s)
          type (star_info), pointer :: s
-         integer :: ierr
          eos_handle = s% eos_handle
          kap_handle = s% kap_handle
          net_iso => s% net_iso
@@ -60,7 +59,7 @@
          use adjust_xyz, only: get_xa_for_standard_metals
          type (star_info), pointer :: s
          
-         integer :: i, k, j, iz, ierr
+         integer :: i, iz, ierr
          real(dp) :: initial_z, initial_y, initial_x, &
             initial_h1, initial_h2, initial_he3, initial_he4, &
             xsol_he3, xsol_he4, z2bar, ye, mass_correction, sumx
@@ -207,15 +206,11 @@
          integer, intent(out) :: ierr
          
          integer :: j
-         real(dp) :: logT, logRho, T, Rho, energy, entropy, &
-            dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas, &
-            d_dlnRho_const_T, d_dlnT_const_Rho, E, dE_dV, dE_dT, &
+         real(dp) :: logT, logRho, T, Rho, E, dE_dV, dE_dT, &
             lnfree_e, d_lnfree_e_dlnRho, d_lnfree_e_dlnT, &
-            frac_Type2, opacity, dlnkap_dlnd, dlnkap_dlnT, &
             dlnd_dV, chiRho, chiT, dchiRho_dlnd, dchiRho_dlnT, &
-            dchiT_dlnd, dchiT_dlnT, dQ_dlnd, dQ_dlnT, opacity_factor
-         real(dp), dimension(num_eos_basic_results) :: &
-            res, d_dlnd, d_dlnT, d_dabar, d_dzbar
+            dchiT_dlnd, dchiT_dlnT, dQ_dlnd, dQ_dlnT
+         real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT
          real(dp) :: d_dxa(num_eos_d_dxa_results,s% species)
 
          include 'formats'
@@ -826,7 +821,6 @@
          real(dp) :: &
             lnT, dlnT_dL, dlnT_dlnR, dlnT_dlnM, dlnT_dlnkap, &
             lnP, dlnP_dL, dlnP_dlnR, dlnP_dlnM, dlnP_dlnkap
-         integer :: iter
          
          ierr = 0
 
@@ -871,7 +865,7 @@
          real(dp), dimension(num_eos_basic_results) :: &
             res, d_dlnd, d_dlnT
          real(dp), dimension(num_eos_d_dxa_results, species) :: d_dxa
-         integer :: max_iter, which_other, eos_calls, iter
+         integer :: max_iter, which_other, eos_calls
             
          include 'formats'
          ierr = 0         
@@ -917,7 +911,7 @@
          real(dp), dimension(num_eos_basic_results) :: &
             res, d_dlnd, d_dlnT
          real(dp) :: d_dxa(num_eos_d_dxa_results, species)
-         integer :: max_iter, which_other, eos_calls, iter
+         integer :: max_iter, eos_calls
             
          include 'formats'
          ierr = 0         
@@ -989,7 +983,7 @@
          real(dp), dimension(num_eos_basic_results) :: &
             res, d_dlnd, d_dlnT
          real(dp), dimension(num_eos_d_dxa_results, species) :: d_dxa
-         integer :: max_iter, which_other, eos_calls, iter
+         integer :: max_iter, which_other, eos_calls
             
          include 'formats'
          ierr = 0         
@@ -1032,7 +1026,7 @@
          real(dp), dimension(num_eos_basic_results) :: &
             res, d_dlnd, d_dlnT
          real(dp), dimension(num_eos_d_dxa_results, species) :: d_dxa
-         integer :: max_iter, which_other, eos_calls, iter
+         integer :: max_iter, which_other, eos_calls
          ierr = 0         
          max_iter = 100
          which_other = i_lnE

--- a/star/private/rsp_lina.f90
+++ b/star/private/rsp_lina.f90
@@ -102,21 +102,20 @@
       real(dp) :: GGXM,GGX0,GGXP,GGY0,GGYP,GG,GPF
       real(dp) :: DFCX0,DFCXM,DFCXP,DFCY0,DFCYP,DFCZ0,DFCZP
       real(dp) :: DFCMX0,DFCMXM,DFCMXP,DFCMY0,DFCMYP,DFCMZ0,DFCMZP
-      real(dp) :: FLIM,FLD
       real(dp) :: T1,DLR,DLRP,DLRM,DLT,DLTP,DLMR,DLMRP,DLMRM,DLMT,DLMTP
       real(dp) :: W_00,W_out,BW,BK,T2,T3,DLK,DLKP,MINI
-      real(dp) :: T4,T5,P2,P3,P5,P6,P7,P8,P9,P10,POM3,POM2,POM,POM4
+      real(dp) :: T4,POM3,POM2,POM,POM4
       integer :: I,J,NZN3,IG,IE,IR,IC,INFO,IMI,LD_VL,LD_VR,n,op_err
-      real(dp) :: RES(12),VRRS(15),Q(15)
+      real(dp) :: VRRS(15),Q(15)
       character (len=250) FILENAME
       character (len=1) NUMER1
       character (len=2) NUMER2
-      complex(8):: DP_0,DV_0,VTTS(15),SCALE(15),CPOM,DPEV,dP_dT_00URB
+      complex(8):: DP_0,DV_0,VTTS(15),SCALE(15),DPEV,dP_dT_00URB
       real(dp) :: SGRP,SGRM
       real(dp) :: PSIG,TEMI,TEMM,TEM1
       real(dp) :: NORMC
       real(dp) :: QCHECK(15),ETOIEV(15),QWKPT(1000,15),ETOIPT(15),SGR(15)
-      real(dp) :: TT4,TT4P,EFL02   
+      real(dp) :: EFL02   
       real(dp) :: ETOI(15)
       
       !write(*,'(a55,i12,99(1pd26.16))') 'start LINA s% w(2)**2', &

--- a/star/private/rsp_relax_env.f90
+++ b/star/private/rsp_relax_env.f90
@@ -45,10 +45,9 @@
          eval1_mesa_Rho_given_PT, eval1_gamma_PT_getRho
       type (star_info), pointer :: s
       integer, intent(out) :: ierr
-      real(dp) :: T,V,P1,DPV,E,OP,F2,P,U,SVEL,CP,QQ
-      real(dp) :: DU1,DU2,DU3,DU4,DU5,DU6,DU7,DU8,DU9,DU10,DU11,DU12
-      integer :: k,I
-      real(dp) :: RES(12)
+      real(dp) :: T,V,P1,DPV,E,OP,F2,P,SVEL,CP,QQ
+      real(dp) :: DU1,DU2,DU3,DU4,DU5,DU6,DU7,DU8,DU9
+      integer :: k,i
 
       real(dp) :: R,A,PRECEQ,rho_guess,rho,Prad,P_test
       data R,A/8.317d7,7.5641d-15/
@@ -174,9 +173,9 @@
       
       real(dp) :: T1,DLR,DLRP,DLRM,DLT,DLTP,DLMR,DLMRP,DLMRM,DLMT,DLMTP
       real(dp) :: W_00,W_out,BW,BK,T2,T3,DLK,DLKP,SVEL,T_0
-      real(dp) :: DU1,DU2,POM3,POM2,POM,MAXFLUXD
+      real(dp) :: POM3,POM2,POM
       integer :: I,J,IW,IR,IC, IMAXR, IMAXW, IMAXC
-      real(dp) :: MAXR,MAXW,MAXC,PB,PPB,ELB,ELMB,RES(12)
+      real(dp) :: MAXR,MAXW,MAXC,PB,PPB,ELB,ELMB
       
       integer :: INFO,II,ITROUBC,ITROUBT,IZIP
       real(dp) :: XXR,XXC,XXT,EZH,DXH,DXXC,DXXT,DXKC,DXKT, &
@@ -185,7 +184,7 @@
       
       real(dp) :: FFXM,FFX0,FFXP,FFY0,FFYP,FF
       real(dp) :: GGXM,GGX0,GGXP,GGY0,GGYP,GG,GPF
-      real(dp) :: FLIM,FLD,EFL02
+      real(dp) :: EFL02
 
       real(dp) :: POM4,DXXR,TEM1,TEMI,TEMM
 
@@ -201,7 +200,7 @@
       integer :: NDIVAA, NDIVAP, NDIVAT, dmN_cnt, max_dmN_cnt
       logical :: ok_to_adjust_mass, ok_to_adjust_Tsurf
       real(dp) :: EDFAC, Psurf, CFIDDLE, FSUB, EMR, ELR
-      real(dp) :: PREC1, SOL, DAMPS,DAMPRS,DELTA,SOURS
+      real(dp) :: PREC1
 
       real(dp) :: XX_max, XX_max_val, XX_max_dx
       integer :: i_XX_max, var_XX_max, n, op_err

--- a/star/private/rsp_step.f90
+++ b/star/private/rsp_step.f90
@@ -43,8 +43,6 @@
       
       logical, parameter :: call_is_bad = .false.
       
-      real(dp) :: x_dbg
-      
       integer, parameter :: i_var_Vol = 99 ! for remeshing tests with dfridr
       
       integer, parameter :: &
@@ -3867,6 +3865,3 @@
 
 
       end module rsp_step
-      
-      
-            

--- a/star/private/rsp_step.f90
+++ b/star/private/rsp_step.f90
@@ -193,11 +193,10 @@
          use star_utils, only: start_time, update_time
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         real(dp) :: DXXT, DXXC, DXXE, DXXL, PREC2, DXH, EZH, rel_err_energy, &
-            T_surf, P_surf, kap_surf, kap_guess, Teff_atm, &
-            R_center_start, dt_max, total
+         real(dp) :: DXXT, DXXC, DXXE, DXXL, PREC2, DXH, EZH, &
+            P_surf, R_center_start, dt_max, total
          integer :: &
-            i_min, i_max, num_tries, max_retries, max_iters, i, IT, k, nz, &
+            i_min, i_max, num_tries, max_retries, max_iters, k, nz, &
             kT_max, kW_max, kE_max, kL_max, iter_for_dfridr, test_partials_k
          integer(8) :: time0
          logical :: converged, dbg_msg, trace
@@ -325,7 +324,6 @@
          end subroutine set_min_k_for_turbulent_flux
                
          subroutine doing_retry
-            integer :: i
             include 'formats'
             if (num_tries  ==  max_retries+1) then
                write(*,*) 'NO CONVERGENCE IN HYD, TIME STEP num tries, max allowed', &
@@ -344,7 +342,6 @@
          end subroutine doing_retry
          
          subroutine write_msg
-            integer :: i, k
             include 'formats'
             !if (EZH < 1d0) write(*,3) 'undercorrection factor', s% model_number, iter, EZH
             write(*,'(i6, 2x, i3, 4(4x, a, 1x, i4, 1x, 1pe11.4, 1x, 1pe11.4))') &
@@ -626,8 +623,6 @@
       subroutine set_f_Edd(s, ierr)
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         real(dp) :: lim_f_Edd, lim_g_Edd
-         integer :: k, j
          include 'formats'
          ierr = 0
          s% g_Edd = 0.5d0
@@ -695,7 +690,7 @@
          type (star_info), pointer :: s
          integer, intent(in) :: iter,i_min,i_max
          integer, intent(out) :: ierr
-         integer :: i, k, op_err
+         integer :: i, op_err
          integer(8) :: time0
          real(dp) :: total
          include 'formats'
@@ -739,11 +734,11 @@
       subroutine eval_eqns(s,P_surf)
          type (star_info), pointer :: s
          real(dp), intent(in) :: P_surf
-         integer :: i, k
+         integer :: i
          include 'formats'
          !$OMP PARALLEL DO PRIVATE(I) SCHEDULE(dynamic,2)
-         do I = 1,NZN
-            call calc_equations(s, I, P_surf)
+         do i = 1,NZN
+            call calc_equations(s, i, P_surf)
          end do
          !$OMP END PARALLEL DO
       end subroutine eval_eqns
@@ -758,22 +753,22 @@
          include 'formats'
          k = NZN+1-i
          T1 = P43/s% dm(k)
-         if (I /= 1) then
+         if (i /= 1) then
             q1 = T1
             q2 = s% r(k)
             q3 = s% r(k+1)
             q4 = q1*(q2**3 - q3**3)
             s% Vol(k) = dble(q4)
-            dVol_dr_in(I) = - 3.0d0*T1*s% r(k+1)**2
+            dVol_dr_in(i) = - 3.0d0*T1*s% r(k+1)**2
          else
             s% Vol(k) = T1*(s% r(k)**3 - s% R_center**3)
-            dVol_dr_in(I) = 0d0
+            dVol_dr_in(i) = 0d0
          end if
          if (s% Vol(k) <= 0d0) then
             write(*,2) 'bad Vol', k, s% Vol(k)
             call mesa_error(__FILE__,__LINE__,'do1_specific_volume')
          end if
-         dVol_dr_00(I) = 3.d0*T1*s% r(k)**2
+         dVol_dr_00(i) = 3.d0*T1*s% r(k)**2
       end subroutine do1_specific_volume
       
       
@@ -945,7 +940,7 @@
          real(dp), intent(in) :: DXH
          real(dp), intent(out) :: XXT, XXC, XXE, XXL, EZH
          integer, intent(out) :: kT_max,kW_max,kE_max,kL_max
-         integer :: i, k, IR, IT, IW, IU, IE, IL, kEZH, &
+         integer :: i, k, IR, IT, IW, IE, IL, kEZH, &
             iTM, kTM, iRM, kRM, iEM, kEM, iCM, kCM, iLM, kLM
          real(dp) :: old_w, XXR, DXXT, DXXC, DXXE, DXXL, DXRM, DXR, &
             EZH1, XXTM, XXCM, XXRM, XXEM, XXLM, DXKT, DXKC, DXKE, DXKL
@@ -1737,7 +1732,7 @@
          integer, intent(in) :: I      
          real(dp) :: RRI, RRM, UUI, UUM, POM, POM2
          integer :: k
-         logical :: test_partials, smoothed
+         logical :: test_partials
          include 'formats'
          k = NZN+1-i
          if (ALFA == 0d0 .or. I <= IBOTOM .or. I >= NZN) then
@@ -2145,8 +2140,7 @@
             dLt_der_00, dLt_der_out, &
             dLt_dw_00, dLt_dw_out
          real(dp) :: POM, POM2, POM3, TEM1, TEM2, &
-            d_POM2_dVol_00, d_POM2_dVol_out, rho2_face, &
-            d_rho2_face_dVol_00, d_rho2_face_dVol_out
+            d_POM2_dVol_00, d_POM2_dVol_out, rho2_face
          integer :: k
          logical :: test_partials
          include 'formats'
@@ -2329,8 +2323,8 @@
             dFr_dT_out, dFr_dT_00, &
             dFr_der_out, dFr_der_00
          real(dp) :: &
-            Vol_00, W_00, d_W_00_dr_in, d_W_00_dr_00, d_W_00_dVol_00, d_W_00_der_00, &
-            Vol_out, W_out, d_W_out_dr_00, d_W_out_dr_out, d_W_out_dVol_out, d_W_out_der_out, &
+            W_00, d_W_00_dr_in, d_W_00_dr_00, d_W_00_dVol_00, d_W_00_der_00, &
+            W_out, d_W_out_dr_00, d_W_out_dr_out, d_W_out_dVol_out, d_W_out_der_out, &
             Prad_factor, Fr2a, d_Fr2a_dW_00, d_Fr2a_dW_out, &
             Fr2b, d_Fr2b_dW_00, d_Fr2b_dW_out, &
             BW, kap_00, kap_out, BK, Fr1, Fr2, Fr3, &
@@ -3566,19 +3560,6 @@
          use const_def, only: crad, clight
          type (star_info), pointer :: s
          integer, intent(in) :: i
-         integer :: IE, k
-         real(dp) :: time_scale, residual, XP, d_XP_der, &
-            d_XP_dVol_00, d_XP_dr_00, d_XP_dr_in, &
-            area_00, area_00_start, area_in, area_in_start, &
-            Lr_00, Lr_00_start, d_Lr_00_dFr_00, d_Lr_00_dr_00, &
-            Lr_in, Lr_in_start, d_Lr_in_dFr_in, d_Lr_in_dr_in, &
-            L_00, L_in, dt, dm, dt_div_dm, DV, opacity, &
-            erad, erad_tw, Vol, T, COUPL_factor, COUPL, COUPL1, &
-            d_COUPL_dVol, d_COUPL_dT, d_COUPL_der, d_COUPL_dr_in, d_COUPL_dr_00, &
-            heat_exchange_time_scale, kE_fac, kP_fac, dt_term, &
-            d_dt_term_dT, d_dt_term_dr_in, d_dt_term_dr_00, &
-            u_div_r, d_u_div_r_dr_00, d_u_div_r_dr_in, u_div_r_factor
-         logical :: test_partials
          include 'formats'
          
          call T_form_of_erad_eqn(s, i)
@@ -3591,30 +3572,7 @@
          type (star_info), pointer :: s
          integer, intent(in) :: i
          integer :: IL, k
-         real(dp) :: residual, &
-            XP_00, d_XP_00_dVol_00, d_XP_00_der_00, d_XP_00_dr_00, d_XP_00_dr_in, &
-            XP_out, d_XP_out_der_out, d_XP_out_dr_out, d_XP_out_dr_00, &
-            u_div_r, d_u_div_r_dr_00, &
-            d_lnV, d_dlnV_dVol_00, d_dlnV_dr_in, d_dlnV_dr_00, d_dlnV_dr_out, &
-            Vol_out, d_Vol_out_dr_00, d_Vol_out_dr_out, &
-            rho_out, d_rho_out_dr_out, d_rho_out_dr_00, &
-            Vol_00, d_Vol_00_dr_in, d_Vol_00_dr_00, &
-            rho_00, d_rho_00_dVol_00, d_rho_00_dr_00, d_rho_00_dr_in, &
-            rho_face, d_rho_dVol_00, d_rho_dr_in, d_rho_dr_00, d_rho_dr_out, &
-            r, dt, dm_bar, dt_div_dm_bar, d_dXP_factor_dr_in, d_dXP_factor_dr_00, &
-            d_dXP_factor_dr_out, Fr, Fr_start, Fr_tw, &
-            kap_00, kap_out, kap_rho_face, rho_face_start, d_dlnV_drho_face, &
-            d_kap_00_dVol_00, d_kap_00_dT_00, d_kap_00_dr_00, d_kap_00_dr_in, &
-            d_kap_out_dT_out, d_kap_out_dr_00, d_kap_out_dr_out, &
-            area, d_area_dr_00, d_kaprho_dVol_00, d_kaprho_dT_00, d_kaprho_dT_out, &
-            d_kaprho_dr_in, d_kaprho_dr_00, d_kaprho_dr_out, &
-            dXP, dXP_factor, Fr_factor, d_dXP_factor_dVol_00, &
-            d_Fr_factor_dVol_00, d_Fr_factor_dT_00, d_Fr_factor_dT_out, &
-            d_Fr_factor_dr_in, d_Fr_factor_dr_00, d_Fr_factor_dr_out, &
-            erad_00, erad_out, erad_tw, erad_factor1, erad_factor, &
-            d_erad_factor_dVol_00, d_erad_factor_dr_in, &
-            d_erad_factor_dr_00, d_erad_factor_dr_out
-         logical :: test_partials, okay
+         real(dp) :: residual
 
          include 'formats'
          

--- a/star/private/set_flags.f90
+++ b/star/private/set_flags.f90
@@ -41,7 +41,6 @@
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          integer :: nvar_hydro_old, k, nz, i_v, i_u
-         real(dp) :: cs
          logical, parameter :: dbg = .false.
 
          include 'formats'
@@ -133,7 +132,6 @@
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          integer :: nvar_hydro_old, k, nz, i_u, i_v
-         real(dp) :: cs
          logical, parameter :: dbg = .false.
 
          integer :: num_u_vars
@@ -232,8 +230,7 @@
          logical, intent(in) :: RTI_flag
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: nvar_hydro_old, k, nz
-         real(dp) :: cs
+         integer :: nvar_hydro_old, nz
          logical, parameter :: dbg = .false.
 
          include 'formats'
@@ -307,7 +304,7 @@
          logical, intent(in) :: RSP2_flag
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: nvar_hydro_old, i, k, j, nz, iounit
+         integer :: nvar_hydro_old, i, k, nz
          logical, parameter :: dbg = .false.
 
          include 'formats'
@@ -556,8 +553,7 @@
          logical, intent(in) :: w_div_wc_flag
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: nvar_hydro_old, k, nz
-         real(dp) :: cs
+         integer :: nvar_hydro_old, nz
          logical, parameter :: dbg = .false.
 
          include 'formats'
@@ -627,8 +623,7 @@
          logical, intent(in) :: j_rot_flag
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
-         integer :: nvar_hydro_old, k, nz
-         real(dp) :: cs
+         integer :: nvar_hydro_old, nz
          logical, parameter :: dbg = .false.
 
          include 'formats'

--- a/star/private/solve_omega_mix.f90
+++ b/star/private/solve_omega_mix.f90
@@ -43,9 +43,9 @@
          type (star_info), pointer :: s
          real(dp), intent(in) :: dt_total
 
-         integer :: ierr, nz, i, j, k, max_iters_per_substep, &
+         integer :: ierr, nz, k, max_iters_per_substep, &
             max_iters_total, total_num_iters, num_iters
-         integer(8) :: time0, clock_rate
+         integer(8) :: time0
          integer :: steps_used, max_steps, min_steps
          real(qp) :: remaining_time, total_time, time, dt, &
             J_tot0, J_tot1, max_del, avg_del, &

--- a/star/private/solver_support.f90
+++ b/star/private/solver_support.f90
@@ -42,9 +42,8 @@
          integer, intent(in) :: nvar
          integer, intent(out) :: ierr
 
-         integer :: i, j, k, nz, nvar_hydro
+         integer :: i, k, nz, nvar_hydro
          real(dp), parameter :: xscale_min = 1
-         real(dp) :: var_scale, lum_scale, vel_scale, omega_scale
 
          include 'formats'
 
@@ -70,7 +69,7 @@
          contains
 
          subroutine dump_xscale
-            integer :: k, j, k0, k1
+            integer :: k, j
             include 'formats'
             !write(*,1) 's% xa_scale', s% xa_scale
             do k=1,s% nz
@@ -94,8 +93,7 @@
          integer, intent(out) :: ierr
 
          integer :: cnt, i, j, k, nz
-         integer :: id
-         real(dp) :: dt, theta_dt
+         real(dp) :: dt
          include 'formats'
 
          ierr = 0
@@ -167,7 +165,7 @@
 
 
          subroutine dump_eval_equ
-            integer :: k, j, k0, k1
+            integer :: k, j
             include 'formats'
             do k=1,s% nz
                do j=1,nvar
@@ -188,9 +186,8 @@
          real(dp), intent(out) :: equ_norm, equ_max
          integer, intent(out) :: k_max, j_max, ierr
 
-         integer :: j, k, num_terms, n, nz, nvar_hydro, nvar_chem, &
-            max_loc, skip_eqn1, skip_eqn2, skip_eqn3
-         real(dp) :: sumequ, absq, max_energy_resid, avg_energy_resid
+         integer :: j, k, num_terms, n, nz, nvar_hydro, nvar_chem, skip_eqn1, skip_eqn2, skip_eqn3
+         real(dp) :: sumequ, absq
          
          logical :: dbg
 
@@ -299,7 +296,7 @@
          contains
 
          subroutine dump_equ
-            integer :: k, j, k0, k1
+            integer :: k, j
             include 'formats'
             do k=1,s% nz
                do j=1,nvar
@@ -325,7 +322,7 @@
          integer :: k, i, nz, num_terms, j, n, nvar_hydro, jmax, num_xa_terms, &
             skip1, skip2, skip3, skip4, skip5
          real(dp) :: abs_corr, sum_corr, sum_xa_corr, x_limit, &
-            max_abs_correction, max_abs_correction_cv, max_abs_corr_for_k, max_abs_xa_corr_for_k
+            max_abs_correction, max_abs_corr_for_k, max_abs_xa_corr_for_k
          logical :: found_NaN, found_bad_num, report
          real(dp), parameter :: frac = 0.1d0
          logical, parameter :: dbg = .false.
@@ -603,7 +600,7 @@
 
 
          subroutine dump_B
-            integer :: k, j, k0, k1
+            integer :: k, j
             include 'formats'
             do k=1,s% nz
                do j=1,nvar
@@ -625,18 +622,13 @@
          use const_def, only: dp
          use chem_def, only: chem_isos
          use star_utils, only: current_min_xa_hard_limit, rand
-         use rsp_def, only: EFL0
          type (star_info), pointer :: s
          integer, intent(in) :: nvar
          real(dp), pointer, dimension(:,:) :: B ! (nvar, nz)
          real(dp), intent(inout) :: correction_factor
          integer, intent(out) :: ierr
-         integer :: id, i, j, k, nz, species, bad_j, bad_k, &
-            i_alpha_RTI, i_w_div_wc
+         integer :: i, j, k, nz, species, bad_j, bad_k
          real(dp) :: alpha, min_alpha, new_xa, old_xa, dxa, eps, min_xa_hard_limit, &
-            old_E, dE, new_E, old_lnd, dlnd, new_lnd, dw, new_w, &
-            dw_div_wc, old_w_div_wc, new_w_div_wc, dconv_vel, old_conv_vel, new_conv_vel, &
-            dalpha_RTI, new_alpha_RTI, old_alpha_RTI, log_conv_vel_v0, &
             dlum_surf, old_lum_surf, new_lum_surf
          include 'formats'
          ierr = 0
@@ -742,7 +734,6 @@
          real(dp), pointer, dimension(:,:) :: B ! (nvar, nz)
          integer, intent(out) :: ierr
 
-         integer :: id
          integer, parameter :: inspectB_iter_stop = -1
          include 'formats'
 
@@ -756,7 +747,7 @@
          contains
 
          subroutine dumpB
-            integer :: k, j, k0, k1
+            integer :: k, j
             include 'formats'
             do k=1,s% nz
                do j=1,nvar
@@ -780,8 +771,6 @@
          type (star_info), pointer :: s
          integer, intent(in) :: iter ! have finished this many iterations and have converged
          integer, intent(in) :: itermin ! this is the requested minimum.  iter may be < itermin.
-
-         integer :: k, res
 
          include 'formats'
 
@@ -845,15 +834,15 @@
             skip_set_cz_bdy_mass = .true., &
             skip_other_cgrav = .true.
          logical :: do_chem, try_again, do_edit_lnR, report_dx
-         integer :: i, j, k, kk, klo, khi, i_var, &
+         integer :: j, k, kk, klo, khi, i_var, &
             i_lnd, i_lnT, i_lnR, i_lum, i_w, i_Hp, i_v, &
             i_u, i_alpha_RTI, i_w_div_wc, i_j_rot, &
             fe56, nvar_chem, species, nz, nvar_hydro
          real(dp), dimension(:, :), pointer :: xh_start, xa_start
          integer :: op_err, kbad, &
-            cnt, max_fixes, loc(2), k_lo, k_hi, k_const_mass
-         real(dp) :: r2, xavg, u00, um1, dx_for_i_var, x_for_i_var, &
-            dq_sum, xa_err_norm, d_dxdt_dx, min_xa_hard_limit, sum_xa_hard_limit
+            cnt, max_fixes, loc(2), k_lo, k_hi
+         real(dp) :: xavg, dx_for_i_var, x_for_i_var, &
+            dq_sum, d_dxdt_dx, min_xa_hard_limit, sum_xa_hard_limit
          logical :: do_lnd, do_lnT, do_lnR, do_lum, do_w, &
             do_u, do_v, do_alpha_RTI, do_w_div_wc, do_j_rot
 

--- a/star/private/star_job_ctrls_io.f90
+++ b/star/private/star_job_ctrls_io.f90
@@ -565,7 +565,6 @@
          integer, intent(in) :: level
          integer, intent(out) :: ierr
          logical, dimension(max_extra_inlists) :: read_extra
-         character (len=strlen) :: message
          character (len=strlen), dimension(max_extra_inlists) :: extra
          integer :: unit, i
 

--- a/star/private/star_solver.f90
+++ b/star/private/star_solver.f90
@@ -121,10 +121,9 @@
          real(dp), dimension(:,:), pointer :: dxsave=>null(), ddxsave=>null(), B=>null(), grad_f=>null(), soln=>null()
          real(dp), dimension(:), pointer :: dxsave1=>null(), ddxsave1=>null(), B1=>null(), grad_f1=>null(), &
             row_scale_factors1=>null(), col_scale_factors1=>null(), soln1=>null(), save_ublk1=>null(), save_dblk1=>null(), save_lblk1=>null()
-         real(dp), dimension(:,:), pointer ::  rhs=>null()
+         real(dp), dimension(:,:), pointer :: rhs=>null()
          integer, dimension(:), pointer :: ipiv1=>null()
-         real(dp), dimension(:,:), pointer :: &
-            ddx=>null(), xgg=>null(), ddxd=>null(), ddxdd=>null(), xder=>null(), equsave=>null()
+         real(dp), dimension(:,:), pointer :: ddx=>null(), xder=>null()
 
          integer, dimension(:), pointer :: ipiv_blk1=>null()
          character (len=s%nz) :: equed1
@@ -136,19 +135,19 @@
          real(dp)  ::  &
             coeff, f, slope, residual_norm, max_residual, &
             corr_norm_min, resid_norm_min, correction_factor, temp_correction_factor, &
-            correction_norm, corr_norm_initial, max_correction, slope_extra, &
+            correction_norm, max_correction, &
             tol_residual_norm, tol_max_residual, &
             tol_residual_norm2, tol_max_residual2, &
             tol_residual_norm3, tol_max_residual3, &
             tol_abs_slope_min, tol_corr_resid_product, &
             min_corr_coeff, max_corr_min, max_resid_min, max_abs_correction
-         integer :: nz, iter, max_tries, zone, tiny_corr_cnt, i, j, k, &
+         integer :: nz, iter, max_tries, tiny_corr_cnt, i, &
             force_iter_value, iter_for_resid_tol2, iter_for_resid_tol3, &
             max_corr_k, max_corr_j, max_resid_k, max_resid_j
-         integer(8) :: test_time1, time0, time1, clock_rate
+         integer(8) :: time0
          character (len=strlen) :: err_msg
          logical :: first_try, dbg_msg, passed_tol_tests, &
-            doing_extra, okay, disabled_resid_tests, pass_resid_tests, &
+            doing_extra, disabled_resid_tests, pass_resid_tests, &
             pass_corr_tests_without_coeff, pass_corr_tests_with_coeff
 
          integer, parameter :: num_tol_msgs = 15
@@ -632,10 +631,8 @@
             real(dp), pointer, dimension(:,:) :: xder ! (nvar, nz)
             integer, intent(out) :: ierr
             
-            integer :: j, k, i_var, i_var_sink, i_equ, k_off, cnt_00, cnt_m1, cnt_p1, k_lo, k_hi
+            integer :: j, k, k_lo, k_hi
             real(dp), dimension(:,:), pointer :: save_equ, save_dx
-            real(dp) :: dvar, dequ, dxtra, &
-               dx_0, dvardx, dvardx_0, xdum, err
             logical :: testing_partial
 
             include 'formats'
@@ -732,7 +729,7 @@
             integer, intent(in) :: nvar
             real(dp), pointer, dimension(:,:) :: xder ! (nvar, nz)
             integer, intent(out) :: ierr
-            integer :: i, j, nz, neqns
+            integer :: nz, neqns
             include 'formats'
             ierr = 0
             nz = s% nz
@@ -760,12 +757,11 @@
             character (len=*), intent(out) :: err_msg
             integer, intent(out) :: ierr
 
-            integer :: i, j, k, iter, k_max_corr, i_max_corr
-            character (len=strlen) :: message
+            integer :: i, k, iter
             logical :: first_time
-            real(dp) :: a1, alam, alam2, alamin, a2, disc, f2, &
-               rhs1, rhs2, temp, test, tmplam, max_corr, fold, min_corr_coeff
-            real(dp) :: frac, f_target
+            real(dp) :: a1, alam, alam2, a2, disc, f2, &
+               rhs1, rhs2, tmplam, fold, min_corr_coeff
+            real(dp) :: f_target
             logical :: skip_eval_f, dbg_adjust
 
             real(dp), parameter :: alf = 1d-2 ! ensures sufficient decrease in f
@@ -1005,8 +1001,8 @@
          logical function solve_equ()
             use star_utils, only: start_time, update_time
             use rsp_def, only: NV, MAX_NZN
-            integer ::  i, k, ierr
-            real(dp) :: ferr, total_time
+            integer ::  i, ierr
+            real(dp) :: total_time
 
             include 'formats'
             ierr = 0

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -2963,9 +2963,7 @@
          type (star_info), pointer :: s
          integer, intent(in) :: i, j, k, nvar
          real(dp), intent(in) :: v
-         integer :: b, q, vp1
-         real(qp) :: q1, q2
-         !logical, parameter :: dbg = .true.
+         integer :: vp1
          logical, parameter :: dbg = .false.
          include 'formats'
          
@@ -3377,7 +3375,7 @@
          type (star_info), pointer :: s
          character(len=*), intent(in) :: str
          logical, intent(in) :: advance
-         integer :: id, ierr, io
+         integer :: ierr, io
          if (len_trim(s% extra_terminal_output_file) > 0) then
             ierr = 0
             open(newunit=io, file=trim(s% extra_terminal_output_file), &

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -280,7 +280,7 @@
             s% grav(k) = s% cgrav(k)*s% m_grav(k)/(r*r)
          end do
       end subroutine set_m_grav_and_grav
-      
+
       
       subroutine get_r_and_lnR_from_xh(s, k, r, lnR, xh_in)
          type (star_info), pointer :: s
@@ -296,7 +296,7 @@
          lnR = xh(s% i_lnR,k)
          r = exp(lnR)
       end subroutine get_r_and_lnR_from_xh
-      
+
       
       real(dp) function get_r_from_xh(s, k, xh_in) result(r)
          type (star_info), pointer :: s
@@ -310,7 +310,7 @@
          end if
          r = exp(xh(s% i_lnR,k))
       end function get_r_from_xh
-      
+
       
       real(dp) function get_lnR_from_xh(s, k, xh_in) result(lnR)
          type (star_info), pointer :: s
@@ -324,7 +324,7 @@
          end if
          lnR = xh(s% i_lnR,k)
       end function get_lnR_from_xh      
-      
+
       subroutine store_r_in_xh(s, k, r, xh_in)
          type (star_info), pointer :: s
          integer, intent(in) :: k
@@ -338,7 +338,7 @@
          end if
          xh(s% i_lnR,k) = log(r)
       end subroutine store_r_in_xh
-      
+
       
       subroutine store_lnR_in_xh(s, k, lnR, xh_in)
          type (star_info), pointer :: s
@@ -353,7 +353,7 @@
          end if
          xh(s% i_lnR,k) = lnR
       end subroutine store_lnR_in_xh
-      
+
       
       subroutine get_T_and_lnT_from_xh(s, k, T, lnT, xh_in)
          type (star_info), pointer :: s
@@ -369,7 +369,7 @@
          lnT = xh(s% i_lnT,k)
          T =  exp(lnT)
       end subroutine get_T_and_lnT_from_xh
-      
+
       
       real(dp) function get_T_from_xh(s, k, xh_in) result(T)
          type (star_info), pointer :: s
@@ -383,7 +383,7 @@
          end if
          T =  exp(xh(s% i_lnT,k))
       end function get_T_from_xh
-      
+
       
       real(dp) function get_lnT_from_xh(s, k, xh_in) result(lnT)
          type (star_info), pointer :: s
@@ -397,7 +397,7 @@
          end if
          lnT = xh(s% i_lnT,k)
       end function get_lnT_from_xh
-      
+
       
       subroutine store_T_in_xh(s, k, T, xh_in)
          type (star_info), pointer :: s
@@ -412,7 +412,7 @@
          end if
          xh(s% i_lnT,k) = log(T)
       end subroutine store_T_in_xh
-      
+
       
       subroutine store_lnT_in_xh(s, k, lnT, xh_in)
          type (star_info), pointer :: s
@@ -427,7 +427,7 @@
          end if
          xh(s% i_lnT,k) = lnT
       end subroutine store_lnT_in_xh
-      
+
       
       subroutine get_rho_and_lnd_from_xh(s, k, rho, lnd, xh_in)
          type (star_info), pointer :: s
@@ -444,7 +444,7 @@
          rho =  exp(lnd)
       end subroutine get_rho_and_lnd_from_xh
             
-      
+
       subroutine store_rho_in_xh(s, k, rho, xh_in)
          type (star_info), pointer :: s
          integer, intent(in) :: k
@@ -458,7 +458,7 @@
          end if
          xh(s% i_lnd,k) = log(rho)
       end subroutine store_rho_in_xh
-      
+
       
       subroutine store_lnd_in_xh(s, k, lnd, xh_in)
          type (star_info), pointer :: s
@@ -479,7 +479,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
          integer :: k, nz, i_lnR, i_lnd
-         real(dp) :: rL, rR, dm, dV, rho, old_lnd, new_lnd
+         real(dp) :: rL, rR, dm, dV, rho
          include 'formats'
          ierr = 0
          i_lnR = s% i_lnR
@@ -719,7 +719,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
          integer :: k
-         real(dp) :: kap, kap_min
+         real(dp) :: kap
          include 'formats'
          ierr = 0
          k = 1
@@ -744,7 +744,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
          ! tau(k) is optical depth at outer boundary of cell k
-         real(dp) :: dtau, dr, Z, kap_min, kap, dm_sum, L_sum
+         real(dp) :: dtau, kap, dm_sum, L_sum
          integer :: k
          logical, parameter :: dbg = .true.
          include 'formats'
@@ -900,7 +900,7 @@
          type (star_info), pointer :: s
          real(dp), intent(in) :: r
          integer, intent(out) :: ierr
-         real(dp) :: dtau, dr, tau_m1, tau_00
+         real(dp) :: dtau, tau_m1, tau_00
          integer :: k
          logical, parameter :: dbg = .false.
          include 'formats'
@@ -921,7 +921,7 @@
             dtau = s% dm(k)*s% opacity(k)/(pi4*s% rmid(k)*s% rmid(k))
          end do
       end function get_tau_at_r
-      
+
       
       subroutine set_phot_info(s)
          use atm_lib, only: atm_black_body_T
@@ -1153,9 +1153,8 @@
                s% abs_du_div_cs(k) = 1d99
             end do
          end if
-      
-      end subroutine set_abs_du_div_cs
 
+      end subroutine set_abs_du_div_cs
 
 
       subroutine get_shock_info(s)
@@ -1321,9 +1320,8 @@
       real(dp) function min_dr_div_cs(s,min_k) ! seconds
          type (star_info), pointer :: s
          integer, intent(out) :: min_k
-         integer :: k, nz, j, k_min
-         real(dp) :: dr, dt, D, abs_du, cs, min_q, max_q, &
-            min_abs_u_div_cs, min_abs_du_div_cs, r00, rp1, dr_div_cs, remnant_mass
+         integer :: k, nz, k_min
+         real(dp) :: dr, dt, min_q, max_q, min_abs_u_div_cs, min_abs_du_div_cs, r00, rp1, dr_div_cs, remnant_mass
          include 'formats'
          nz = s% nz
          min_k = nz
@@ -1373,7 +1371,7 @@
             end if
          end do
       end function min_dr_div_cs
-      
+
 
       subroutine reset_epsnuc_vectors(s)
          type (star_info), pointer :: s
@@ -1446,7 +1444,7 @@
          call store_partials( &
             s, k, i_eqn, nvar, d_dm1, d_d00, d_dp1, str, ierr)
       end subroutine save_eqn_residual_info
-      
+
 
 
       subroutine unpack_residual_partials(s, k, nvar, i_eqn, &
@@ -1467,7 +1465,6 @@
             djrot_m1, djrot_00, djrot_p1, &
             dxtra1_m1, dxtra1_00, dxtra1_p1, &
             dxtra2_m1, dxtra2_00, dxtra2_p1
-         integer :: j
 
          include 'formats'
 
@@ -1504,7 +1501,7 @@
          end subroutine unpack1         
          
       end subroutine unpack_residual_partials
-      
+
       subroutine store_partials(s, k, i_eqn, nvar, d_dm1, d_d00, d_dp1, str, ierr)
          type (star_info), pointer :: s
          integer, intent(in) :: k, i_eqn, nvar
@@ -1607,7 +1604,7 @@
       real(dp) function eval_Ledd(s, ierr)
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         real(dp) :: dtau1, dtau, dr, tau, dqsum, Ledd_sum
+         real(dp) :: dtau1, dtau, tau, dqsum, Ledd_sum
          integer :: k
          logical, parameter :: dbg = .false.
          include 'formats'
@@ -1750,12 +1747,12 @@
             s% time_set_mixing_info
       end function total_times
 
-      
+
       real(dp) function get_remnant_mass(s)
          type (star_info), pointer :: s
          get_remnant_mass = s% m(1) - get_ejecta_mass(s)
       end function get_remnant_mass
-      
+
       
       real(dp) function get_ejecta_mass(s)
          use num_lib, only: find0
@@ -1971,15 +1968,14 @@
          L_rad_div_Ledd = &
             -(area*area*crad*(del_T4/del_m)/3)/(pi4*s% cgrav(j)*s% m_grav(j))
       end function get_Lrad_div_Ledd
-      
+
       
       real(dp) function cell_start_specific_KE(s,k)
          type (star_info), pointer :: s
          integer, intent(in) :: k
-         real(dp) :: ke
          cell_start_specific_KE = cell_start_specific_KE_qp(s,k)
       end function cell_start_specific_KE
-      
+
       
       real(qp) function cell_start_specific_KE_qp(s,k)
          ! for consistency with dual cells at faces, use <v**2> instead of <v>**2
@@ -2008,16 +2004,15 @@
             cell_start_specific_KE_qp = 0d0
          end if
       end function cell_start_specific_KE_qp
-      
+
       
       real(dp) function cell_specific_KE(s,k,d_dv00,d_dvp1)
          type (star_info), pointer :: s
          integer, intent(in) :: k
          real(dp), intent(out) :: d_dv00, d_dvp1
-         real(dp) :: v2, dv2_dv00, dv2_dvp1
          cell_specific_KE = cell_specific_KE_qp(s,k,d_dv00,d_dvp1)
       end function cell_specific_KE
-      
+
       
       real(qp) function cell_specific_KE_qp(s,k,d_dv00,d_dvp1)
          ! for consistency with dual cells at faces, use <v**2> instead of <v>**2
@@ -2057,7 +2052,7 @@
             d_dvp1 = 0d0
          end if
       end function cell_specific_KE_qp
-      
+
       
       real(dp) function cell_specific_PE(s,k,d_dlnR00,d_dlnRp1)
          type (star_info), pointer :: s
@@ -2065,7 +2060,7 @@
          real(dp), intent(out) :: d_dlnR00,d_dlnRp1
          cell_specific_PE = cell_specific_PE_qp(s,k,d_dlnR00,d_dlnRp1)
       end function cell_specific_PE
-      
+
       
       real(qp) function cell_specific_PE_qp(s,k,d_dlnR00,d_dlnRp1)
          ! for consistency with dual cells at faces, <m/r>_cntr => (m(k)/r(k) + m(k+1)/r(k+1))/2 /= m_cntr/r_cntr
@@ -2113,14 +2108,14 @@
             call mesa_error(__FILE__,__LINE__,'cell_specific_PE')
          end if
       end function cell_specific_PE_qp
-      
+
       
       real(dp) function cell_start_specific_PE(s,k)
          type (star_info), pointer :: s
          integer, intent(in) :: k
          cell_start_specific_PE = cell_start_specific_PE_qp(s,k)
       end function cell_start_specific_PE
-      
+
       
       real(dp) function cell_start_specific_PE_qp(s,k)
          ! for consistency with dual cells at faces, <m/r>_cntr => (m(k)/r(k) + m(k+1)/r(k+1))/2 /= m_cntr/r_cntr
@@ -2161,7 +2156,7 @@
             call mesa_error(__FILE__,__LINE__,'cell_start_specific_PE_qp')
          end if
       end function cell_start_specific_PE_qp
-      
+
       
       real(dp) function cell_specific_rotational_energy(s,k)
          type (star_info), pointer :: s
@@ -2176,7 +2171,7 @@
          cell_specific_rotational_energy = 0.5d0*(e_p1 + e_00)
       end function cell_specific_rotational_energy
 
-      
+
       subroutine get_dke_dt_dpe_dt(s, k, dt, &
             dke_dt, d_dkedt_dv00, d_dkedt_dvp1, &
             dpe_dt, d_dpedt_dlnR00, d_dpedt_dlnRp1, ierr)
@@ -2189,7 +2184,6 @@
          integer, intent(out) :: ierr
          real(dp) :: PE_start, PE_new, KE_start, KE_new, q1
          real(dp) :: dpe_dlnR00, dpe_dlnRp1, dke_dv00, dke_dvp1
-         integer :: nz
          include 'formats'
          ierr = 0
          ! rate of change in specific PE (erg/g/s)
@@ -2207,7 +2201,7 @@
          d_dkedt_dv00 = dke_dv00/dt
          d_dkedt_dvp1 = dke_dvp1/dt   
       end subroutine get_dke_dt_dpe_dt
-      
+
       
       real(dp) function eval_deltaM_total_from_profile( &
             deltaM, premesh_dm, profile)
@@ -2231,7 +2225,7 @@
          end do
          eval_deltaM_total_from_profile = total
       end function eval_deltaM_total_from_profile
-      
+
       
       real(dp) function cell_specific_total_energy(s, k) result(cell_total)
          type (star_info), pointer :: s
@@ -2247,7 +2241,7 @@
          if (s% RSP2_flag) cell_total = cell_total + pow2(s% w(k))
          if (s% rsp_flag) cell_total = cell_total + s% RSP_Et(k)
       end function cell_specific_total_energy
-      
+
       
       subroutine eval_integrated_total_energy_profile(s, arr, direction, ierr)
          type (star_info), pointer :: s
@@ -2291,8 +2285,7 @@
             total_radial_kinetic_energy, total_rotational_kinetic_energy, &
             total_turbulent_energy, sum_total
          integer :: k
-         real(dp) :: rR, rL, rC, dVR, dV, dm, m_cntr, rho, egas, v, sum_dm, &
-            cell_total, cell1, d_dv00, d_dvp1, d_dlnR00, d_dlnRp1
+         real(dp) :: dm, sum_dm, cell_total, cell1, d_dv00, d_dvp1, d_dlnR00, d_dlnRp1
          include 'formats'
          
          total_internal_energy = 0d0
@@ -2356,8 +2349,7 @@
          real(dp), intent(out), dimension(:) :: total_energy_profile
 
          integer :: k
-         real(dp) :: rR, rL, rC, dVR, dV, dm, m_cntr, rho, egas, v, &
-            cell_total, cell1, d_dv00, d_dvp1, d_dlnR00, d_dlnRp1
+         real(dp) :: dm, cell_total, cell1, d_dv00, d_dvp1, d_dlnR00, d_dlnRp1
          include 'formats'
          
          do k=1, s%nz
@@ -2388,7 +2380,7 @@
          end do
             
       end subroutine eval_total_energy_profile
-      
+
       
       real(dp) function eval_cell_section_total_energy( &
             s, klo, khi) result(sum_total)
@@ -2549,7 +2541,7 @@
              s% xa(c12,nz) > c12_limit) return
          after_C_burn = .true.
       end function after_C_burn
-      
+
       
       integer function lookup_nameofvar(s, namestr)
          type (star_info), pointer :: s
@@ -2563,7 +2555,7 @@
             end if
          end do
       end function lookup_nameofvar
-      
+
       
       integer function lookup_nameofequ(s, namestr)
          type (star_info), pointer :: s
@@ -2659,7 +2651,7 @@
 
       end subroutine weighed_smoothing
 
-      
+
       subroutine threshold_smoothing (dd, dd_thresh, n, ns, preserve_sign, ddold)
 
         ! Same as weighed_smoothing, but only smooth contiguous regions where |dd| >= dd_thresh
@@ -2717,7 +2709,7 @@
         return
 
       end subroutine threshold_smoothing
-      
+
 
       real(dp) function eval_kh_timescale(G,M,R,L) result(kh)
          real(dp), intent(in) :: G,M,R,L
@@ -2727,7 +2719,6 @@
             kh = 0.75d0*G*M*M/(R*L) ! 0.75 is based on sun.  Hansen & Kawaler eqn 1.30
          end if
       end function eval_kh_timescale
-
 
 
       real(dp) function yrs_for_init_timestep(s)
@@ -2744,8 +2735,7 @@
          use rates_def, only: i_rate
          use chem_def
          type (star_info), pointer :: s
-         real(dp) :: power_he_burn, power_c_burn, power_neutrinos, &
-            center_h1, center_he4
+         real(dp) :: center_h1, center_he4
          integer :: nz, j
          include 'formats'
          nz = s% nz
@@ -2753,7 +2743,6 @@
          s% phase_of_evolution = phase_starting
          if (s%doing_first_model_of_run) return
 
-         
          j = s% net_iso(ih1)
          if (j > 0) then
             center_h1 = center_avg_x(s,j)
@@ -2803,8 +2792,7 @@
          
       end subroutine set_phase_of_evolution
 
-      
-      
+
       subroutine set_rv_info(s,k)
          type (star_info), pointer :: s
          integer, intent(in) :: k
@@ -2819,7 +2807,7 @@
             s% vc(k) = 0d0
          end if
       end subroutine set_rv_info
-      
+
       
       subroutine show_matrix(s, dmat, nvar)
          type (star_info), pointer :: s
@@ -2850,9 +2838,6 @@
          type (star_info), pointer :: s
          integer, intent(in) :: i, j, k, nvar
          real(dp), intent(in) :: v
-         integer :: b, q, v00
-         real(qp) :: q1, q2
-         !logical, parameter :: dbg = .true.
          logical, parameter :: dbg = .false.
          include 'formats'
          
@@ -2908,9 +2893,6 @@
          type (star_info), pointer :: s
          integer, intent(in) :: i, j, k, nvar
          real(dp), intent(in) :: v
-         integer :: b, q, vm1
-         real(qp) :: q1, q2
-         !logical, parameter :: dbg = .true.
          logical, parameter :: dbg = .false.
          if (k == 1) return
          include 'formats'
@@ -2963,7 +2945,6 @@
          type (star_info), pointer :: s
          integer, intent(in) :: i, j, k, nvar
          real(dp), intent(in) :: v
-         integer :: vp1
          logical, parameter :: dbg = .false.
          include 'formats'
          
@@ -3074,7 +3055,6 @@
 
          ! interpolant f(dq) = a + b*dq + (c/2)*dq^2, with dq = q - q_midpoint
          ! c0 holds a's, c1 holds b's, and c2 holds c's.
-
 
 
       subroutine get1_lpp(k, nz, &
@@ -3285,7 +3265,7 @@
          if (s% use_other_pressure) Ptot_ad = Ptot_ad + s% extra_pressure(k)
 
       end subroutine calc_Ptot_ad_tw
-      
+
       
       subroutine get_Pvsc_ad(s, k, Pvsc, ierr)
          use auto_diff
@@ -3316,7 +3296,7 @@
          s% Pvsc(k) = Pvsc%val
          if (Pvsc_start < 0d0) s% Pvsc_start(k) = s% Pvsc(k)
       end subroutine get_Pvsc_ad
-      
+
       
       ! marsaglia and zaman random number generator. period is 2**43 with
       ! 900 million different sequences. the state of the generator (for restarts)
@@ -3351,7 +3331,7 @@
          s% rand_i97 = 97
          s% rand_j97 = 33
       end subroutine init_random
-      
+
       
       real(dp) function rand(s)
          type (star_info), pointer :: s      
@@ -3393,7 +3373,7 @@
             end if
          end if
       end subroutine write_to_extra_terminal_output_file
-      
+
       
       subroutine write_eos_call_info(s,k)
          use chem_def
@@ -3458,7 +3438,6 @@
 
 
       real(dp) function surface_avg_x(s,j)
-         use chem_def, only: chem_isos
          type (star_info), pointer :: s
          integer, intent(in) :: j
          real(dp) :: sum_x, sum_dq
@@ -3503,7 +3482,7 @@
          end do
          center_avg_x = sum_x/sum_dq
       end function center_avg_x
-      
+
       
       subroutine get_area_info_opt_time_center(s, k, area, inv_R2, ierr)
          use auto_diff_support
@@ -3523,7 +3502,7 @@
             inv_R2 = 1d0/r2_00
          end if
       end subroutine get_area_info_opt_time_center
-      
+
       
       subroutine set_energy_eqn_scal(s, k, scal, ierr) ! 1/(erg g^-1 s^-1)
          type (star_info), pointer :: s
@@ -3545,7 +3524,7 @@
          end if
          scal = scal*s% dt/s% energy_start(k)
       end subroutine set_energy_eqn_scal
-      
+
       
       real(dp) function conv_time_scale(s,k_in) result(tau_conv)
          type (star_info), pointer :: s
@@ -3576,7 +3555,7 @@
             tau_conv = 0d0
          end if
       end function conv_time_scale
-      
+
       
       subroutine set_conv_time_scales(s)
          type (star_info), pointer :: s
@@ -3599,7 +3578,7 @@
          if (s% max_conv_time_scale == 0d0) s% max_conv_time_scale = 1d99
          if (s% min_conv_time_scale == 1d99) s% min_conv_time_scale = 0d0
       end subroutine set_conv_time_scales      
-      
+
       
       real(dp) function QHSE_time_scale(s,k) result(tau_qhse)
          type (star_info), pointer :: s
@@ -3614,16 +3593,16 @@
          end if
          tau_qhse = abs_dv/(s% cgrav(k)*s% m_grav(k)/pow2(s% r(k)))
       end function QHSE_time_scale
+
       
-      
-      
+
       
       real(dp) function eps_nuc_time_scale(s,k) result(tau_epsnuc)
          type (star_info), pointer :: s
          integer, intent(in) :: k
          tau_epsnuc = s% Cp(k)*s% T(k)/max(1d-10,abs(s% eps_nuc(k)))
       end function eps_nuc_time_scale
-      
+
       
       real(dp) function cooling_time_scale(s,k) result(tau_cool)
          type (star_info), pointer :: s
@@ -3632,7 +3611,7 @@
          thermal_conductivity = (4d0*crad*clight*pow3(s% T(k)))/(3d0*s% opacity(k)*s% rho(k)*s% Cp(k))
          tau_cool = pow2(s% scale_height(k)) / thermal_conductivity
       end function cooling_time_scale
-      
+
       
       function get_rho_face(s,k) result(rho_face)
          type (star_info), pointer :: s
@@ -3646,7 +3625,7 @@
          call get_face_weights(s, k, alfa, beta)
          rho_face = alfa*wrap_d_00(s,k) + beta*wrap_d_m1(s,k)
       end function get_rho_face
-      
+
       
       real(dp) function get_rho_face_val(s,k) result(rho_face)
          type (star_info), pointer :: s
@@ -3659,7 +3638,7 @@
          call get_face_weights(s, k, alfa, beta)
          rho_face = alfa*s% rho(k) + beta*s% rho(k-1)
       end function get_rho_face_val
-      
+
       
       function get_T_face(s,k) result(T_face)
          type (star_info), pointer :: s
@@ -3673,7 +3652,7 @@
          call get_face_weights(s, k, alfa, beta)
          T_face = alfa*wrap_T_00(s,k) + beta*wrap_T_m1(s,k)
       end function get_T_face
-      
+
       
       function get_Prad_face(s,k) result(Prad_face)
          type (star_info), pointer :: s
@@ -3681,7 +3660,7 @@
          type(auto_diff_real_star_order1) :: Prad_face
          Prad_face = crad*pow4(get_T_face(s,k))/3d0
       end function get_Prad_face
-      
+
       
       function get_Peos_face(s,k) result(Peos_face)
          type (star_info), pointer :: s
@@ -3695,7 +3674,7 @@
          call get_face_weights(s, k, alfa, beta)
          Peos_face = alfa*wrap_Peos_00(s,k) + beta*wrap_Peos_m1(s,k)
       end function get_Peos_face
-      
+
       
       function get_Cp_face(s,k) result(Cp_face)
          type (star_info), pointer :: s
@@ -3709,7 +3688,7 @@
          call get_face_weights(s, k, alfa, beta)
          Cp_face = alfa*wrap_Cp_00(s,k) + beta*wrap_Cp_m1(s,k)
       end function get_Cp_face
-      
+
       
       function get_ChiRho_face(s,k) result(ChiRho_face)
          type (star_info), pointer :: s
@@ -3723,7 +3702,7 @@
          call get_face_weights(s, k, alfa, beta)
          ChiRho_face = alfa*wrap_ChiRho_00(s,k) + beta*wrap_ChiRho_m1(s,k)
       end function get_ChiRho_face
-      
+
       
       function get_ChiT_face(s,k) result(ChiT_face)
          type (star_info), pointer :: s
@@ -3737,7 +3716,7 @@
          call get_face_weights(s, k, alfa, beta)
          ChiT_face = alfa*wrap_ChiT_00(s,k) + beta*wrap_ChiT_m1(s,k)
       end function get_ChiT_face
-      
+
       
       function get_kap_face(s,k) result(kap_face)
          type (star_info), pointer :: s
@@ -3751,7 +3730,7 @@
          call get_face_weights(s, k, alfa, beta)
          kap_face = alfa*wrap_kap_00(s,k) + beta*wrap_kap_m1(s,k)
       end function get_kap_face
-      
+
       
       function get_grada_face(s,k) result(grada_face)
          type (star_info), pointer :: s
@@ -3765,7 +3744,7 @@
          call get_face_weights(s, k, alfa, beta)
          grada_face = alfa*wrap_grad_ad_00(s,k) + beta*wrap_grad_ad_m1(s,k)
       end function get_grada_face
-      
+
       
       function get_gradr_face(s,k) result(gradr)
          type (star_info), pointer :: s
@@ -3779,7 +3758,7 @@
          Pr = get_Prad_face(s,k)
          gradr = P*opacity*L/(16d0*pi*clight*s% m_grav(k)*s% cgrav(k)*Pr) 
       end function get_gradr_face
-      
+
       
       function get_scale_height_face(s,k) result(scale_height)
          type (star_info), pointer :: s
@@ -3802,7 +3781,7 @@
             end if
          end if
       end function get_scale_height_face
-      
+
       
       real(dp) function get_scale_height_face_val(s,k) result(scale_height)
          type (star_info), pointer :: s
@@ -3826,7 +3805,7 @@
          end if
       end function get_scale_height_face_val
 
-      
+
       function get_QQ_cell(s,k) result(QQ_cell)
          type (star_info), pointer :: s
          integer, intent(in) :: k
@@ -3839,7 +3818,7 @@
          chiRho_00 = wrap_chiRho_00(s,k)
          QQ_cell = chiT_00/(d_00*T_00*chiRho_00)
       end function get_QQ_cell
-      
+
       
       subroutine get_face_weights(s, k, alfa, beta)
          type (star_info), pointer :: s
@@ -3926,6 +3905,6 @@
          s% alpha_RTI(1:s% nz) = 0d0
          s% need_to_setvars = .true.
       end subroutine set_zero_alpha_RTI
-      
+
 
       end module star_utils

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -273,10 +273,8 @@
 
 
       subroutine save_start_values(s, ierr)
-         use chem_def, only: num_categories
          use hydro_rsp2, only: set_etrb_start_vars
          use star_utils, only: eval_total_energy_integrals, set_luminosity_by_category
-         use chem_def, only: ih1
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
          integer :: k, j
@@ -513,7 +511,7 @@
 
          logical :: converged
          integer :: k, species, ierr, j1, j2, gold_tolerances_level
-         real(dp) :: r003, maxT
+         real(dp) :: maxT
 
          include 'formats'
 
@@ -967,7 +965,7 @@
          use net_lib, only: net_1_zone_burn_const_density, net_1_zone_burn, &
             show_net_reactions_and_info
          use rates_def, only: std_reaction_Qs, std_reaction_neuQs
-         use chem_def, only: chem_isos, num_categories, category_name
+         use chem_def, only: num_categories
          use net, only: do1_net
          use star_utils, only: store_lnT_in_xh, get_T_and_lnT_from_xh
          type (star_info), pointer :: s
@@ -1185,7 +1183,6 @@
 
 
          subroutine burn_finish_substep(nstp, time, y, ierr)
-            use chem_def, only: category_name
             integer,intent(in) :: nstp
             real(dp), intent(in) :: time, y(:)
             integer, intent(out) :: ierr

--- a/star/private/timestep.f90
+++ b/star/private/timestep.f90
@@ -101,7 +101,7 @@
          type (star_info), pointer :: s
          real(dp), intent(in) :: dt ! timestep just completed
 
-         real(dp) :: dt_limit_ratio(numTlim), dt_limit, limit, order, max_timestep_factor
+         real(dp) :: dt_limit_ratio(numTlim), order, max_timestep_factor
          integer :: i_limit, nz, ierr
          logical :: skip_hard_limit
          integer :: num_mix_boundaries ! boundaries of regions with mixing_type /= no_mixing
@@ -375,7 +375,6 @@
 
          logical function return_now(i_limit)
             integer, intent(in) :: i_limit
-            integer :: k
             if (do_timestep_limits == keep_going) then
                return_now = .false.
                return
@@ -420,7 +419,7 @@
          logical, intent(in) :: skip_hard_limit
          real(dp), intent(in) :: dt
          real(dp), intent(inout) :: dt_limit_ratio
-         integer :: max_steps, i
+         integer :: max_steps
          check_burn_steps_limit = keep_going
          if (.not. s% op_split_burn .or. maxval(s% T_start(1:s%nz)) < s% op_split_burn_min_T) return
  
@@ -2189,9 +2188,9 @@
          subroutine do1(k)
             integer, intent(in) :: k
 
-            integer :: j, jj, ii
+            integer :: j
             real(dp) :: dx, dx_drop, dm, dt_dm, dx_burning, dx_inflow, dxdt_nuc
-            real(dp) ::dx00, dxp1, sig00, sigp1, flux00, fluxp1
+            real(dp) :: dx00, dxp1, sig00, sigp1, flux00, fluxp1
 
             include 'formats'
 
@@ -2320,7 +2319,7 @@
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
 
-         integer :: j, nterms, nvar_hydro, nz, k, kk
+         integer :: j, nterms, nvar_hydro, nz, k
          real(dp) :: sumj, sumvar, sumscales, sumterm(s% nvar_total)
          real(dp), parameter :: xscale_min = 1
 

--- a/star/private/turb_info.f90
+++ b/star/private/turb_info.f90
@@ -83,7 +83,6 @@
          use star_utils
          use turb_support, only: do1_mlt_eval
          use eos_def
-         use chem_def, only: ih1
          use auto_diff_support
          type (star_info), pointer :: s
          integer, intent(in) :: k
@@ -93,10 +92,9 @@
             mixing_length_alpha_in, gradL_composition_term_in
 
          type(auto_diff_real_star_order1) :: gradr_factor
-         real(dp) :: v, f, xh_face, &
-            gradL_composition_term, abs_du_div_cs, cs, mixing_length_alpha
+         real(dp) :: f, gradL_composition_term, abs_du_div_cs, cs, mixing_length_alpha
          real(dp), pointer :: vel(:)
-         integer :: i, mixing_type, h1, nz, k_T_max
+         integer :: i, mixing_type, nz, k_T_max
          real(dp), parameter :: conv_vel_mach_limit = 0.9d0
          real(dp) :: crystal_pad
          logical :: no_mix
@@ -425,7 +423,7 @@
          use chem_def, only: ih1, ihe4
          type (star_info), pointer :: s
          integer, intent(out) :: ierr
-         real(dp) :: beta, lambda, phi, tmp, alpha, alpha2, &
+         real(dp) :: beta, lambda, tmp, alpha, &
             beta_limit, lambda1, beta1, lambda2, beta2, dlambda, dbeta
          integer :: k, k_beta, k_lambda, nz, h1, he4
          include 'formats'
@@ -575,7 +573,7 @@
          contains
 
          subroutine end_of_convective_region()
-            integer :: kk, op_err, mix_type
+            integer :: kk, op_err
             real(dp) :: Hp
             logical :: end_dbg
             9 format(a40, 3i7, 99(1pd26.16))

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -119,8 +119,8 @@ contains
          gradT, Y_face, mlt_vc, D, Gamma
       integer, intent(out) :: ierr 
               
-      real(dp) :: cgrav, m, XH1, gradL_old, grada_face_old
-      integer :: iso, old_mix_type
+      real(dp) :: cgrav, m, XH1
+      integer :: iso
       type(auto_diff_real_star_order1) :: gradr, r, L, T, P, opacity, rho, dV, chiRho, chiT, Cp
       include 'formats'
       ierr = 0
@@ -190,8 +190,7 @@ contains
       real(dp) :: Gamma_limit, scale_value1, scale_value2, diff_grads_limit, reduction_limit, lambda_limit
       type(auto_diff_real_star_order1) :: Lrad_div_Ledd, Gamma_inv_threshold, Gamma_factor, alfa0, &
          diff_grads_factor, Gamma_term, exp_limit, grad_scale, gradr_scaled
-
-      character (len=256) :: message        
+     
       logical ::  test_partials, using_TDC
       logical, parameter :: report = .false.
       include 'formats'

--- a/star/private/winds.f90
+++ b/star/private/winds.f90
@@ -64,15 +64,15 @@
          real(dp), intent(in) :: L_phot, M_phot, T_phot ! photosphere values (cgs)
          integer, intent(out) :: ierr
 
-         integer :: k, j, h1, he4, nz, base
-         real(dp) :: max_ejection_mass, wind_mdot, wind, alfa, total_H, &
+         integer :: h1, he4, nz
+         real(dp) :: wind_mdot, wind, alfa, &
             X, Y, Z, w1, w2, T_high, T_low, L1, M1, R1, T1, &
-            log_dtyr, log_dtyr_full_off, log_dtyr_full_on, beta, divisor, &
+            beta, divisor, &
             center_h1, center_he4, surface_h1, surface_he4, mdot, xfer_ratio, &
             L_div_Ledd, full_off, full_on, max_boost, super_eddington_boost, &
             hot_wind, cool_wind, H_env_mass, H_He_env_mass, He_layer_mass
-         character (len=strlen) :: message, cool_wind_scheme, hot_wind_scheme, scheme
-         logical :: is_infalling, using_wind_scheme_mdot, use_other
+         character (len=strlen) :: scheme
+         logical :: using_wind_scheme_mdot, use_other
          real(dp), parameter :: Zsolar = 0.019d0 ! for Vink et al formula
 
          logical, parameter :: dbg = .false.
@@ -425,7 +425,7 @@
             !       Osurf_crit^2 = (1 - Gamma_edd)*G*M/R_equatorial^3
             !       Gamma_edd = kappa*L/(4 pi c G M), Eddington factor
             real(dp) :: enhancement, wind_mdot, wind_mdot_lim, &
-               kh_timescale, mdot_lim, wind_mdot_prev, dmsfac, dmskhf
+               kh_timescale, wind_mdot_prev, dmsfac, dmskhf
 
             include 'formats'
 

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -558,7 +558,7 @@
             ! false if this is a repeat for a retry
          type (star_info), pointer :: s
          integer :: ierr
-         integer(8) :: time0, clock_rate
+         integer(8) :: time0
          real(dp) :: total
          star_evolve_step = terminate
          ierr = 0
@@ -2097,7 +2097,7 @@
             res, dres_dlnRho, dres_dlnT
          real(dp), intent(out) :: dres_dxa(:,:)
          integer, intent(out) :: ierr
-         type (star_info), pointer :: s
+         !type (star_info), pointer :: s
          !ierr = 0
          !call star_ptr(id, s, ierr)
          !if (ierr /= 0) return


### PR DESCRIPTION
Cleaning up unused variables and some formatting in `star`.

The goal is that we will be able to turn a "best-practice" set of Fortran compiler warning flags for good development practices and minimize bugs, but first I need to clean up warnings

Changes in this PR should not affect how the code performs