### PR TITLE
(minor) cleanup warnings in binary

### DIFF
--- a/binary/other/mod_other_tsync.f90
+++ b/binary/other/mod_other_tsync.f90
@@ -138,7 +138,6 @@
          real(dp), intent(in) :: osep ! orbital separation (cm)
          real(dp), intent(out) :: t_sync
          integer, intent(out) :: ierr
-         real(dp) :: rGyr_squared, moment_of_inertia
          type (binary_info), pointer :: b
          type (star_info), pointer :: s
    

--- a/binary/private/binary_ce.f90
+++ b/binary/private/binary_ce.f90
@@ -39,7 +39,6 @@
       contains
 
       subroutine CE_init(b, restart, ierr)
-         use chem_def, only: chem_isos
          use interp_1d_def, only: pm_work_size
          use interp_1d_lib, only: interp_pm
          type (binary_info), pointer :: b
@@ -47,7 +46,7 @@
          integer, intent(out) :: ierr
          type (star_info), pointer :: s
          real(dp), pointer :: interp_work(:), adjusted_energy(:)
-         integer :: i, k, op_err
+         integer :: k, op_err
          real(dp) :: rec_energy_HII_to_HI, &
                      rec_energy_HeII_to_HeI, &
                      rec_energy_HeIII_to_HeII, &

--- a/binary/private/binary_ctrls_io.f90
+++ b/binary/private/binary_ctrls_io.f90
@@ -277,7 +277,6 @@
          integer, intent(in) :: level
          integer, intent(out) :: ierr
          logical, dimension(max_extra_inlists) :: read_extra
-         character (len=strlen) :: message
          character (len=strlen), dimension(max_extra_inlists) :: extra
          integer :: unit, i
          

--- a/binary/private/binary_edot.f90
+++ b/binary/private/binary_edot.f90
@@ -196,7 +196,7 @@
        integer, intent(out) :: ierr
        type (binary_info), pointer :: b
        integer :: i
-       real(dp) :: de, Mtot, xfer, costh
+       real(dp) :: de, Mtot, costh
 
        ierr = 0
        call binary_ptr(binary_id, b, ierr)

--- a/binary/private/binary_evolve.f90
+++ b/binary/private/binary_evolve.f90
@@ -400,7 +400,7 @@
          use binary_irradiation
          type (binary_info), pointer :: b
 
-         integer :: i, j, ierr, id
+         integer :: ierr, id
          logical :: implicit_rlo
          real(dp) :: new_mdot, q
 
@@ -506,7 +506,6 @@
 
       integer function binary_finish_step(b)
          type (binary_info), pointer :: b
-         real(dp) :: spin_period
 
          binary_finish_step = keep_going
          ! update change factor in case mtransfer_rate has changed

--- a/binary/private/binary_history.f90
+++ b/binary/private/binary_history.f90
@@ -70,7 +70,7 @@ contains
       integer, intent(out) :: ierr
 
       type (binary_info), pointer :: b
-      integer :: c, int_val, i, j
+      integer :: c, int_val, j
       logical :: is_int_val
       real(dp) :: val
 
@@ -121,7 +121,7 @@ contains
       integer, intent(out) :: ierr
 
       character (len = strlen) :: fname, dbl_fmt, int_fmt, txt_fmt
-      integer :: numcols, io, i, nz, col, j, i0, n
+      integer :: numcols, io, i, col, j, i0, n
 
       integer :: num_extra_header_items, num_extra_cols
 
@@ -408,8 +408,7 @@ contains
       subroutine do_col_pass2(j) ! get the column name
          integer, intent(in) :: j
          character (len = 100) :: col_name
-         character (len = 10) :: str
-         integer :: c, i, ii
+         integer :: c
          c = b% binary_history_column_spec(j)
          col_name = trim(binary_history_column_name(c))
          call do_name(j, col_name)
@@ -418,9 +417,9 @@ contains
 
       subroutine do_col_pass3(c) ! get the column value
          integer, intent(in) :: c
-         integer :: i, ii, k, int_val
+         integer :: k, int_val
          logical :: is_int_val
-         real(dp) :: val, val1, Ledd, power_photo, frac
+         real(dp) :: val
          int_val = 0; val = 0; is_int_val = .false.
          call binary_history_getval(&
             b, c, val, int_val, is_int_val, ierr)
@@ -521,7 +520,6 @@ contains
       integer, intent(out) :: int_val
       logical, intent(out) :: is_int_val
       integer, intent(out) :: ierr
-      integer :: k, i
 
       include 'formats'
 
@@ -812,10 +810,7 @@ contains
       real(dp), intent(inout) :: values(:)
       logical, intent(out) :: failed_to_find_value(:)
 
-      integer :: i, c, int_val, ierr, n, t, j, iounit
-      real(dp) :: val
-      logical :: is_int_val, special_case
-      character (len = strlen) :: buffer, string
+      integer :: i, c, ierr
 
       include 'formats'
       ierr = 0
@@ -844,10 +839,8 @@ contains
       character (len = *) :: name
       real(dp), intent(out) :: val
       integer :: i, ierr, num_extra_cols
-      character (len = 80), pointer, dimension(:) :: &
-         extra_col_names, binary_col_names
-      real(dp), pointer, dimension(:) :: &
-         extra_col_vals, binary_col_vals
+      character (len = 80), pointer, dimension(:) :: extra_col_names
+      real(dp), pointer, dimension(:) :: extra_col_vals
       include 'formats'
 
       get1_binary_hist_value = .false.

--- a/binary/private/binary_history_specs.f90
+++ b/binary/private/binary_history_specs.f90
@@ -52,7 +52,7 @@ contains
       character (len = *), intent(in) :: history_columns_file
       integer, intent(out) :: ierr
 
-      integer :: iounit, n, i, t, id, j, cnt, ii, nxt_spec
+      integer :: iounit, n, i, t, j, nxt_spec
       character (len = 256) :: buffer, string, filename
       integer, parameter :: max_level = 20
       logical :: bad_item
@@ -195,7 +195,7 @@ contains
       use utils_def
       use chem_lib
 
-      integer :: iounit, t, n, i, j, id
+      integer :: iounit, t, n, i, j
       character (len = *) :: string, buffer
       integer, intent(out) :: ierr
 

--- a/binary/private/binary_jdot.f90
+++ b/binary/private/binary_jdot.f90
@@ -120,7 +120,6 @@
          integer, intent(in) :: binary_id
          integer, intent(out) :: ierr
          type (binary_info), pointer :: b
-         real(dp) :: alfa
          ierr = 0
          call binary_ptr(binary_id, b, ierr)
          if (ierr /= 0) then
@@ -212,7 +211,7 @@
          real(dp), intent(out) :: qconv_env
          
          real(dp) :: qconv_core
-         integer :: i, k, id
+         integer :: k
 
          include 'formats'
 
@@ -256,7 +255,6 @@
          integer, intent(in) :: binary_id
          integer, intent(out) :: ierr
          type (binary_info), pointer :: b
-         logical :: apply_mdot_mb
          real(dp) :: rsun4,two_pi_div_p3, qconv_env, jdot_scale
          logical :: apply_jdot_mb
          ierr = 0

--- a/binary/private/binary_job_ctrls_io.f90
+++ b/binary/private/binary_job_ctrls_io.f90
@@ -94,7 +94,6 @@
          integer, intent(in) :: level
          integer, intent(out) :: ierr
          logical, dimension(max_extra_inlists) :: read_extra
-         character (len=strlen) :: message
          character (len=strlen), dimension(max_extra_inlists) :: extra
          integer :: unit, i
 

--- a/binary/private/binary_mdot.f90
+++ b/binary/private/binary_mdot.f90
@@ -502,7 +502,7 @@
          use binary_wind, only: eval_wind_xfer_fractions
          type (binary_info), pointer :: b
 
-         real(dp) :: fixed_xfer_fraction, actual_mtransfer_rate
+         real(dp) :: actual_mtransfer_rate
          integer :: ierr
 
          actual_mtransfer_rate = 0d0
@@ -690,7 +690,7 @@
 
       subroutine get_info_for_ritter(b)
          type(binary_info), pointer :: b
-         real(dp) :: rho_exponent, F1, q, rho, p, grav, hp, v_th, rl3, q_temp
+         real(dp) :: F1, q, rho, p, grav, hp, v_th, rl3, q_temp
          include 'formats'
 
          !--------------------- Optically thin MT rate -----------------------------------------------
@@ -735,7 +735,7 @@
       real(dp) function calculate_kolb_mdot_thick(b, indexR, rl_d) result(mdot_thick)
          real(dp), intent(in) :: rl_d
          integer, intent(in) :: indexR
-         real(dp) :: F1, F3, G1, dP, q, rho, p, grav, hp, v_th, rl3, q_temp
+         real(dp) :: F1, F3, G1, d_P, q, q_temp
          integer :: i
          type(binary_info), pointer :: b
          include 'formats'
@@ -751,12 +751,12 @@
             mdot_thick = mdot_thick + F3*sqrt(kerg * b% s_donor% T(i) / &
                (mp * b% s_donor% mu(i)))*(b% s_donor% Peos(i+1)-b% s_donor% Peos(i))
          end do
-         ! only take a fraction of dP for last cell 
+         ! only take a fraction of d_P for last cell 
          G1 = b% s_donor% gamma1(i)
          F3 = sqrt(G1) * pow(2d0/(G1+1d0), (G1+1d0)/(2d0*G1-2d0))
-         dP = (b% s_donor% r(indexR) - rl_d) / &
+         d_P = (b% s_donor% r(indexR) - rl_d) / &
             (b% s_donor% r(indexR) - b% s_donor% r(indexR+1)) * (b% s_donor% Peos(i+1)-b% s_donor% Peos(i))
-         mdot_thick = mdot_thick + F3*sqrt(kerg * b% s_donor% T(i) / (mp*b% s_donor% mu(i)))*dP
+         mdot_thick = mdot_thick + F3*sqrt(kerg * b% s_donor% T(i) / (mp*b% s_donor% mu(i)))*d_P
 
          q = b% m(b% a_i)/b% m(b% d_i) ! Mass ratio, as defined in Ritter 1988
                                        ! (Kolb & Ritter 1990 use the opposite!)
