### PR TITLE
removing file_extension user option

### DIFF
--- a/binary/defaults/pgbinary.defaults
+++ b/binary/defaults/pgbinary.defaults
@@ -87,15 +87,14 @@
 
       ! file_device
       ! ~~~~~~~~~~~
-      ! file_extension
-      ! ~~~~~~~~~~~~~~
 
-      ! 'png' is Portable Network Graphics format; can also use 'pdf'
+      ! 'png' for Portable Network Graphics format
+      ! 'vcps' for Color PostScript ('ps')
+      ! 'ps' for PostScript
 
       ! ::
 
    file_device = 'png'
-   file_extension = 'png'
 
 
       ! file_digits

--- a/binary/private/pgbinary_ctrls_io.f90
+++ b/binary/private/pgbinary_ctrls_io.f90
@@ -35,7 +35,6 @@ module pgbinary_ctrls_io
    namelist /pgbinary/ &
 
       file_device, &
-      file_extension, &
       file_digits, &
       pgbinary_interval, &
       pause, &
@@ -1455,7 +1454,6 @@ contains
       pg => b% pg
 
       pg% file_device = file_device
-      pg% file_extension = file_extension
       pg% file_digits = file_digits
       pg% pgbinary_interval = pgbinary_interval
       pg% pause = pause

--- a/binary/private/pgbinary_support.f90
+++ b/binary/private/pgbinary_support.f90
@@ -169,6 +169,7 @@ contains
       character (len = *), intent(in) :: dir, prefix
       character (len = *), intent(out) :: name
       character (len = strlen) :: num_str, fstring
+      character (len = 4) :: file_extension
       write(fstring, '( "(i",i2.2,".",i2.2,")" )') &
          b% pg% file_digits, b% pg% file_digits
       write(num_str, fstring) b% model_number
@@ -177,7 +178,12 @@ contains
       else
          name = prefix
       end if
-      name = trim(name) // trim(num_str) // '.' // trim(b% pg% file_extension)
+      if (b%pg%file_device=='vcps') then
+         file_extension = 'ps'
+      else
+         file_extension = b%pg%file_device
+      end if
+      name = trim(name) // trim(num_str) // '.' // trim(file_extension)
    end subroutine create_file_name
 
 

--- a/binary/test_suite/evolve_both_stars/README.rst
+++ b/binary/test_suite/evolve_both_stars/README.rst
@@ -40,10 +40,7 @@ pgstar commands used for the binary and star1 plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 
@@ -246,10 +243,7 @@ pgstar commands used for the star2 plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 

--- a/binary/test_suite/jdot_gr_check/README.rst
+++ b/binary/test_suite/jdot_gr_check/README.rst
@@ -37,10 +37,7 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 

--- a/binary/test_suite/jdot_ls_check/README.rst
+++ b/binary/test_suite/jdot_ls_check/README.rst
@@ -23,10 +23,7 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 

--- a/binary/test_suite/jdot_ml_check/README.rst
+++ b/binary/test_suite/jdot_ml_check/README.rst
@@ -43,10 +43,7 @@ pgstar commands used for the binary and star1 plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 

--- a/binary/test_suite/star_plus_point_mass/README.rst
+++ b/binary/test_suite/star_plus_point_mass/README.rst
@@ -41,10 +41,7 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 

--- a/binary/test_suite/star_plus_point_mass_explicit_mdot/README.rst
+++ b/binary/test_suite/star_plus_point_mass_explicit_mdot/README.rst
@@ -40,10 +40,7 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 1
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,16 @@ Changelog
 Changes in main
 ===============
 
+.. _Backwards-incompatible changes main:
+
+Backwards-incompatible changes
+------------------------------
+
+``pgstar`` / ``pgbinary``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Removed `file_extension` option because it is redundant with `file_device`. Delete `file_extension` from your inlists.
+
 .. _New Features main:
 
 New Features

