### PR TITLE
Export makefile_header's USE_CRMATH to GYRE's CRMATH

### DIFF
--- a/gyre/make/makefile_full
+++ b/gyre/make/makefile_full
@@ -31,6 +31,12 @@ else
    export SHARED = no
 endif
 
+ifeq ($(USE_CRMATH), YES)
+   export CRMATH = yes
+else
+   export CRMATH = no
+endif
+
 all :
 	@$(MAKE) --no-print-directory -C $(GYRE_DIR) install
 


### PR DESCRIPTION
Aside from having to skip tests in many modules, building with `USE_CRMATH = NO`  in `utils/makefile_header` currently fails on GYRE because it's own `CRMATH` make variable defaults to `yes` and it tries to build with CRMATH.

This PR adds a block to export the appropriate value of `CRMATH` in GYRE's makefile, as is already done for `USE_SHARED`/`SHARED`.