@@ -769,8 +769,6 @@
       
       subroutine get_info_for_kolb(b)
          type(binary_info), pointer :: b
-         real(dp) :: F3, FF, G1, x_L1, q, g
-         real(dp) :: mdot_thick0,  R_gas, dP, rl, s_div_rl
          integer :: i, indexR
          include 'formats'
 
@@ -841,7 +839,7 @@
       subroutine get_info_for_ritter_eccentric(b)
          type(binary_info), pointer :: b
          integer :: i
-         real(dp) :: rho_exponent, F1, q, q_temp, rho, p, grav, hp, v_th, dm
+         real(dp) :: F1, q, q_temp, rho, p, grav, hp, v_th, dm
          real(dp), DIMENSION(b% anomaly_steps):: mdot0, mdot, Erit, rl_d
          include 'formats'
          

--- a/binary/private/binary_photos.f90
+++ b/binary/private/binary_photos.f90
@@ -40,7 +40,7 @@ contains
    subroutine do_saves_for_binary(b, ierr)
       type(binary_info), pointer :: b
       integer, intent(out) :: ierr
-      integer :: iounit, id
+      integer :: iounit
       character (len = strlen) :: str_photo, filename, iomsg, report_str
 
       call string_for_model_number('x', b% model_number, b% photo_digits, str_photo)

--- a/binary/private/binary_tides.f90
+++ b/binary/private/binary_tides.f90
@@ -108,13 +108,13 @@
          integer, intent(out) :: ierr
       
          type (star_info), pointer :: s
-         real(dp) :: G, m, m_lim, t_sync, r_phot, delta_total_J, &
+         real(dp) :: G, m, t_sync, r_phot, delta_total_J, &
             sum_J_sync, sum_J_non_sync, tdyn, tkh, rho_face, cv_face, &
             T_face, csound_face, ff, omega_orb
             
          real(dp), dimension(nz) :: j_sync, delta_j, tdyn_div_tkh         
          integer, dimension(nz) :: layers_in_sync
-         integer :: k, k_rl, k_xm, num_sync_layers
+         integer :: k, num_sync_layers
          type (binary_info), pointer :: b
 
          real(dp) :: a1,a2

--- a/binary/private/binary_timestep.f90
+++ b/binary/private/binary_timestep.f90
@@ -39,7 +39,7 @@
       subroutine set_star_timesteps(b) ! sets the smallest next timestep for all stars
          type (binary_info), pointer :: b
          integer :: i, l
-         real(dp) :: dt_min, rel_overlap
+         real(dp) :: dt_min
          type (star_info), pointer :: s
          integer :: ierr, num_stars
          ierr = 0

--- a/binary/private/pgbinary_ctrls_io.f90
+++ b/binary/private/pgbinary_ctrls_io.f90
@@ -1393,7 +1393,6 @@ contains
       integer, intent(in) :: level
       integer, intent(out) :: ierr
       logical, dimension(max_extra_inlists) :: read_extra
-      character (len=strlen) :: message
       character (len=strlen), dimension(max_extra_inlists) :: extra
       integer :: unit, i
 

--- a/binary/private/pgbinary_full.f90
+++ b/binary/private/pgbinary_full.f90
@@ -766,7 +766,6 @@ contains
       logical, intent(in) :: must_write_files
       integer, intent(out) :: ierr
 
-      integer :: i
       integer(8) :: time0, time1, clock_rate
       logical :: pause
 
@@ -826,7 +825,6 @@ contains
       integer :: i
       type (pgbinary_win_file_data), pointer :: p
       logical, parameter :: dbg = .false.
-      real(dp) :: dlgL, dlgTeff, dHR
       logical :: must_write_files, show_plot_now, save_plot_now
 
       include 'formats'
@@ -905,7 +903,7 @@ contains
       type (binary_info), pointer :: b
       integer, intent(out) :: ierr
 
-      integer :: iounit, i, n
+      integer :: iounit, n
       character (len = 1024) :: fname
       type (pgbinary_hist_node), pointer :: pg
 
@@ -950,7 +948,7 @@ contains
       integer, intent(out) :: ierr
 
       logical :: fexist
-      integer :: iounit, i, n
+      integer :: iounit, n
       character (len = 1024) :: fname
       type (pgbinary_hist_node), pointer :: pg
 
@@ -1009,7 +1007,7 @@ contains
       type (binary_info), pointer :: b
       integer, intent(out) :: ierr
 
-      integer :: num, i
+      integer :: num
       type (pgbinary_hist_node), pointer :: pg
 
       include 'formats'

--- a/binary/private/pgbinary_hist_track.f90
+++ b/binary/private/pgbinary_hist_track.f90
@@ -649,11 +649,10 @@ contains
       integer, intent(out) :: ierr
       procedure(pgbinary_decorator_interface), pointer :: pgbinary_decorator
 
-      real :: xmin, xmax, ymin, ymax, xleft, xright, ybot, ytop
-      integer :: i, j, j_min, j_max
+      real :: xleft, xright, ybot, ytop
+      integer :: j, j_min, j_max
       real :: dx, dy, xplus, xminus, yplus, yminus
       real, dimension(:), pointer :: xvec, yvec
-      character (len = strlen) :: str
       integer :: k, n
       integer :: ix, iy
       integer :: file_data_len

--- a/binary/private/pgbinary_history_panels.f90
+++ b/binary/private/pgbinary_history_panels.f90
@@ -619,15 +619,14 @@ contains
       real, pointer, dimension(:) :: yfile_xdata, other_yfile_xdata
       real, pointer, dimension(:) :: yfile_ydata, other_yfile_ydata
       integer :: i, ii, n, j, k, max_width, step_min, step_max, &
-         y_color, other_y_color, yaxis_id, other_yaxis_id, &
-         clr_sav, npts, yfile_data_len, other_yfile_data_len
-      real :: hist_xmin, xmin, xmax, dx, xleft, xright, &
+         y_color, other_y_color, &
+         yfile_data_len, other_yfile_data_len
+      real :: hist_xmin, xleft, xright, &
          ymargin, panel_dy, panel_ytop, panel_ybot, &
-         ymin, ymax, dy, ybot, ytop, xpt, ypt, errpt, &
-         other_ymin, other_ymax, other_ybot, other_ytop
+         ybot, ytop, xpt, ypt, errpt, &
+         other_ybot, other_ytop
       logical :: have_yaxis, have_other_yaxis
 
-      integer :: grid_min, grid_max
       integer :: ix, iounit, ishape, num_pts
 
       include 'formats'

--- a/binary/private/pgbinary_star.f90
+++ b/binary/private/pgbinary_star.f90
@@ -160,7 +160,6 @@ contains
       integer, intent(out) :: ierr
 
       character (len = strlen) :: title, status, mass
-      real, dimension(5) :: xs, ys
       logical, parameter :: star_subplot = .true.
 
       include 'formats'

--- a/binary/private/pgbinary_summary_history.f90
+++ b/binary/private/pgbinary_summary_history.f90
@@ -77,7 +77,7 @@ contains
 
       character (len = strlen) :: yname
       real, pointer, dimension(:) :: xvec, yvec
-      real :: xmin, xmax, windy, ymin, ymax, xmargin, &
+      real :: xmin, xmax, windy, ymin, ymax, &
          legend_xmin, legend_xmax, legend_ymin, legend_ymax
       integer :: lw, lw_sav, num_lines, &
          npts, step_min, step_max
@@ -147,7 +147,7 @@ contains
          use rates_def
          integer, intent(out) :: ierr
 
-         integer :: j, ii, jj, i, cnt, k, yaxis_id
+         integer :: j, cnt, k
          logical :: show(num_lines)
          logical, parameter :: dbg = .false.
          real :: ybot, yvec_min, yvec_max

--- a/binary/private/pgbinary_support.f90
+++ b/binary/private/pgbinary_support.f90
@@ -48,7 +48,7 @@ contains
    subroutine add_to_pgbinary_hist(b, pg_hist_new)
       type (binary_info), pointer :: b
       type (pgbinary_hist_node), pointer :: pg_hist_new
-      type (pgbinary_hist_node), pointer :: pg_hist => null(), next => null()
+      type (pgbinary_hist_node), pointer :: next => null()
       integer :: step
       step = pg_hist_new% step
       do
@@ -73,7 +73,7 @@ contains
 
    subroutine pgbinary_clear(b)
       type (binary_info), pointer :: b
-      integer :: i, num
+      integer :: i
       type (pgbinary_win_file_data), pointer :: p
       type (pgbinary_hist_node), pointer :: pg_hist => null(), next => null()
       pg_hist => b% pg% pgbinary_hist
@@ -211,8 +211,8 @@ contains
       integer, intent(out) :: id
       integer, intent(out) :: ierr
 
-      integer :: pgopen, system
-      character (len = strlen) :: dir, cmd
+      integer :: pgopen
+      character (len = strlen) :: dir
       logical :: white_on_black_flag
       real :: width, ratio
 
@@ -296,7 +296,7 @@ contains
       integer, intent(in) :: step_min, step_max, numpts
       real, intent(out) :: vec(:)
       integer, intent(out) :: ierr
-      integer :: i, n
+      integer :: i
       type (pgbinary_hist_node), pointer :: pg
       ierr = 0
       if (numpts == 0) return
@@ -342,7 +342,7 @@ contains
       type (binary_info), pointer :: b
       integer, intent(in) :: step_min, step_max, numpts, index
       real, intent(out) :: vec(:)
-      integer :: i, n
+      integer :: i
       type (pgbinary_hist_node), pointer :: pg => null()
       include 'formats'
       if (numpts == 0) return
@@ -576,7 +576,7 @@ contains
       character (len = 32) :: age_str, units_str
       real(dp) :: age
       real :: ch
-      integer :: len, i, j, iE, n
+      integer :: len, i, j, iE
       if (.not. b% pg% pgbinary_show_age) return
       age = b% binary_age
       if (b% pg% pgbinary_show_age_in_seconds) then

--- a/binary/private/run_binary_support.f90
+++ b/binary/private/run_binary_support.f90
@@ -96,10 +96,9 @@ contains
          result_reason, model_number, iounit, binary_startup, model, num_stars
       type (star_info), pointer :: s
       character (len = 256) :: restart_filename, photo_filename