--- a/docs/source/using_mesa/using_pgstar.rst
+++ b/docs/source/using_mesa/using_pgstar.rst
@@ -438,12 +438,10 @@ PGSTAR has a number of options to control its file output.
 The default output format is PNG::
 
   file_device = 'png'
-  file_extension = 'png'
 
 but you can use PostScript output by setting::
 
   file_device = 'vcps'
-  file_extension = 'ps'
 
 You can change the foreground/background color of your plots between
 black/white and white/black::

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -88,24 +88,13 @@
       ! file_device
       ! ~~~~~~~~~~~
 
-      ! 'png' is Portable Network Graphics format
-      ! can also use:
-      ! 'ps' (in combination with file_extension = 'ps') for PostScript
-      ! or:
-      ! 'vcps' (in combination with file_extension = 'eps') for Encapsulated PostScript
+      ! 'png' for Portable Network Graphics format
+      ! 'vcps' for Color PostScript ('ps')
+      ! 'ps' for PostScript
 
       ! ::
 
     file_device = 'png'
-
-      ! file_extension
-      ! ~~~~~~~~~~~~~~
-
-      ! Can use: 'png', 'ps', or 'eps' with the appropriate file_device
-
-      ! ::
-
-    file_extension = 'png'
 
 
       ! file_digits
@@ -121,7 +110,7 @@
       ! delta_HR_limit_for_file_output
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! trigger file output by distance travelled on HR diagram
+      ! trigger file output by distance traveled on HR diagram
       ! negative means no limit
       ! HR distance since last file output = sum of dHR
       ! where per step dHR = same definition as used for timestep limits

--- a/star/private/pgstar_ctrls_io.f90
+++ b/star/private/pgstar_ctrls_io.f90
@@ -36,7 +36,6 @@
       namelist /pgstar/ &
 
             file_device, &
-            file_extension, &
             file_digits, &
             pgstar_interval, &
             pause, &
@@ -3154,7 +3153,6 @@
          ierr = 0
 
          s% pg% file_device = file_device
-         s% pg% file_extension = file_extension
          s% pg% file_digits = file_digits
          s% pg% pgstar_interval = pgstar_interval
          s% pg% pause = pause

--- a/star/private/pgstar_support.f90
+++ b/star/private/pgstar_support.f90
@@ -203,6 +203,7 @@ contains
       character (len = *), intent(in) :: dir, prefix
       character (len = *), intent(out) :: name
       character (len = strlen) :: num_str, fstring
+      character (len = 4) :: file_extension
       write(fstring, '( "(i",i2.2,".",i2.2,")" )') s% pg% file_digits, s% pg% file_digits
       write(num_str, fstring) s% model_number
       if (len_trim(dir) > 0) then
@@ -210,7 +211,13 @@ contains
       else
          name = prefix
       end if
-      name = trim(name) // trim(num_str) // '.' // trim(s% pg% file_extension)
+      if (s%pg%file_device=='vcps') then
+         file_extension = 'ps'
+      else
+         ! e.g.: png, ps
+         file_extension = s%pg%file_device
+      end if
+      name = trim(name) // trim(num_str) // '.' // trim(file_extension)
    end subroutine create_file_name
 
 

--- a/star/test_suite/1.3M_ms_high_Z/inlist_pgstar
+++ b/star/test_suite/1.3M_ms_high_Z/inlist_pgstar
@@ -3,12 +3,9 @@
    ! MESA uses PGPLOT for live plotting and gives the user a tremendous
    ! amount of control of the presentation of the information.
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps'      ! postscript
-   file_extension = 'ps'
    !file_device = 'png'      ! png
-   !file_extension = 'png'
 
    pgstar_interval = 10
 

--- a/star/test_suite/1.4M_ms_op_mono/README.rst
+++ b/star/test_suite/1.4M_ms_op_mono/README.rst
@@ -41,11 +41,8 @@ pgstar commands used for the plots above:
 
    pgstar_interval = 10
 
