### PR TITLE
fix uninitialized memory in net_burn_const_p.f90

### DIFF
--- a/net/private/net_burn_const_p.f90
+++ b/net/private/net_burn_const_p.f90
@@ -195,6 +195,7 @@
          t = 0
          tend = times(ntimes)
          
+         rpar(r_burn_const_P_rho) = 1e-99 ! dummy value, will be calculated later
          rpar(r_burn_const_P_pressure) = exp10(log10Ps_f1(1)) ! no interpolation yet
          rpar(r_burn_const_P_temperature) = starting_temp
          rpar(r_burn_const_P_init_rho) = -1d99

--- a/net/private/net_burn_const_p.f90
+++ b/net/private/net_burn_const_p.f90
@@ -195,7 +195,7 @@
          t = 0
          tend = times(ntimes)
          
-         rpar(r_burn_const_P_rho) = 1e-99 ! dummy value, will be calculated later
+         rpar(r_burn_const_P_rho) = 1d-99 ! dummy value, will be calculated later
          rpar(r_burn_const_P_pressure) = exp10(log10Ps_f1(1)) ! no interpolation yet
          rpar(r_burn_const_P_temperature) = starting_temp
          rpar(r_burn_const_P_init_rho) = -1d99

--- a/net/test/src/mod_one_zone_burn.f90
+++ b/net/test/src/mod_one_zone_burn.f90
@@ -1011,7 +1011,7 @@
             integer, intent(inout), target :: iwork_y(*)
             integer, intent(inout), pointer :: ipar(:) ! (lipar)
             real(dp), intent(inout), pointer :: rpar(:) ! (lrpar)
-            real(dp) :: lgt,lgrho
+            real(dp) :: lgt, lgrho
             integer :: i, cid
             interface
                include 'num_interp_y.dek'


### PR DESCRIPTION

Fixes #726 

Set a dummy value for `rpar(r_burn_const_P_rho)` right before this line:
https://github.com/MESAHub/mesa/blob/e29ed74db65f919404919714f058f6ea18cde072/net/private/net_burn_const_p.f90#L198
so it is initialized. The code will calculate the right value later, but prior to that calculation the code (for some reason) has a function that takes the log of this value, so it has to be initialized:
https://github.com/MESAHub/mesa/blob/e29ed74db65f919404919714f058f6ea18cde072/net/test/src/mod_one_zone_burn.f90#L1026