-      integer(8) :: total, time0, time1, clock_rate
+      integer(8) :: time0, clock_rate
       logical :: doing_restart, first_try, continue_evolve_loop, &
           get_history_info, write_history, write_terminal, will_read_pgbinary_inlist
-      real(dp) :: sum_times, dt, timestep_factor
       type (binary_info), pointer :: b
       character (len = strlen) :: inlist_fname
 

--- a/eos/eosDT_builder/src/create_eos_files.f
+++ b/eos/eosDT_builder/src/create_eos_files.f
@@ -21,13 +21,13 @@
 ! ***********************************************************************
 
       program create_eosDT_files
-		use eos_def
-		use helm
-		use helm_alloc
-		use helm_opal_scvh_driver
-		use const_def
+            use eos_def
+            use helm
+            use helm_alloc
+            use helm_opal_scvh_driver
+            use const_def
       use const_lib
-		
+            
       implicit none
 
 
@@ -45,11 +45,11 @@
       real(dp) :: logT_max
 
 
-		integer, parameter :: version_number = 51 ! update this to force rebuiding of caches
-		! update min_version in eosDT_load_tables to force rebuild of data files
+            integer, parameter :: version_number = 51 ! update this to force rebuiding of caches
+            ! update min_version in eosDT_load_tables to force rebuild of data files
 
       integer :: ix, io_unit, ios, info, irad
-		real(dp) :: whichz
+            real(dp) :: whichz
 
       ! control what is done by saving the Z in whichz.txt and, if necessary, setting the Xs below
       
@@ -57,7 +57,7 @@
       real(dp) :: Xs(num_Xs)
       
       Xs(1:num_Xs) = (/ 0.80d0, 0.00d0, 0.20d0, 0.40d0, 0.60d0 /)
-		
+            
       io_unit = 40
       open(UNIT=io_unit, FILE=trim("whichz.txt"), ACTION='READ', STATUS='OLD', IOSTAT=ios)
       if (ios /= 0) call do_stop('failed to open whichz.txt')
@@ -95,8 +95,8 @@
 
       
       subroutine Make_EoS_Files(Z_in, X_in, include_radiation)
-		use helm_opal_scvh_driver
-		
+            use helm_opal_scvh_driver
+            
       real(dp), intent(in) :: Z_in, X_in
       logical, intent(in) :: include_radiation
       
@@ -110,8 +110,8 @@
      >      mu, free_e, gamma1, gamma3, grad_ad, eta, HELM_fraction
       character (len=64) :: fname_prefix
       
-		logical :: helm_only = .false., opal_scvh_only = .false., 
-     >			opal_only = .false., scvh_only = .false., search_for_SCVH = .true.
+            logical :: helm_only = .false., opal_scvh_only = .false., 
+     >                  opal_only = .false., scvh_only = .false., search_for_SCVH = .true.
       
       !opal_only = .true.
       scvh_only = .true.
@@ -123,7 +123,7 @@
       call get_composition_info(X, Z, abar, zbar, z53bar)
 
 !..other initialization
-		info = 0
+            info = 0
       
       if (opal_only) then
          fname_prefix = '/eosOPAL_data/mesa-OPAL_0'
@@ -155,7 +155,7 @@
          write(fname,'(a,a,i1,a)') trim(dir), trim(fname_prefix), floor(100d0*Z + 0.5d0), 'z00x.data'
       else if (X < 1) then
          write(fname,'(a,a,i1,a,i2,a)') trim(dir), trim(fname_prefix), 
-     >		floor(100d0*Z + 0.5d0), 'z', floor(100d0*X + 0.5d0), 'x.data'
+     >            floor(100d0*Z + 0.5d0), 'z', floor(100d0*X + 0.5d0), 'x.data'
       else
          fname = trim(dir) // trim(fname_prefix) // '0z100x.data'
       end if
@@ -165,11 +165,11 @@
       open(unit=io_unit,file=trim(fname))
       
       write(io_unit,'(99(a14))') 'version', 'X', 'Z', 'num logTs', 'logT min', 'logT max', 'del logT', 
-     1		'num logQs', 'logQ min', 'logQ max', 'del logQ'
+     1            'num logQs', 'logQ min', 'logQ max', 'del logQ'
       
       write(io_unit,'(i14,2f14.4,2(i10,4x,3(f14.4)))') 
      >      version_number, X, Z, num_logTs, logT_min, logT_max, del_logT,
-     >		num_logQs, logQ_min, logQ_max, del_logQ
+     >            num_logQs, logQ_min, logQ_max, del_logQ
 
       do i = 1, num_logQs
          logQ = logQ_min + (i-1) * del_logQ
@@ -189,14 +189,14 @@
             info = 0
             call helm_opal_scvh(
      >            helm_only, opal_scvh_only, opal_only, scvh_only, search_for_SCVH,
-     >				include_radiation, logT, logRho, T, Rho, abar, zbar, z53bar, X, Z,
+     >                        include_radiation, logT, logRho, T, Rho, abar, zbar, z53bar, X, Z,
      >            logPgas, logE, logS, chiRho, chiT, Cp, Cv, dE_dRho, dS_dT, dS_dRho, 
      >            mu, free_e, gamma1, gamma3, grad_ad, eta, HELM_fraction, data_dir, info)
-				if (info /= 0) then
-					write(*,*) 'logT', logT
-					write(*,*) 'logRho', logRho
-					call do_stop('failed in helm_opal_scvh')
-				end if
+                        if (info /= 0) then
+                              write(*,*) 'logT', logT
+                              write(*,*) 'logRho', logRho
+                              call do_stop('failed in helm_opal_scvh')
+                        end if
 
             write(io_unit,'(f4.2,3(f10.5),7(1pe13.5),1(0pf9.5),4(0pf10.5),2(0pf11.5))') 
      >         logT, logPgas, logE, logS, chiRho, chiT, Cp, Cv, dE_dRho, dS_dT, dS_dRho, 

--- a/eos/eosDT_builder/src/eos5_xtrin_h-he.f
+++ b/eos/eosDT_builder/src/eos5_xtrin_h-he.f
@@ -52,7 +52,7 @@ c
 c
       save
       double precision results_out(iorder), pgas_out, prad_out
-		integer info ! returned = 0 if AOK
+      integer info ! returned = 0 if AOK
       character (len=*) filename
       integer w
       real moles
@@ -85,7 +85,7 @@ c
          stop
       endif
 
-		info = 0
+      info = 0
       xxi=xh
       ri=r
 c
@@ -355,22 +355,22 @@ c
       return
 
    61 continue
-		info = -61; return
-		write(*,'(" Mass fractions exceed unity (61)")')
+      info = -61; return
+      write(*,'(" Mass fractions exceed unity (61)")')
       stop 1
    62 continue
-		info = -62; return
-		write(*,'(" T6/LogR outside of table range (62)")')
+      info = -62; return
+      write(*,'(" T6/LogR outside of table range (62)")')
       write(*,*) 'T6', t6, 'LogR', log10(r), 'LogT', log10(t6*1d6)
       stop 1
    65 continue
-		info = -65; return
-		write(*,'("T6/log rho in empty region od table (65)")')
+      info = -65; return
+      write(*,'("T6/log rho in empty region od table (65)")')
       write (*,'("xh,t6,r=", 3e12.4)') xh,t6,r
       stop 1
    66 continue