-  ! device
-
    file_white_on_black_flag = .true. 
-   file_device = 'vcps'
-   file_extension = 'ps'           
+   file_device = 'vcps'      
 
   ! two profile panels
     Profile_Panels1_win_flag = .true.

--- a/star/test_suite/1.5M_with_diffusion/inlist_1.5M_with_diffusion
+++ b/star/test_suite/1.5M_with_diffusion/inlist_1.5M_with_diffusion
@@ -151,10 +151,8 @@
 
    pgstar_interval = 50
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps' ! postscript
-   file_extension = 'ps'
 
    Abundance_win_flag = .false. ! switch to .true. to visualize in real-time
    Abundance_file_flag = .true.

--- a/star/test_suite/1.5M_with_diffusion/inlist_to_ZAMS
+++ b/star/test_suite/1.5M_with_diffusion/inlist_to_ZAMS
@@ -74,10 +74,8 @@
 
    pgstar_interval = 50
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps' ! postscript
-   file_extension = 'ps'
 
    Grid2_win_flag = .false. ! switch to .true. to visualize in real-time
    file_digits = 7

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_pgstar
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_pgstar
@@ -667,13 +667,7 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
 !file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
 
 kipp_win_flag=.true.
 kipp_file_flag=.true.

--- a/star/test_suite/15M_dynamo/README.rst
+++ b/star/test_suite/15M_dynamo/README.rst
@@ -62,10 +62,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    !file_device = 'png'            ! png
-   !file_extension = 'png'
 
    file_device = 'vcps'          ! postscript
-   file_extension = 'ps'
 
     pgstar_interval = 10
     file_digits = 8

--- a/star/test_suite/15M_dynamo/inlist_common
+++ b/star/test_suite/15M_dynamo/inlist_common
@@ -92,10 +92,7 @@
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   file_device = 'png'            ! png
-  file_extension = 'png'
-
   !file_device = 'vcps'          ! postscript
-  !file_extension = 'ps'
 
    pgstar_interval = 50
    file_digits = 8

--- a/star/test_suite/16M_conv_premix/README.rst
+++ b/star/test_suite/16M_conv_premix/README.rst
@@ -30,10 +30,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
     file_digits = 8

--- a/star/test_suite/16M_predictive_mix/README.rst
+++ b/star/test_suite/16M_predictive_mix/README.rst
@@ -30,10 +30,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
     file_digits = 8

--- a/star/test_suite/1M_pre_ms_to_wd/README.rst
+++ b/star/test_suite/1M_pre_ms_to_wd/README.rst
@@ -44,10 +44,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
     file_digits = 8

--- a/star/test_suite/1M_thermohaline/README.rst
+++ b/star/test_suite/1M_thermohaline/README.rst
@@ -62,10 +62,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
     file_digits = 8

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_pgstar
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_pgstar
@@ -667,13 +667,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
 
 kipp_win_flag=.true.
 kipp_file_flag=.true.

--- a/star/test_suite/20M_z2m2_high_rotation/README.rst
+++ b/star/test_suite/20M_z2m2_high_rotation/README.rst
@@ -21,10 +21,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
     file_digits = 8

--- a/star/test_suite/20M_z2m2_high_rotation/inlist_pgstar
+++ b/star/test_suite/20M_z2m2_high_rotation/inlist_pgstar
@@ -677,13 +677,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
 
 
 / ! end of pgstar namelist

--- a/star/test_suite/5M_cepheid_blue_loop/README.rst
+++ b/star/test_suite/5M_cepheid_blue_loop/README.rst
@@ -24,10 +24,8 @@ pgstar commands used:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
 

--- a/star/test_suite/7M_prems_to_AGB/inlist_pgstar
+++ b/star/test_suite/7M_prems_to_AGB/inlist_pgstar
@@ -1,11 +1,8 @@
 &pgstar
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps'      ! postscript
-   file_extension = 'ps'
    !file_device = 'png'      ! png
