### PR TITLE
[skip ci] fix and expand file_device and file_extension documentation

### DIFF
--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -87,14 +87,24 @@
 
       ! file_device
       ! ~~~~~~~~~~~
-      ! file_extension
-      ! ~~~~~~~~~~~~~~
 
-      ! 'png' is Portable Network Graphics format; can also use 'pdf'
+      ! 'png' is Portable Network Graphics format
+      ! can also use:
+      ! 'ps' (in combination with file_extension = 'ps') for PostScript
+      ! or:
+      ! 'vcps' (in combination with file_extension = 'eps') for Encapsulated PostScript
 
       ! ::
 
     file_device = 'png'
+
+      ! file_extension
+      ! ~~~~~~~~~~~~~~
+
+      ! Can use: 'png', 'ps', or 'eps' with the appropriate file_device
+
+      ! ::
+
     file_extension = 'png'
 
 


### PR DESCRIPTION
Regarding this mailing list request: https://lists.mesastar.org/pipermail/mesa-users/2024-August/015307.html

Documentation was incorrectly suggesting `pdf` files can be produced directly from pgplots and the option to produce `ps` and `eps` were instead not documented. 