-		info = -66; return
-		write(*,'(" Z does not match Z in EOS5_data* files you are",
+      info = -66; return
+      write(*,'(" Z does not match Z in EOS5_data* files you are",
      . " using (66)")')
       write (*,'("mf,zz(mf)=",i5,e12.4)') mf,zz(mf)
       write (*,'("  iq,ip,k3,l3,xh,t6,r,z= ",4i5,4e12.4)')
@@ -492,9 +492,9 @@ c..... The purpose of this subroutine is to read the data tables
 !..... read  tables
 !       call system (' gunzip EOS5_data_H-He')
 !       open(2, FILE='EOS5_data_H-He')
-		
-		write(*,*) 'read ' // trim(filename)
-		
+      
+      write(*,*) 'read ' // trim(filename)
+      
        open(2, FILE=trim(filename), IOSTAT=ios)
       if (ios .ne. 0) then
          write(*,*) 'failed to open ', trim(filename)

--- a/eos/eosDT_builder/src/opal_core.f
+++ b/eos/eosDT_builder/src/opal_core.f
@@ -8,9 +8,9 @@ c        ztab is metal fraction of the EOS5_data tables you are using.
 c           included only for purpose of preventing mismatch
 c        t6=T6=temperature in millions of degrees kelvin
 c        r=rho=Rho=density(g/cm**3)
-c      	iorder=11  ! gives all 1st and 2nd order data. See instructions
+c            iorder=11  ! gives all 1st and 2nd order data. See instructions
 c                  in esac.
-c      	irad=0    ! if 1, then adds radiation corrections
+c            irad=0    ! if 1, then adds radiation corrections
 c        results   ! array of length iorder to hold the results
 c            results(1) is the pressure in megabars (10**12dyne/cm**2)
 c            results(2) is energy in 10**12 ergs/gm. Zero is zero T6
@@ -25,7 +25,7 @@ c            results(8) is gamma1. Eqs. 9.88 Cox and Guili.
 c            results(9) is gamma2/(gamma2-1). Eqs. 9.88 Cox and Guili
 c            results(10) is mu_M
 c            results(11) is log_Ne
-		integer info ! returned = 0 if AOK
+      integer info ! returned = 0 if AOK
       character (len=256) data_dir, filename
       parameter (mx=5,mv=12,nr=169,nt=197)
       common/eeos/esact,eos(mv)
@@ -56,7 +56,7 @@ c            results(11) is log_Ne
       end if
       
       call esac(xh,ztab,t6,r,iorder,irad,filename,pgas_out,prad_out,info)
-		if (info /= 0) return
+      if (info /= 0) return
       do j=1,iorder
          results_out(j) = eos(j)
       end do
@@ -110,7 +110,7 @@ c
 c
       save
       double precision pgas_out, prad_out
-		integer info ! returned = 0 if AOK
+      integer info ! returned = 0 if AOK
       character (len=*) filename
       real moles
       parameter (mx=5,mv=12,nr=169,nt=197)
@@ -127,7 +127,7 @@ c
       dimension frac(7)
       data aprop/83.14511/
 
-		info = 0
+      info = 0
       blank=' '
       if (iorder .gt. mv ) then
          write (*,*) ' iorder cannot exceed ', mv
@@ -158,10 +158,10 @@ c
         call readcoeos(filename)
         z=zz(1)
         if (ztab .ne. z) then
-        		write (*,'("requested z=",f10.6," EOS5_data is for z=",
+              write (*,'("requested z=",f10.6," EOS5_data is for z=",
      x             f10.6)')
-     x    		ztab,z      
-        		stop 1
+     x          ztab,z      
+              stop 1
         endif
 
         if (.false.) then ! report grid
@@ -264,7 +264,7 @@ c
         ipu=3
         if (k4 .gt. nt) ipu=2
       if (k3 .eq. 0) then
-      		write (*,'(" ihi,ilo,imd",3i5)')
+            write (*,'(" ihi,ilo,imd",3i5)')
       endif
 
 c     check to determine if interpolation indices fall within
@@ -412,22 +412,22 @@ c
       return
 
    61 continue
-		info = -61; return
-		write(*,'(" Mass fractions exceed unity (61)")')
+      info = -61; return
+      write(*,'(" Mass fractions exceed unity (61)")')
       stop 1
    62 continue
-		info = -62; return
-		write(*,'(" T6/LogR outside of table range (62)")')
+      info = -62; return
+      write(*,'(" T6/LogR outside of table range (62)")')
       write(*,*) 'T6', t6, 'LogR', log10(r), 'LogT', log10(t6*1d6)
       stop 1
    65 continue
-		info = -65; return
-		write(*,'("T6/log rho in empty region od table (65)")')
+      info = -65; return
+      write(*,'("T6/log rho in empty region od table (65)")')
       write (*,'("xh,t6,r=", 3e12.4)') xh,t6,r
       stop 1
    66 continue
-		info = -66; return
-		write(*,'(" Z does not match Z in EOS5_data* files you are",
+      info = -66; return
+      write(*,'(" Z does not match Z in EOS5_data* files you are",
      . " using (66)")')
       write (*,'("mf,zz(mf)=",i5,e12.4)') mf,zz(mf)
       write (*,'("  iq,ip,k3,l3,xh,t6,r,z= ",4i5,4e12.4)')
@@ -549,9 +549,9 @@ c
 !..... read  tables
 c       call system (' gunzip EOS5_data')
 c       open(2, FILE='EOS5_data')
-		
-		write(*,*) 'read ' // trim(filename)
-		
+      
+      write(*,*) 'read ' // trim(filename)
+      
        open(2, FILE=trim(filename), IOSTAT=ios)
       if (ios .ne. 0) then
          write(*,*) 'failed to open ', trim(filename)

--- a/eos/test/src/sample_eos.f90
+++ b/eos/test/src/sample_eos.f90
@@ -9,7 +9,7 @@
 !   by the Free Software Foundation; either version 2 of the License, or
 !   (at your option) any later version.
 !
-!   MESA is distributed in the hope that it will be useful, 
+!   MESA is distributed in the hope that it will be useful,
 !   but WITHOUT ANY WARRANTY; without even the implied warranty of
 !   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 !   GNU Library General Public License for more details.
@@ -20,158 +20,143 @@
 !
 ! ***********************************************************************
 
-      program sample_eos
+program sample_eos
       use eos_def
       use eos_lib
       use chem_def
       use chem_lib
       use const_lib
       use math_lib
-
+   
       implicit none
-
-! this program shows how to setup and use the mesa eos in an interactive manner.
-
-
-      real(dp) :: X, Z, Y, abar, zbar, z2bar, z53bar, ye
+   
+      ! this program shows how to setup and use the mesa eos in an interactive manner.
+   
+      real(dp) :: X, Y, abar, zbar, z2bar, z53bar, ye
       integer, parameter :: species = 7
-      integer, parameter :: h1=1, he4=2, c12=3, n14=4, o16=5, ne20=6, mg24=7
+      integer, parameter :: h1 = 1, he4 = 2, c12 = 3, n14 = 4, o16 = 5, ne20 = 6, mg24 = 7
       integer, pointer, dimension(:) :: net_iso, chem_id
       real(dp) :: xa(species)
-
-
+   
       call Sample
-      
-      contains
-      
+   
+   contains
+   
       subroutine Sample
-         
+   
          integer :: handle
-         real(dp) :: Rho, T, Pgas, log10Rho
-         real(dp) :: dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas, d_dlnRho_const_T, d_dlnT_const_Rho
-         real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT, d_dabar, d_dzbar
-         real(dp) :: d_dxa(num_eos_d_dxa_results,species)
-         real(dp) :: xz, frac, dabar_dx(species), dzbar_dx(species), sumx,mass_correction, dmc_dx(species)
+         real(dp) :: Rho, T
+         real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT
+         real(dp) :: d_dxa(num_eos_d_dxa_results, species)
+         real(dp) :: xz, dabar_dx(species), dzbar_dx(species), sumx, mass_correction, dmc_dx(species)
          integer :: ierr
-         character (len=32) :: my_mesa_dir
-         character (len=80) :: string
-
-
-! explicitly set my_mesa_dir to your $MESA_DIR, or use a blank string, in which case your $MESA_DIR is automagically used
-
+         character(len=32) :: my_mesa_dir
+         character(len=80) :: string
+   
+         ! explicitly set my_mesa_dir to your $MESA_DIR, or use a blank string, in which case your $MESA_DIR is automagically used
+   
          my_mesa_dir = '../..'
-!         my_mesa_dir = ''         
-
-
-! initialize 
+         ! my_mesa_dir = ''
+   
+         ! initialize
          ierr = 0
-
-         call const_init(my_mesa_dir,ierr)     
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-         
+   
+         call const_init(my_mesa_dir, ierr)
+         if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
+   
          call math_init()
-         
+   
          call chem_init('isotopes.data', ierr)
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-
+         if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
+   
          call Setup_eos(handle)
-         allocate(net_iso(num_chem_isos), chem_id(species), stat=ierr)
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-
+         allocate (net_iso(num_chem_isos), chem_id(species), stat=ierr)
+         if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
+   
          call Init_Composition
-
-
-
-! keep returning to here
-100   xa(:)  = 0.0d0
-
-! get the temperature, density and composition
-
-      write(6,*)  
-      write(6,*) 'give the temperature, density, and mass fractions (h1, he4, c12, n14, o16, ne20, mg24) =>'
-      write(6,*) 'hit return for T = 1e9 K, Rho = 1e4 g/cc, x(c12) = 1 ; enter -1 to stop'
-      write(6,*)  
-      read(5,'(a)') string
-
-! stop
-      if (string(1:2) .eq. '-1') then
-       call Shutdown_eos(handle)
-       deallocate(net_iso, chem_id)
-       if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-       call mesa_error(__FILE__,__LINE__,'normal termination')
-
-! read the conditions
-      else
-       if (string(1:6) .ne. '      ') then
-        read(string,*) T,Rho, xa(h1), xa(he4), xa(c12), xa(n14), xa(o16), xa(ne20), xa(mg24)
-
-! or set some defaults
-       else
-        T = 1.0d9 ; Rho = 1.0d4 ; xa(c12) = 1.0d0
-       end if
-      end if
-
-
-! get some composition variables
-         call composition_info( &
+   
+         ! keep returning to here
+         do
+            xa(:) = 0.0d0
+   
+            ! get the temperature, density and composition
+   
+            write (6, *)
+            write (6, *) 'give the temperature, density, and mass fractions (h1, he4, c12, n14, o16, ne20, mg24) =>'
+            write (6, *) 'hit return for T = 1e9 K, Rho = 1e4 g/cc, x(c12) = 1 ; enter -1 to stop'
+            write (6, *)
+            read (5, '(a)') string
+   
+            ! stop
+            if (string(1:2) .eq. '-1') then
+               call Shutdown_eos(handle)
+               deallocate (net_iso, chem_id)
+               if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
+               ! exit
+               call mesa_error(__FILE__, __LINE__, 'normal termination')
+   
+               ! read the conditions
+            else
+               if (string(1:6) .ne. '      ') then
+                  read (string, *) T, Rho, xa(h1), xa(he4), xa(c12), xa(n14), xa(o16), xa(ne20), xa(mg24)
+   
+                  ! or set some defaults
+               else
+                  T = 1.0d9; Rho = 1.0d4; xa(c12) = 1.0d0
+               end if
+            end if
+   
+            ! get some composition variables
+            call composition_info( &
                species, chem_id, xa, X, Y, xz, abar, zbar, z2bar, z53bar, ye, mass_correction, &
                sumx, dabar_dx, dzbar_dx, dmc_dx)
-         
-
-! call the density-temperature based eos
-
-! composition derivatives by isotope
-
-         call eosDT_get( &
+   
+            ! call the density-temperature based eos
+   
+            ! composition derivatives by isotope
+   
+            call eosDT_get( &
                handle, species, chem_id, net_iso, xa, &
                Rho, log10(Rho), T, log10(T), &
                res, d_dlnd, d_dlnT, d_dxa, ierr)
-
-
-! report the results
-
-         call PrettyOut(Rho, T, abar, zbar, res, d_dlnd, d_dlnT)
-
-
-! example calling the pressure-temperature based eos
-!         Pgas = exp(res(i_lnPgas))
-!         call eosPT_get( &
-!               handle, Z, X, abar, zbar, &
-!               species, chem_id, net_iso, xa, &
-!               Pgas, log10(Pgas), T, log10(T), &
-!               Rho, log10Rho, dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas, &
-!               res, d_dlnd, d_dlnT, d_dabar, d_dzbar, ierr)
-      
-
-! back for another one
-      goto 100
-         
+   
+            ! report the results
+   
+            call PrettyOut(Rho, T, abar, zbar, res, d_dlnd, d_dlnT)
+   
+   ! example calling the pressure-temperature based eos
+   !         Pgas = exp(res(i_lnPgas))
+   !         call eosPT_get( &
+   !               handle, Z, X, abar, zbar, &
+   !               species, chem_id, net_iso, xa, &
+   !               Pgas, log10(Pgas), T, log10(T), &
+   !               Rho, log10Rho, dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas, &
+   !               res, d_dlnd, d_dlnT, d_dabar, d_dzbar, ierr)
+   
+            ! back for another one
+         end do
+   
       end subroutine Sample
-      
-
-
-
+   
       subroutine Setup_eos(handle)
          ! allocate and load the eos tables
          use eos_def
          use eos_lib
          integer, intent(out) :: handle
-
+   
          integer :: ierr
          logical, parameter :: use_cache = .true.
-
+   
          call eos_init(' ', use_cache, ierr)
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-
-         write(*,*) 'loading eos tables'
-         
+         if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
+   
+         write (*, *) 'loading eos tables'
+   
          handle = alloc_eos_handle(ierr)
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__)
-
+         if (ierr /= 0) call mesa_error(__FILE__, __LINE__)
+   
       end subroutine Setup_eos
-      
-
-      
+   
       subroutine Shutdown_eos(handle)
          use eos_def
          use eos_lib
@@ -179,14 +164,12 @@
          call free_eos_handle(handle)
          call eos_shutdown
       end subroutine Shutdown_eos
-
-
-
+   
       subroutine Init_Composition
          use chem_lib
-       
+   
          net_iso(:) = 0
-         
+   
          chem_id(h1) = ih1; net_iso(ih1) = h1
          chem_id(he4) = ihe4; net_iso(ihe4) = he4
          chem_id(c12) = ic12; net_iso(ic12) = c12
@@ -194,24 +177,19 @@
          chem_id(o16) = io16; net_iso(io16) = o16
          chem_id(ne20) = ine20; net_iso(ine20) = ne20
          chem_id(mg24) = img24; net_iso(img24) = mg24
-         
+   
       end subroutine Init_Composition
-
-
-
-
-
+   
       subroutine PrettyOut(Rho, T, abar, zbar, res, d_dlnd, d_dlnT)
          use eos_def
          use eos_lib
          use chem_lib
-
-! declare the pass
+   
+         ! declare the pass
          real(dp) :: Rho, T, abar, zbar
-         real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT, d_dabar, d_dzbar
-
-
-! local variables
+         real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT
+   
+         ! local variables
          real(dp) :: my_ptot, my_dptotdd, my_dptotdt, my_dptotddd, my_dptotddt, my_dptotdtt, &
                      my_etot, my_detotdd, my_detotdt, my_detotddd, my_detotddt, my_detotdtt, &
                      my_stot, my_dstotdd, my_dstotdt, my_dstotddd, my_dstotddt, my_dstotdtt, &
@@ -222,222 +200,212 @@
                      my_erad, my_deraddd, my_deraddt, my_deradddd, my_deradddt, my_deraddtt, &
                      my_srad, my_dsraddd, my_dsraddt, my_dsradddd, my_dsradddt, my_dsraddtt, &
                      my_xni, my_dxnidd, my_dxnidt, my_xne, my_dxnedd, my_dxnedt, my_eta, my_detadd, my_detadt, &
-                     my_cv, my_dcvdd, my_dcvdt, my_cp, my_dcpdd, my_dcpdt, & 
-                     my_g1, my_dg1dd, my_dg1dt, my_g2, my_dg2dd, my_dg2dt, my_g3, my_dg3dd, my_dg3dt, & 
+                     my_cv, my_dcvdd, my_dcvdt, my_cp, my_dcpdd, my_dcpdt, &
+                     my_g1, my_dg1dd, my_dg1dt, my_g2, my_dg2dd, my_dg2dt, my_g3, my_dg3dd, my_dg3dt, &
                      my_grad, my_dgraddd, my_dgraddt, my_chit, my_dchitdd, my_dchitdt, my_chir, my_dchirdd, my_dchirdt, &
                      my_cs, my_dcsdd, my_dcsdt, x, z, xx, yy, ww, dfk, dse, dpe, dsp
-
-! popular format statements
-01    format(1x,t2,a,t16,a,t31,a,t46,a,t59,a,t74,a,t89,a)
-02    format(1x,t2,a,1p7e15.6)
-03    format(1x,t2,a7,1pe14.6,t24,a7,1pe14.6,t46,a7,1pe14.6,t68,a7,1pe14.6)
-
-
-! indices for the res, d_dlnd, and d_dlnt arrays are defined in $MESA_DIR/eos/public/eos_def.f90 
-
-! radiation
-         my_prad     = crad * one_third * T * T * T * T
-         my_dpraddd  = 0.0d0
-         my_dpraddt  = 4.0d0 * my_prad/T
+   
+         ! popular format statements
+         character(len=*), parameter :: fmt1 = "(1x, t2, a, t16, a, t31, a, t46, a, t59, a, t74, a, t89, a)"
+         character(len=*), parameter :: fmt2 = "(1x, t2, a, 1p7e15.6)"
+         character(len=*), parameter :: fmt3 = "(1x, t2, a7, 1pe14.6, t24, a7, 1pe14.6, t46, a7, 1pe14.6, t68, a7, 1pe14.6)"
+   
+         ! indices for the res, d_dlnd, and d_dlnt arrays are defined in $MESA_DIR/eos/public/eos_def.f90
+   
+         ! radiation
+         my_prad = crad*one_third*T*T*T*T
+         my_dpraddd = 0.0d0
+         my_dpraddt = 4.0d0*my_prad/T
          my_dpradddd = 0.0d0
          my_dpradddt = 0.0d0
-         my_dpraddtt = 4.0d0 * crad * T * T 
-
-         my_erad    = 3.0d0 * my_prad / Rho
-         my_deraddd = -my_erad / Rho 
-         my_deraddt = 3.0d0 * my_dpraddt / Rho
-         my_deradddd = -2.0d0 * my_deraddd / Rho
-         my_deradddt = -my_deraddt / Rho
-         my_deraddtt = 3.0d0 * my_dpraddtt / Rho
-
-         my_srad    = (my_prad/Rho + my_erad) / T
-         my_dsraddd = (my_dpraddd/Rho - my_prad/(Rho*Rho) + my_deraddd) / T
-         my_dsraddt = (my_dpraddt/Rho + my_deraddt - my_srad) / T
+         my_dpraddtt = 4.0d0*crad*T*T
+   
+         my_erad = 3.0d0*my_prad/Rho
+         my_deraddd = -my_erad/Rho
+         my_deraddt = 3.0d0*my_dpraddt/Rho
+         my_deradddd = -2.0d0*my_deraddd/Rho
+         my_deradddt = -my_deraddt/Rho
+         my_deraddtt = 3.0d0*my_dpraddtt/Rho
+   
+         my_srad = (my_prad/Rho + my_erad)/T
+         my_dsraddd = (my_dpraddd/Rho - my_prad/(Rho*Rho) + my_deraddd)/T
+         my_dsraddt = (my_dpraddt/Rho + my_deraddt - my_srad)/T
          my_dsradddd = ((my_dpradddd &
-                    - (2.0d0*my_dpraddd - 2.0d0*my_prad/Rho)/Rho)/Rho &
-                     + my_deradddd) / T
+                         - (2.0d0*my_dpraddd - 2.0d0*my_prad/Rho)/Rho)/Rho &
+                        + my_deradddd)/T
          my_dsradddt = ((my_dpradddt - my_dpraddt/Rho)/Rho &
-                    + my_deradddt - my_dsraddd) / T
-         my_dsraddtt = ((my_dpraddtt/Rho + my_deraddtt - my_dsraddt) - my_dsraddt)/ T
-
-
-! gas and totals
-! pressure
-         my_pgas     = exp(res(i_lnPgas))
-         my_dpgasdd  = my_pgas/Rho * d_dlnd(i_lnPgas)  
-         my_dpgasdt  = my_pgas/T   * d_dlnt(i_lnPgas)  
-
-         my_ptot    = my_pgas    + my_prad  
+                        + my_deradddt - my_dsraddd)/T
+         my_dsraddtt = ((my_dpraddtt/Rho + my_deraddtt - my_dsraddt) - my_dsraddt)/T
+   
+         ! gas and totals
+         ! pressure
+         my_pgas = exp(res(i_lnPgas))
+         my_dpgasdd = my_pgas/Rho*d_dlnd(i_lnPgas)
+         my_dpgasdt = my_pgas/T*d_dlnt(i_lnPgas)
+   
+         my_ptot = my_pgas + my_prad
          my_dptotdd = my_dpgasdd + my_dpraddd
          my_dptotdt = my_dpgasdt + my_dpraddt
-
-! energy
-         my_etot     = exp(res(i_lnE))
-         my_detotdd  = my_etot/Rho * d_dlnd(i_lnE)  
-         my_detotdt  = my_etot/T   * d_dlnt(i_lnE)  
-
-         my_egas    = my_etot    - my_erad
+   
+         ! energy
+         my_etot = exp(res(i_lnE))
+         my_detotdd = my_etot/Rho*d_dlnd(i_lnE)
+         my_detotdt = my_etot/T*d_dlnt(i_lnE)
+   
+         my_egas = my_etot - my_erad
          my_degasdd = my_detotdd - my_deraddd
          my_degasdt = my_detotdt - my_deraddt
-
-! entropy
-         my_stot    = exp(res(i_lnS))
-         my_dstotdd = my_stot/Rho * d_dlnd(i_lnS)  
-         my_dstotdt = my_stot/T   * d_dlnt(i_lnS)  
-
-         my_sgas    = my_stot    - my_srad
+   
+         ! entropy
+         my_stot = exp(res(i_lnS))
+         my_dstotdd = my_stot/Rho*d_dlnd(i_lnS)
+         my_dstotdt = my_stot/T*d_dlnt(i_lnS)
+   
+         my_sgas = my_stot - my_srad
          my_dsgasdd = my_dstotdd - my_dsraddd
          my_dsgasdt = my_dstotdt - my_dsraddt
-
-
-! number densities and electron degeneracy 
-         my_xni    = avo * Rho/abar
-         my_dxnidd = avo / abar
+   
+         ! number densities and electron degeneracy
+         my_xni = avo*Rho/abar
+         my_dxnidd = avo/abar
          my_dxnidt = 0.0d0
-
-         my_xne    = abar * my_xni * exp(res(i_lnfree_e))
-         my_dxnedd = abar * my_xni * exp(res(i_lnfree_e))/Rho * d_dlnd(i_lnfree_e) + abar * my_dxnidd * exp(res(i_lnfree_e))
-         my_dxnedt = abar * my_xni * exp(res(i_lnfree_e))/T   * d_dlnt(i_lnfree_e) + abar * my_dxnidt * exp(res(i_lnfree_e))
-
-         my_eta    = res(i_eta)
-         my_detadd = d_dlnd(i_eta) / Rho
-         my_detadt = d_dlnt(i_eta) / T
-
-! total specific heats
-         my_cv     = res(i_Cv)
-         my_dcvdd  = d_dlnd(i_Cv) / Rho
-         my_dcvdt  = d_dlnt(i_Cv) / T
-
-         my_cp     = res(i_Cp)
-         my_dcpdd  = d_dlnd(i_Cp) / Rho
-         my_dcpdt  = d_dlnt(i_Cp) / T
-
-! total gammas
-         my_grad    = res(i_grad_ad)
-         my_dgraddd = d_dlnd(i_grad_ad) / Rho
-         my_dgraddt = d_dlnt(i_grad_ad) / T
-
-         my_g1    = res(i_gamma1)
-         my_dg1dd = d_dlnd(i_gamma1) / Rho
-         my_dg1dt = d_dlnt(i_gamma1) / T
-
-         my_g2    = 1.0d0/(1.0d0 - my_grad)
-         my_dg2dd = my_g2*my_g2 * my_dgraddd
-         my_dg2dt = my_g2*my_g2 * my_dgraddt
-
-         my_g3    = res(i_gamma3)
-         my_dg3dd = d_dlnd(i_gamma3) / Rho
-         my_dg3dt = d_dlnt(i_gamma3) / T
-
-! total adiabatic exponents
-         my_chit    = res(i_chiT)
-         my_dchitdd = d_dlnd(i_chiT) / Rho
-         my_dchitdt = d_dlnt(i_chiT) / T
-
-         my_chir    = res(i_chiRho)
-         my_dchirdd = d_dlnd(i_chiRho) / Rho
-         my_dchirdt = d_dlnt(i_chiRho) / T
-
-! total sound speed
-         x         = my_etot + clight*clight
-         z         = 1.0d0 + x*Rho/my_ptot
-         xx        = 1.0d0/z
-         ww        = x*Rho/my_ptot
-         dfk       = my_g1*xx
-         my_cs     = clight*sqrt(dfk)
-         yy        = 0.5d0*my_cs/dfk
-         my_dcsdd = yy*((my_dg1dd - dfk)*xx * (my_detotdd*Rho - ww*my_dptotdd + x)/my_ptot)
-         my_dcsdt = yy*((my_dg1dt - dfk)*xx * (my_detotdt*Rho - ww*my_dptotdt)/my_ptot)
-
-
-! maxwell relations; each is at flaoting point if the consistency is perfect
+   
+         my_xne = abar*my_xni*exp(res(i_lnfree_e))
+         my_dxnedd = abar*my_xni*exp(res(i_lnfree_e))/Rho*d_dlnd(i_lnfree_e) + abar*my_dxnidd*exp(res(i_lnfree_e))
+         my_dxnedt = abar*my_xni*exp(res(i_lnfree_e))/T*d_dlnt(i_lnfree_e) + abar*my_dxnidt*exp(res(i_lnfree_e))
+   
+         my_eta = res(i_eta)
+         my_detadd = d_dlnd(i_eta)/Rho
+         my_detadt = d_dlnt(i_eta)/T
+   
+         ! total specific heats
+         my_cv = res(i_Cv)
+         my_dcvdd = d_dlnd(i_Cv)/Rho
+         my_dcvdt = d_dlnt(i_Cv)/T
+   
+         my_cp = res(i_Cp)
+         my_dcpdd = d_dlnd(i_Cp)/Rho
+         my_dcpdt = d_dlnt(i_Cp)/T
+   
+         ! total gammas
+         my_grad = res(i_grad_ad)
+         my_dgraddd = d_dlnd(i_grad_ad)/Rho
+         my_dgraddt = d_dlnt(i_grad_ad)/T
+   
+         my_g1 = res(i_gamma1)
+         my_dg1dd = d_dlnd(i_gamma1)/Rho
+         my_dg1dt = d_dlnt(i_gamma1)/T
+   
+         my_g2 = 1.0d0/(1.0d0 - my_grad)
+         my_dg2dd = my_g2*my_g2*my_dgraddd
+         my_dg2dt = my_g2*my_g2*my_dgraddt
+   
+         my_g3 = res(i_gamma3)
+         my_dg3dd = d_dlnd(i_gamma3)/Rho
+         my_dg3dt = d_dlnt(i_gamma3)/T
+   
+         ! total adiabatic exponents
+         my_chit = res(i_chiT)
+         my_dchitdd = d_dlnd(i_chiT)/Rho
+         my_dchitdt = d_dlnt(i_chiT)/T
+   
+         my_chir = res(i_chiRho)
+         my_dchirdd = d_dlnd(i_chiRho)/Rho
+         my_dchirdt = d_dlnt(i_chiRho)/T
+   
+         ! total sound speed
+         x = my_etot + clight*clight
+         z = 1.0d0 + x*Rho/my_ptot
+         xx = 1.0d0/z
+         ww = x*Rho/my_ptot
+         dfk = my_g1*xx
+         my_cs = clight*sqrt(dfk)
+         yy = 0.5d0*my_cs/dfk
+         my_dcsdd = yy*((my_dg1dd - dfk)*xx*(my_detotdd*Rho - ww*my_dptotdd + x)/my_ptot)
+         my_dcsdt = yy*((my_dg1dt - dfk)*xx*(my_detotdt*Rho - ww*my_dptotdt)/my_ptot)
+   
+         ! maxwell relations; each is at flaoting point if the consistency is perfect
          dse = T*my_dstotdt/my_detotdt - 1.0d0
          dpe = (my_detotdd*Rho*Rho + T*my_dptotdt)/my_ptot - 1.0d0
          dsp = -my_dstotdd*(Rho*Rho/my_dptotdt) - 1.0d0
-
-
-
-! and finally some second derivatives
-
-! pressure
-         my_dpgasddd = my_pgas/Rho * my_dchirdd  
-         my_dpgasddt = my_pgas/Rho * my_dchirdt 
-         my_dpgasdtt = my_pgas/T * my_dchitdt 
-
+   
+         ! and finally some second derivatives
+   
+         ! pressure
+         my_dpgasddd = my_pgas/Rho*my_dchirdd
+         my_dpgasddt = my_pgas/Rho*my_dchirdt
+         my_dpgasdtt = my_pgas/T*my_dchitdt
+   
          my_dptotddd = my_dpgasddd + my_dpradddd
          my_dptotddt = my_dpgasddt + my_dpradddt
          my_dptotdtt = my_dpgasdtt + my_dpraddtt
-
-! energy
+   
+         ! energy
          my_detotddd = d_dlnd(i_dE_dRho)/Rho
          my_detotddt = d_dlnT(i_dE_dRho)/T
-         my_detotdtt = my_dcvdt 
-
+         my_detotdtt = my_dcvdt
+   
          my_degasddd = my_detotddd - my_deradddd
          my_degasddt = my_detotddt - my_deradddt
          my_degasdtt = my_detotdtt - my_deraddtt
-
-! entropy
+   
+         ! entropy
          my_dstotddd = d_dlnd(i_dS_dRho)/Rho
          my_dstotddt = d_dlnT(i_dS_dRho)/T
          my_dstotdtt = d_dlnT(i_dS_dT)/T
-
+   
          my_dsgasddd = my_dstotddd - my_dsradddd
          my_dsgasddt = my_dstotddt - my_dsradddt
          my_dsgasdtt = my_dstotdtt - my_dsraddtt
-
-
-
-! write 'em
-
-         write(6,03) 'T     =',T,       'Rho   =',Rho,      'abar  =',abar,   'zbar  =',zbar
-         write(6,03) 'h1    =',xa(h1),  'he4   =',xa(he4),  'c12   =',xa(c12), 'n14   =',xa(n14)
-         write(6,03) 'o16   =',xa(o16), 'ne20  =',xa(ne20), 'mg24  =',xa(mg24)
-
-         write(6,*)  ' '
-         write(6,01)  'quantity','value','d/d(Rho)','d/d(T)','d^2/d(Rho)^2','d^2/d(Rho)d(T)','d^2/d(T)^2'
-
-! pressure, energy, entropy
-         write(6,02) 'p tot   =', my_ptot, my_dptotdd, my_dptotdt, my_dptotddd, my_dptotddt, my_dptotdtt
-         write(6,02) 'p gas   =', my_pgas, my_dpgasdd, my_dpgasdt, my_dpgasddd, my_dpgasddt, my_dpgasdtt
-         write(6,02) 'p rad   =', my_prad, my_dpraddd, my_dpraddt, my_dpradddd, my_dpradddt, my_dpraddtt
-
-         write(6,'(A)')
-         write(6,02) 'e tot   =', my_etot, my_detotdd, my_detotdt, my_detotddd, my_detotddt, my_detotdtt
-         write(6,02) 'e gas   =', my_egas, my_degasdd, my_degasdt, my_degasddd, my_degasddt, my_degasdtt
-         write(6,02) 'e rad   =', my_erad, my_deraddd, my_deraddt, my_deradddd, my_deradddt, my_deraddtt
-
-         write(6,'(A)')
-         write(6,02) 's tot   =', my_stot, my_dstotdd, my_dstotdt, my_dstotddd, my_dstotddt, my_dstotdtt
-         write(6,02) 's gas   =', my_sgas, my_dsgasdd, my_dsgasdt, my_dsgasddd, my_dsgasddt, my_dsgasdtt
-         write(6,02) 's rad   =', my_srad, my_dsraddd, my_dsraddt, my_dsradddd, my_dsradddt, my_dsraddtt
-
-
-! ion and free electron matter number density, electron degeneracy parameter
-         write(6,'(A)')
-         write(6,02) 'n_ion   =',my_xni, my_dxnidd, my_dxnidt
-         write(6,02) 'n_ele   =',my_xne, my_dxnedd, my_dxnedt
-         write(6,02) 'eta_e   =',my_eta, my_detadd, my_detadt
-
-! specific heats, 3 gammas, sound speed, chit and chid for the gas and the total
-         write(6,02) 'cv      =',my_cv, my_dcvdd, my_dcvdt
-         write(6,02) 'cp      =',my_cp, my_dcpdd, my_dcpdt
-
-         write(6,02) 'gamma_1 =',my_g1, my_dg1dd, my_dg1dt
-         write(6,02) 'gamma_2 =',my_g2, my_dg2dd, my_dg2dt
-         write(6,02) 'gamma_3 =',my_g3, my_dg3dd, my_dg3dt
-         write(6,02) 'grad_ad =',my_grad, my_dgraddd, my_dgraddt
-
-         write(6,02) 'chi_t   =',my_chit, my_dchitdd, my_dchitdt
-         write(6,02) 'chi_d   =',my_chir, my_dchirdd, my_dchirdt
-
-         write(6,02) 'c_sound =',my_cs, my_dcsdd, my_dcsdt
-
-         write(6,'(A)')
-         write(6,03) 'dsp   =',dse,'dpe   =',dpe,'dsp   =',dsp
-
+   
+         ! write 'em
+   
+         write (6, fmt3) 'T     =', T, 'Rho   =', Rho, 'abar  =', abar, 'zbar  =', zbar
+         write (6, fmt3) 'h1    =', xa(h1), 'he4   =', xa(he4), 'c12   =', xa(c12), 'n14   =', xa(n14)
+         write (6, fmt3) 'o16   =', xa(o16), 'ne20  =', xa(ne20), 'mg24  =', xa(mg24)
+   
+         write (6, *) ' '
+         write (6, fmt1) 'quantity', 'value', 'd/d(Rho)', 'd/d(T)', 'd^2/d(Rho)^2', 'd^2/d(Rho)d(T)', 'd^2/d(T)^2'
+   
+         ! pressure, energy, entropy
+         write (6, fmt2) 'p tot   =', my_ptot, my_dptotdd, my_dptotdt, my_dptotddd, my_dptotddt, my_dptotdtt
+         write (6, fmt2) 'p gas   =', my_pgas, my_dpgasdd, my_dpgasdt, my_dpgasddd, my_dpgasddt, my_dpgasdtt
+         write (6, fmt2) 'p rad   =', my_prad, my_dpraddd, my_dpraddt, my_dpradddd, my_dpradddt, my_dpraddtt
+   
+         write (6, '(A)')
+         write (6, fmt2) 'e tot   =', my_etot, my_detotdd, my_detotdt, my_detotddd, my_detotddt, my_detotdtt
+         write (6, fmt2) 'e gas   =', my_egas, my_degasdd, my_degasdt, my_degasddd, my_degasddt, my_degasdtt
+         write (6, fmt2) 'e rad   =', my_erad, my_deraddd, my_deraddt, my_deradddd, my_deradddt, my_deraddtt
+   
+         write (6, '(A)')
+         write (6, fmt2) 's tot   =', my_stot, my_dstotdd, my_dstotdt, my_dstotddd, my_dstotddt, my_dstotdtt
+         write (6, fmt2) 's gas   =', my_sgas, my_dsgasdd, my_dsgasdt, my_dsgasddd, my_dsgasddt, my_dsgasdtt
+         write (6, fmt2) 's rad   =', my_srad, my_dsraddd, my_dsraddt, my_dsradddd, my_dsradddt, my_dsraddtt
+   
+         ! ion and free electron matter number density, electron degeneracy parameter
+         write (6, '(A)')
+         write (6, fmt2) 'n_ion   =', my_xni, my_dxnidd, my_dxnidt
+         write (6, fmt2) 'n_ele   =', my_xne, my_dxnedd, my_dxnedt
+         write (6, fmt2) 'eta_e   =', my_eta, my_detadd, my_detadt
+   
+         ! specific heats, 3 gammas, sound speed, chit and chid for the gas and the total
+         write (6, fmt2) 'cv      =', my_cv, my_dcvdd, my_dcvdt
+         write (6, fmt2) 'cp      =', my_cp, my_dcpdd, my_dcpdt
+   
+         write (6, fmt2) 'gamma_1 =', my_g1, my_dg1dd, my_dg1dt
+         write (6, fmt2) 'gamma_2 =', my_g2, my_dg2dd, my_dg2dt
+         write (6, fmt2) 'gamma_3 =', my_g3, my_dg3dd, my_dg3dt
+         write (6, fmt2) 'grad_ad =', my_grad, my_dgraddd, my_dgraddt
+   
+         write (6, fmt2) 'chi_t   =', my_chit, my_dchitdd, my_dchitdt
+         write (6, fmt2) 'chi_d   =', my_chir, my_dchirdd, my_dchirdt
+   
+         write (6, fmt2) 'c_sound =', my_cs, my_dcsdd, my_dcsdt
+   
+         write (6, '(A)')
+         write (6, fmt3) 'dsp   =', dse, 'dpe   =', dpe, 'dsp   =', dsp
+   
       end subroutine PrettyOut
-
-
-      end program sample_eos
-
+   
+   end program sample_eos
+   

--- a/sample/src/sample.f90
+++ b/sample/src/sample.f90
@@ -9,7 +9,7 @@
 !   by the Free Software Foundation; either version 2 of the License, or
 !   (at your option) any later version.
 !
-!   MESA is distributed in the hope that it will be useful, 
+!   MESA is distributed in the hope that it will be useful,
 !   but WITHOUT ANY WARRANTY; without even the implied warranty of
 !   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 !   GNU Library General Public License for more details.
@@ -20,208 +20,200 @@
 !
 ! ***********************************************************************
 
-      program sample_eos
+program sample_eos
+   use eos_def
+   use eos_lib
+   use chem_def
+   use chem_lib
+   use const_lib
+   use math_lib
+
+   implicit none
+
+   real(dp) :: X, Z, Y, abar, zbar, z2bar, z53bar, ye
+   integer, parameter :: species = 7
+   integer, parameter :: h1 = 1, he4 = 2, c12 = 3, n14 = 4, o16 = 5, ne20 = 6, mg24 = 7
+   integer, pointer, dimension(:) :: net_iso, chem_id
+   real(dp) :: xa(species)
+   character(len=256) :: my_mesa_dir
+
+   call Sample
+
+contains
+
+   subroutine Sample
+
+      integer :: handle
+      real(dp) :: Rho, T, Pgas, log10Rho, log10T
+      real(dp) :: dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas
+      real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT
+      real(dp), dimension(num_eos_d_dxa_results, species) :: d_dxa
+      integer :: ierr
+      character(len=*), parameter :: fmt1 = "(a20, 3x, e20.12)"
+
+      ierr = 0
+
+      my_mesa_dir = '..' ! if empty string, uses environment variable MESA_DIR
+      call const_init(my_mesa_dir, ierr)
+      if (ierr /= 0) then
+         write (*, *) 'const_init failed'
+         call mesa_error(__FILE__, __LINE__)
+      end if
+
+      call math_init()
+
+      call chem_init('isotopes.data', ierr)
+      if (ierr /= 0) then
+         write (*, *) 'failed in chem_init'
+         call mesa_error(__FILE__, __LINE__)
+      end if
+
+      ! allocate and initialize the eos tables
+      call Setup_eos(handle)
+
+      allocate (net_iso(num_chem_isos), chem_id(species), stat=ierr)
+      if (ierr /= 0) call mesa_error(__FILE__, __LINE__, 'allocate failed')
+      X = 0.70_dp
+      Z = 0.02_dp
+      call Init_Composition
+
+      Rho = 1.3519d2
+      log10T = 8.15_dp
+      T = exp10(log10T)
+
+      ! get a set of results for given temperature and density
+      call eosDT_get( &
+         handle, &
+         species, chem_id, net_iso, xa, &
+         Rho, log10(Rho), T, log10T, &
+         res, d_dlnd, d_dlnT, &
+         d_dxa, ierr)
+
+      Pgas = exp(res(i_lnPgas))
+
+      ! the indices for the results are defined in eos_def.f
+      write (*, '(A)')
+      write (*, fmt1) 'temperature', T
+      write (*, fmt1) 'density', Rho
+      write (*, fmt1) 'logT', log10T
+      write (*, fmt1) 'logRho', log10(Rho)
+      write (*, '(A)')
+      write (*, fmt1) 'Z', Z
+      write (*, fmt1) 'X', X
+      write (*, fmt1) 'abar', abar
+      write (*, fmt1) 'zbar', zbar
+      write (*, '(A)')
+      write (*, fmt1) 'Pgas', Pgas
+      write (*, fmt1) 'logPgas', res(i_lnPgas)/ln10
+      write (*, fmt1) 'grad_ad', res(i_grad_ad)
+      write (*, fmt1) 'c_P', res(i_Cp)
+      write (*, '(A)')
+
+      call eosPT_get( &
+         handle, &
+         species, chem_id, net_iso, xa, &
+         Pgas, log10(Pgas), T, log10(T), &
+         Rho, log10Rho, dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas, &
+         res, d_dlnd, d_dlnT, d_dxa, ierr)
+
+      ! the indices for the results are defined in eos_def.f
+      write (*, '(A)')
+      write (*, fmt1) 'temperature', T
+      write (*, fmt1) 'Pgas', Pgas
+      write (*, fmt1) 'logT', log10(T)
+      write (*, fmt1) 'logPgas', res(i_lnPgas)/ln10
+      write (*, '(A)')
+      write (*, fmt1) 'Z', Z
+      write (*, fmt1) 'X', X
+      write (*, fmt1) 'abar', abar
+      write (*, fmt1) 'zbar', zbar
+      write (*, '(A)')
+      write (*, fmt1) 'density', Rho
+      write (*, fmt1) 'logRho', log10Rho
+      write (*, fmt1) 'grad_ad', res(i_grad_ad)
+      write (*, fmt1) 'c_P', res(i_Cp)
+      write (*, '(A)')
+
+      ! deallocate the eos tables
+      call Shutdown_eos(handle)
+
+      deallocate (net_iso, chem_id)
+
+      if (ierr /= 0) then
+         write (*, *) 'bad result from eos_get'
+         call mesa_error(__FILE__, __LINE__)
+      end if
+
+   end subroutine Sample
+
+   subroutine Setup_eos(handle)
+      ! allocate and load the eos tables
       use eos_def
       use eos_lib
-      use chem_def
+      integer, intent(out) :: handle
+
+      integer :: ierr
+      logical, parameter :: use_cache = .true.
+
+      call eos_init('', use_cache, ierr)
+      if (ierr /= 0) then
+         write (*, *) 'eos_init failed in Setup_eos'
+         call mesa_error(__FILE__, __LINE__)
+      end if
+
+      write (*, *) 'loading eos tables'
+
+      handle = alloc_eos_handle(ierr)
+      if (ierr /= 0) then
+         write (*, *) 'failed trying to allocate eos handle'
+         call mesa_error(__FILE__, __LINE__)
+      end if
+
+   end subroutine Setup_eos
+
+   subroutine Shutdown_eos(handle)
+      use eos_def
+      use eos_lib
+      integer, intent(in) :: handle
+      call free_eos_handle(handle)
+      call eos_shutdown
+   end subroutine Shutdown_eos
+
+   subroutine Init_Composition
       use chem_lib
-      use const_lib
-      use math_lib
 
-      implicit none
+      real(dp), parameter :: Zfrac_C = 0.173312d0
+      real(dp), parameter :: Zfrac_N = 0.053177d0
+      real(dp), parameter :: Zfrac_O = 0.482398d0
+      real(dp), parameter :: Zfrac_Ne = 0.098675d0
 
-      real(dp) :: X, Z, Y, abar, zbar, z2bar, z53bar, ye
-      integer, parameter :: species = 7
-      integer, parameter :: h1=1, he4=2, c12=3, n14=4, o16=5, ne20=6, mg24=7
-      integer, pointer, dimension(:) :: net_iso, chem_id
-      real(dp) :: xa(species)
-      character (len=256) :: my_mesa_dir
+      real(dp) :: dabar_dx(species), dzbar_dx(species), &
+                  sumx, xh, xhe, xz, mass_correction, dmc_dx(species)
 
+      net_iso(:) = 0
 
-      call Sample
-      
-      contains
-      
-      subroutine Sample
-         
-         integer :: handle
-         real(dp) :: Rho, T, Pgas, log10Rho, log10T, Prad, energy, entropy
-         real(dp) :: dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas, d_dlnRho_const_T, d_dlnT_const_Rho
-         real(dp), dimension(num_eos_basic_results) :: res, d_dlnd, d_dlnT, d_dabar, d_dzbar
-         real(dp), dimension(num_eos_d_dxa_results, species) :: d_dxa
-         integer :: ierr
-         
-         ierr = 0
+      chem_id(h1) = ih1; net_iso(ih1) = h1
+      chem_id(he4) = ihe4; net_iso(ihe4) = he4
+      chem_id(c12) = ic12; net_iso(ic12) = c12
+      chem_id(n14) = in14; net_iso(in14) = n14
+      chem_id(o16) = io16; net_iso(io16) = o16
+      chem_id(ne20) = ine20; net_iso(ine20) = ne20
+      chem_id(mg24) = img24; net_iso(img24) = mg24
 
-         my_mesa_dir = '..' ! if empty string, uses environment variable MESA_DIR
-         call const_init(my_mesa_dir,ierr)     
-         if (ierr /= 0) then
-            write(*,*) 'const_init failed'
-            call mesa_error(__FILE__,__LINE__)
-         end if        
-         
-         call math_init()
-         
-         call chem_init('isotopes.data', ierr)
-         if (ierr /= 0) then
-            write(*,*) 'failed in chem_init'
-            call mesa_error(__FILE__,__LINE__)
-         end if
+      Y = 1 - (X + Z)
 
-         ! allocate and initialize the eos tables
-         call Setup_eos(handle)
-         
-         allocate(net_iso(num_chem_isos), chem_id(species), stat=ierr)
-         if (ierr /= 0) call mesa_error(__FILE__,__LINE__,'allocate failed')
-         X = 0.70_dp
-         Z = 0.02_dp
-         call Init_Composition
-         
-         Rho = 1.3519d2
-         log10T = 8.15_dp
-         T = exp10(log10T)
-         
-         ! get a set of results for given temperature and density
-         call eosDT_get( &
-               handle, &
-               species, chem_id, net_iso, xa, &
-               Rho, log10(Rho), T, log10T,  &
-               res, d_dlnd, d_dlnT, &
-               d_dxa, ierr)
-         
-        
- 1       format(a20,3x,e20.12)
+      xa(h1) = X
+      xa(he4) = Y
+      xa(c12) = Z*Zfrac_C
+      xa(n14) = Z*Zfrac_N
+      xa(o16) = Z*Zfrac_O
+      xa(ne20) = Z*Zfrac_Ne
+      xa(species) = 1 - sum(xa(1:species - 1))
 
-         Pgas = exp(res(i_lnPgas))
+      call composition_info( &
+         species, chem_id, xa, xh, xhe, xz, abar, zbar, z2bar, z53bar, ye, &
+         mass_correction, sumx, dabar_dx, dzbar_dx, dmc_dx)
 
-         ! the indices for the results are defined in eos_def.f
-         write(*,'(A)')
-         write(*,1) 'temperature', T
-         write(*,1) 'density', Rho
-         write(*,1) 'logT', log10T
-         write(*,1) 'logRho', log10(Rho)
-         write(*,'(A)')
-         write(*,1) 'Z', Z
-         write(*,1) 'X', X
-         write(*,1) 'abar', abar
-         write(*,1) 'zbar', zbar
-         write(*,'(A)')
-         write(*,1) 'Pgas', Pgas
-         write(*,1) 'logPgas', res(i_lnPgas)/ln10
-         write(*,1) 'grad_ad', res(i_grad_ad)
-         write(*,1) 'c_P', res(i_Cp)
-         write(*,'(A)')
+   end subroutine Init_Composition
 
-         call eosPT_get(  &
-               handle, &
-               species, chem_id, net_iso, xa, &
-               Pgas, log10(Pgas), T, log10(T),  &
-               Rho, log10Rho, dlnRho_dlnPgas_const_T, dlnRho_dlnT_const_Pgas,  &
-               res, d_dlnd, d_dlnT, d_dxa, ierr)
-      
-         ! the indices for the results are defined in eos_def.f
-         write(*,'(A)')
-         write(*,1) 'temperature', T
-         write(*,1) 'Pgas', Pgas
-         write(*,1) 'logT', log10(T)
-         write(*,1) 'logPgas', res(i_lnPgas)/ln10
-         write(*,'(A)')
-         write(*,1) 'Z', Z
-         write(*,1) 'X', X
-         write(*,1) 'abar', abar
-         write(*,1) 'zbar', zbar
-         write(*,'(A)')
-         write(*,1) 'density', Rho
-         write(*,1) 'logRho', log10Rho
-         write(*,1) 'grad_ad', res(i_grad_ad)
-         write(*,1) 'c_P', res(i_Cp)
-         write(*,'(A)')
-
-         ! deallocate the eos tables
-         call Shutdown_eos(handle)
-         
-         deallocate(net_iso, chem_id)
-         
-         if (ierr /= 0) then
-            write(*,*) 'bad result from eos_get'
-            call mesa_error(__FILE__,__LINE__)
-         end if
-
-      end subroutine Sample
-      
-
-      subroutine Setup_eos(handle)
-         ! allocate and load the eos tables
-         use eos_def
-         use eos_lib
-         integer, intent(out) :: handle
-
-         integer :: ierr
-         logical, parameter :: use_cache = .true.
-
-         call eos_init('', use_cache, ierr)
-         if (ierr /= 0) then
-            write(*,*) 'eos_init failed in Setup_eos'
-            call mesa_error(__FILE__,__LINE__)
-         end if
-         
-         write(*,*) 'loading eos tables'
-         
-         handle = alloc_eos_handle(ierr)
-         if (ierr /= 0) then
-            write(*,*) 'failed trying to allocate eos handle'
-            call mesa_error(__FILE__,__LINE__)
-         end if
-      
-      end subroutine Setup_eos
-      
-      
-      subroutine Shutdown_eos(handle)
-         use eos_def
-         use eos_lib
-         integer, intent(in) :: handle
-         call free_eos_handle(handle)
-         call eos_shutdown
-      end subroutine Shutdown_eos
-
-
-      subroutine Init_Composition
-         use chem_lib
-
-         real(dp), parameter :: Zfrac_C = 0.173312d0
-         real(dp), parameter :: Zfrac_N = 0.053177d0
-         real(dp), parameter :: Zfrac_O = 0.482398d0
-         real(dp), parameter :: Zfrac_Ne = 0.098675d0
-         
-         real(dp) :: frac, dabar_dx(species), dzbar_dx(species),  &
-               sumx, xh, xhe, xz, mass_correction, dmc_dx(species)
-         
-         net_iso(:) = 0
-         
-         chem_id(h1) = ih1; net_iso(ih1) = h1
-         chem_id(he4) = ihe4; net_iso(ihe4) = he4
-         chem_id(c12) = ic12; net_iso(ic12) = c12
-         chem_id(n14) = in14; net_iso(in14) = n14
-         chem_id(o16) = io16; net_iso(io16) = o16
-         chem_id(ne20) = ine20; net_iso(ine20) = ne20
-         chem_id(mg24) = img24; net_iso(img24) = mg24
-         
-         Y = 1 - (X + Z)
-               
-         xa(h1) = X
-         xa(he4) = Y
-         xa(c12) = Z * Zfrac_C
-         xa(n14) = Z * Zfrac_N
-         xa(o16) = Z * Zfrac_O
-         xa(ne20) = Z * Zfrac_Ne
-         xa(species) = 1 - sum(xa(1:species-1))
-         
-         call composition_info( &
-               species, chem_id, xa, xh, xhe, xz, abar, zbar, z2bar, z53bar, ye,  &
-               mass_correction, sumx, dabar_dx, dzbar_dx, dmc_dx)
-         
-      end subroutine Init_Composition
-
-
-      end   
-
+end


### PR DESCRIPTION
cleaning up unused variables and some other compiler warnings in `binary`

changed a `dP` to `d_P` to avoid possible conflict with `dp` (since Fortran is case-insensitive)

Goal is that we will add more (best-practice) compile flags to avoid future bugs, but first I need to clean up warnings before committing the flags because there are a lot.