-   !file_extension = 'png'
 
    pgstar_interval = 10
 

--- a/star/test_suite/accreted_material_j/inlist_pgstar
+++ b/star/test_suite/accreted_material_j/inlist_pgstar
@@ -1,11 +1,8 @@
 &pgstar
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps'      ! postscript
-   file_extension = 'ps'
    !file_device = 'png'      ! png
-   !file_extension = 'png'
 
    pgstar_interval = 10
 

--- a/star/test_suite/adjust_net/README.rst
+++ b/star/test_suite/adjust_net/README.rst
@@ -38,10 +38,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
 

--- a/star/test_suite/cburn_inward/README.rst
+++ b/star/test_suite/cburn_inward/README.rst
@@ -47,10 +47,8 @@ pgstar commands used for the plots above:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 1
 

--- a/star/test_suite/ccsn_IIp/README.rst
+++ b/star/test_suite/ccsn_IIp/README.rst
@@ -59,11 +59,8 @@ pgstar commands used for the first 7 plots:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
-
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
-
+   
     pgstar_interval = 10
 
   pgstar_grid_title_disp = 1.8
@@ -245,10 +242,8 @@ pgstar commands used for the 8th plot:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 1
 

--- a/star/test_suite/conductive_flame/inlist_pgstar
+++ b/star/test_suite/conductive_flame/inlist_pgstar
@@ -1,11 +1,8 @@
 &pgstar
 
-   ! device
    file_white_on_black_flag = .true.
-   !file_device = 'vcps'      ! postscript
-   !file_extension = 'ps'
+   !file_device = 'vcps'    ! postscript
    file_device = 'png'      ! png
-   file_extension = 'png'
 
    pgstar_interval = 1
    pause = .false.

--- a/star/test_suite/conserve_angular_momentum/README.rst
+++ b/star/test_suite/conserve_angular_momentum/README.rst
@@ -24,10 +24,8 @@ pgstar commands used for the first 7 plots:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
 

--- a/star/test_suite/conv_core_cpm/inlist_conv_core_cpm
+++ b/star/test_suite/conv_core_cpm/inlist_conv_core_cpm
@@ -99,7 +99,6 @@
 ! file output
    file_white_on_black_flag = .true.
    file_device = 'vcps'
-   file_extension = 'ps'
    Grid1_file_flag = .true.
    Grid1_file_dir = 'pgstar_out'
    Grid1_file_prefix = 'grid_'

--- a/star/test_suite/custom_colors/README.rst
+++ b/star/test_suite/custom_colors/README.rst
@@ -28,10 +28,8 @@ pgstar commands used for the first 7 plots:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 1
 

--- a/star/test_suite/custom_rates/README.rst
+++ b/star/test_suite/custom_rates/README.rst
@@ -42,10 +42,8 @@ pgstar commands used for the first 7 plots:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
 

--- a/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness
+++ b/star/test_suite/diffusion_smoothness/inlist_diffusion_smoothness
@@ -118,12 +118,9 @@
 
 &pgstar
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps'      ! postscript
-   file_extension = 'ps'
    !file_device = 'png'      ! png
-   !file_extension = 'png'
 
    pgstar_interval = 1
 

--- a/star/test_suite/extended_convective_penetration/README.rst
+++ b/star/test_suite/extended_convective_penetration/README.rst
@@ -85,10 +85,8 @@ pgstar commands used for the plot:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    file_device = 'png'            ! png
-   file_extension = 'png'
 
    !file_device = 'vcps'          ! postscript
-   !file_extension = 'ps'
 
     pgstar_interval = 10
 

--- a/star/test_suite/high_mass/inlist_pgstar
+++ b/star/test_suite/high_mass/inlist_pgstar
@@ -1,11 +1,8 @@
 &pgstar
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps'      ! postscript
-   file_extension = 'ps'
    !file_device = 'png'      ! png
-   !file_extension = 'png'
 
    pgstar_interval = 10
 

--- a/star/test_suite/high_z/README.rst
+++ b/star/test_suite/high_z/README.rst
@@ -29,10 +29,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/hot_cool_wind/README.rst
+++ b/star/test_suite/hot_cool_wind/README.rst
@@ -28,10 +28,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/hse_riemann/README.rst
+++ b/star/test_suite/hse_riemann/README.rst
@@ -27,10 +27,8 @@ pgstar commands used for the plots that ake the movie above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 2
 

--- a/star/test_suite/irradiated_planet/README.rst
+++ b/star/test_suite/irradiated_planet/README.rst
@@ -30,10 +30,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/low_z/README.rst
+++ b/star/test_suite/low_z/README.rst
@@ -30,10 +30,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/make_brown_dwarf/README.rst
+++ b/star/test_suite/make_brown_dwarf/README.rst
@@ -22,10 +22,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/make_env/README.rst
+++ b/star/test_suite/make_env/README.rst
@@ -22,10 +22,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/make_he_wd/README.rst
+++ b/star/test_suite/make_he_wd/README.rst
@@ -33,10 +33,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
    pgstar_interval = 10
 

--- a/star/test_suite/make_metals/README.rst
+++ b/star/test_suite/make_metals/README.rst
@@ -33,10 +33,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/make_o_ne_wd/inlist_pgstar
+++ b/star/test_suite/make_o_ne_wd/inlist_pgstar
@@ -673,14 +673,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 / ! end of pgstar namelist
 

--- a/star/test_suite/make_planets/README.rst
+++ b/star/test_suite/make_planets/README.rst
@@ -34,10 +34,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/make_pre_ccsn_13bvn/inlist_pgstar
+++ b/star/test_suite/make_pre_ccsn_13bvn/inlist_pgstar
@@ -13,14 +13,6 @@ pgstar_show_age = .true.
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 ! Text_Summary windows
 

--- a/star/test_suite/make_sdb/README.rst
+++ b/star/test_suite/make_sdb/README.rst
@@ -22,10 +22,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/make_zams/inlist_zams
+++ b/star/test_suite/make_zams/inlist_zams
@@ -52,7 +52,6 @@
 
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/make_zams_low_mass/README.rst
+++ b/star/test_suite/make_zams_low_mass/README.rst
@@ -22,10 +22,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/make_zams_ultra_high_mass/README.rst
+++ b/star/test_suite/make_zams_ultra_high_mass/README.rst
@@ -22,10 +22,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/ns_c/README.rst
+++ b/star/test_suite/ns_c/README.rst
@@ -22,10 +22,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
   pgstar_grid_title_disp = 1.8

--- a/star/test_suite/ns_c/inlist_pgstar
+++ b/star/test_suite/ns_c/inlist_pgstar
@@ -668,14 +668,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 / ! end of pgstar namelist
 

--- a/star/test_suite/ns_h/README.rst
+++ b/star/test_suite/ns_h/README.rst
@@ -27,10 +27,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/ns_he/README.rst
+++ b/star/test_suite/ns_he/README.rst
@@ -23,10 +23,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
   pgstar_grid_title_disp = 1.8

--- a/star/test_suite/ns_he/inlist_to_flash
+++ b/star/test_suite/ns_he/inlist_to_flash
@@ -192,10 +192,7 @@ Mixing_xaxis_reversed = .true.
 
  file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
  !file_device = 'png'            ! png
- !file_extension = 'png'
-
  file_device = 'vcps'          ! postscript
- file_extension = 'ps'
 
  pgstar_interval = 10
  pgstar_grid_title_disp = 1.8

--- a/star/test_suite/other_physics_hooks/README.rst
+++ b/star/test_suite/other_physics_hooks/README.rst
@@ -38,10 +38,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/pisn/inlist_pgstar
+++ b/star/test_suite/pisn/inlist_pgstar
@@ -699,14 +699,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 / ! end of pgstar namelist
 

--- a/star/test_suite/radiative_levitation/README.rst
+++ b/star/test_suite/radiative_levitation/README.rst
@@ -27,10 +27,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/rsp_BEP/README.rst
+++ b/star/test_suite/rsp_BEP/README.rst
@@ -28,10 +28,8 @@ pgstar commands, in addition to those in ``inlist_rsp_pgstar_default``, used for
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/rsp_BLAP/README.rst
+++ b/star/test_suite/rsp_BLAP/README.rst
@@ -28,10 +28,8 @@ pgstar commands, in addition to those in ``inlist_rsp_pgstar_default``, used for
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/rsp_Cepheid/README.rst
+++ b/star/test_suite/rsp_Cepheid/README.rst
@@ -27,10 +27,8 @@ pgstar commands, in addition to those in ``inlist_rsp_pgstar_default``, used for
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/rsp_Delta_Scuti/README.rst
+++ b/star/test_suite/rsp_Delta_Scuti/README.rst
@@ -30,10 +30,7 @@ pgstar commands, in addition to those in ``inlist_rsp_pgstar_default``, used for
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/rsp_RR_Lyrae/README.rst
+++ b/star/test_suite/rsp_RR_Lyrae/README.rst
@@ -28,10 +28,8 @@ pgstar commands, in addition to those in ``inlist_rsp_pgstar_default``, used for
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/rsp_Type_II_Cepheid/README.rst
+++ b/star/test_suite/rsp_Type_II_Cepheid/README.rst
@@ -28,10 +28,8 @@ pgstar commands, in addition to those in ``inlist_rsp_pgstar_default`` which cur
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/rsp_save_and_load_file/README.rst
+++ b/star/test_suite/rsp_save_and_load_file/README.rst
@@ -30,10 +30,8 @@ pgstar commands, in addition to those in ``inlist_rsp_common`` and modifcations 
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 100
 

--- a/star/test_suite/semiconvection/README.rst
+++ b/star/test_suite/semiconvection/README.rst
@@ -50,10 +50,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/simplex_solar_calibration/README.rst
+++ b/star/test_suite/simplex_solar_calibration/README.rst
@@ -87,10 +87,8 @@ pgstar commands used for the plot above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
   pgstar_interval = 10
 

--- a/star/test_suite/split_burn_big_net/inlist_pgstar
+++ b/star/test_suite/split_burn_big_net/inlist_pgstar
@@ -675,14 +675,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 / ! end of pgstar namelist
 

--- a/star/test_suite/starspots/inlist_starspots
+++ b/star/test_suite/starspots/inlist_starspots
@@ -143,10 +143,8 @@
 
    pgstar_interval = 50
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps' ! postscript
-   file_extension = 'ps'
 
    HR_win_flag = .true. ! switch to .true. to visualize in real-time
    HR_file_flag = .true.

--- a/star/test_suite/twin_studies/README.rst
+++ b/star/test_suite/twin_studies/README.rst
@@ -39,10 +39,8 @@ for star 1:
   
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    !file_device = 'png'            ! png
-   !file_extension = 'png'
 
    file_device = 'vcps'          ! postscript
-   file_extension = 'ps'
 
    Grid1_file_flag = .true.
    Grid1_file_dir = 'png1'
@@ -62,10 +60,8 @@ and for star 2:
 
    file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
    !file_device = 'png'            ! png
-   !file_extension = 'png'
 
    file_device = 'vcps'          ! postscript
-   file_extension = 'ps'
 
    Grid1_title = 'star2 - without overshooting'
    

--- a/star/test_suite/twin_studies/inlist_pgstar
+++ b/star/test_suite/twin_studies/inlist_pgstar
@@ -667,14 +667,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 / ! end of pgstar namelist
 

--- a/star/test_suite/tzo/inlist_pgstar
+++ b/star/test_suite/tzo/inlist_pgstar
@@ -8,14 +8,6 @@ pgstar_interval=1
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
-
 
 ! Text_Summary windows
 

--- a/star/test_suite/wd_c_core_ignition/README.rst
+++ b/star/test_suite/wd_c_core_ignition/README.rst
@@ -37,10 +37,8 @@ pgstar commands used for the Part 1 plot above:
  &pgstar
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
      Abundance_win_flag = .true.
      Abundance_win_width = 12
@@ -74,10 +72,8 @@ pgstar commands used for the Part 2 plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
      TRho_win_flag = .true.
      TRho_win_width = 12

--- a/star/test_suite/wd_cool_0.6M/README.rst
+++ b/star/test_suite/wd_cool_0.6M/README.rst
@@ -29,10 +29,7 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
          Grid2_win_flag = .true.
          Grid2_win_width = 16

--- a/star/test_suite/wd_diffusion/README.rst
+++ b/star/test_suite/wd_diffusion/README.rst
@@ -29,10 +29,8 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
 
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
         Profile_Panels2_win_flag = .true.
         Profile_Panels2_win_width = 12

--- a/star/test_suite/wd_he_shell_ignition/README.rst
+++ b/star/test_suite/wd_he_shell_ignition/README.rst
@@ -38,11 +38,7 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
-
 
     Profile_Panels2_win_flag = .true.
     Profile_Panels2_win_width = 10

--- a/star/test_suite/wd_nova_burst/inlist_pgstar
+++ b/star/test_suite/wd_nova_burst/inlist_pgstar
@@ -1,11 +1,8 @@
 &pgstar
 
-   ! device
    file_white_on_black_flag = .true.
    file_device = 'vcps'      ! postscript
-   file_extension = 'ps'
    !file_device = 'png'      ! png
-   !file_extension = 'png'
 
    pgstar_interval = 1
 

--- a/star/test_suite/wd_stable_h_burn/README.rst
+++ b/star/test_suite/wd_stable_h_burn/README.rst
@@ -24,12 +24,9 @@ pgstar commands used for the plots above:
 
   file_white_on_black_flag = .true. ! white_on_black flags -- true means white foreground color on black background
   !file_device = 'png'            ! png
-  !file_extension = 'png'
-
   file_device = 'vcps'          ! postscript
-  file_extension = 'ps'
 
-          pgstar_interval = 1
+   pgstar_interval = 1
 
    pgstar_left_yaxis_label_disp = 4.0
 

--- a/star/test_suite/zams_to_cc_80/inlist_pgstar
+++ b/star/test_suite/zams_to_cc_80/inlist_pgstar
@@ -667,13 +667,6 @@ pgstar_model_fjust = 1.0
 ! white_on_black flags -- true means white foreground color on black background
 file_white_on_black_flag = .true.
 file_device = 'png'            ! options 'png' and 'vcps' for png and postscript respectively
-file_extension = 'png'           ! common names are 'png' and 'ps'
-
-
-!file_white_on_black_flag = .false.
-!file_device = 'vcps'            ! options 'png' and 'vcps' for png and postscript respectively
-!file_extension = 'ps'           ! common names are 'png' and 'ps'
-
 
 kipp_win_flag=.true.
 kipp_file_flag=.true.

--- a/star_data/private/pgstar_controls.inc
+++ b/star_data/private/pgstar_controls.inc
@@ -10,7 +10,6 @@
       ! PGstar controls
       integer :: pgstar_interval
       character (len=32) :: file_device
-      character (len=32) :: file_extension
       integer :: file_digits
 
       real :: delta_HR_limit_for_file_output


### PR DESCRIPTION
Inspired by @warrickball 's comment: https://github.com/MESAHub/mesa/pull/721#issuecomment-2308515534

this PR removes the `file_extension` option from inlists for pgstar/pgbinary because it is redundant with `file_device`. The file extension is now deduced from the pgplot device that is set.

