### PR TITLE
implicit save and floating point literal gotchas

### DIFF
--- a/atm/private/atm_table.f90
+++ b/atm/private/atm_table.f90
@@ -80,7 +80,7 @@ contains
     real(dp), intent(out) :: dlnP_dlnkap
     integer, intent(out)  :: ierr
 
-    logical, parameter :: DBG = .FALSE.
+    logical, parameter :: dbg = .false.
 
     real(dp) :: g
     real(dp) :: logg
@@ -125,14 +125,14 @@ contains
 
     ! Perform the table lookup
 
-    if (DBG) write(*,*) 'call get_table_values', id
+    if (dbg) write(*,*) 'call get_table_values', id
     call get_table_values( &
          id, Z, logg, Teff, &
          Pgas, dPgas_dTeff, dPgas_dlogg, &
          T, dT_dTeff, dT_dlogg, &
          ierr)
     if (ierr /= 0) then
-       if (DBG) write(*,*) 'get_table_values(_at_fixed_Z) ierr', ierr
+       if (dbg) write(*,*) 'get_table_values(_at_fixed_Z) ierr', ierr
        return
     end if
 
@@ -191,7 +191,7 @@ contains
 
     endif
 
-    if (DBG .or. is_bad(lnP) .or. is_bad(lnT)) then
+    if (dbg .or. is_bad(lnP) .or. is_bad(lnT)) then
        write(*,*) 'eval_table'
        write(*,1) 'Teff', Teff
        write(*,1) 'T', T
@@ -234,7 +234,7 @@ contains
     integer, parameter :: BLEND_IN_Y = 4
     integer, parameter :: BLEND_CORNER_OUT = 5
 
-    logical, parameter :: DBG = .FALSE.
+    logical, parameter :: dbg = .false.
 
     real(dp)                :: g
     real(dp)                :: logTeff

--- a/auto_diff/private/auto_diff_real_15var_order1_module.f90
+++ b/auto_diff/private/auto_diff_real_15var_order1_module.f90
@@ -306,14 +306,14 @@ module auto_diff_real_15var_order1_module
       type(auto_diff_real_15var_order1), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1Array = 0_dp
+      this%d1Array = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_15var_order1), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1Array = 0_dp
+      this%d1Array = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)

--- a/auto_diff/private/auto_diff_real_1var_order1_module.f90
+++ b/auto_diff/private/auto_diff_real_1var_order1_module.f90
@@ -372,14 +372,14 @@ module auto_diff_real_1var_order1_module
       type(auto_diff_real_1var_order1), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
+      this%d1val1 = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_1var_order1), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
+      this%d1val1 = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)
@@ -1294,7 +1294,7 @@ module auto_diff_real_1var_order1_module
       type(auto_diff_real_1var_order1), intent(in) :: this
       type(auto_diff_real_1var_order1) :: derivative
       derivative%val = this%d1val1
-      derivative%d1val1 = 0_dp
+      derivative%d1val1 = 0.0_dp
    end function differentiate_auto_diff_real_1var_order1_1
    
 end module auto_diff_real_1var_order1_module

--- a/auto_diff/private/auto_diff_real_2var_order1_module.f90
+++ b/auto_diff/private/auto_diff_real_2var_order1_module.f90
@@ -379,16 +379,16 @@ module auto_diff_real_2var_order1_module
       type(auto_diff_real_2var_order1), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_2var_order1), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)
@@ -1511,16 +1511,16 @@ module auto_diff_real_2var_order1_module
       type(auto_diff_real_2var_order1), intent(in) :: this
       type(auto_diff_real_2var_order1) :: derivative
       derivative%val = this%d1val1
-      derivative%d1val1 = 0_dp
-      derivative%d1val2 = 0_dp
+      derivative%d1val1 = 0.0_dp
+      derivative%d1val2 = 0.0_dp
    end function differentiate_auto_diff_real_2var_order1_1
    
    function differentiate_auto_diff_real_2var_order1_2(this) result(derivative)
       type(auto_diff_real_2var_order1), intent(in) :: this
       type(auto_diff_real_2var_order1) :: derivative
       derivative%val = this%d1val2
-      derivative%d1val1 = 0_dp
-      derivative%d1val2 = 0_dp
+      derivative%d1val1 = 0.0_dp
+      derivative%d1val2 = 0.0_dp
    end function differentiate_auto_diff_real_2var_order1_2
    
 end module auto_diff_real_2var_order1_module

--- a/auto_diff/private/auto_diff_real_2var_order2_module.f90
+++ b/auto_diff/private/auto_diff_real_2var_order2_module.f90
@@ -385,22 +385,22 @@ module auto_diff_real_2var_order2_module
       type(auto_diff_real_2var_order2), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
-      this%d2val1 = 0_dp
-      this%d1val1_d1val2 = 0_dp
-      this%d2val2 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
+      this%d2val1 = 0.0_dp
+      this%d1val1_d1val2 = 0.0_dp
+      this%d2val2 = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_2var_order2), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
-      this%d2val1 = 0_dp
-      this%d1val1_d1val2 = 0_dp
-      this%d2val2 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
+      this%d2val1 = 0.0_dp
+      this%d1val1_d1val2 = 0.0_dp
+      this%d2val2 = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)
@@ -1969,9 +1969,9 @@ module auto_diff_real_2var_order2_module
       derivative%val = this%d1val1
       derivative%d1val1 = this%d2val1
       derivative%d1val2 = this%d1val1_d1val2
-      derivative%d2val1 = 0_dp
-      derivative%d1val1_d1val2 = 0_dp
-      derivative%d2val2 = 0_dp
+      derivative%d2val1 = 0.0_dp
+      derivative%d1val1_d1val2 = 0.0_dp
+      derivative%d2val2 = 0.0_dp
    end function differentiate_auto_diff_real_2var_order2_1
    
    function differentiate_auto_diff_real_2var_order2_2(this) result(derivative)
@@ -1980,9 +1980,9 @@ module auto_diff_real_2var_order2_module
       derivative%val = this%d1val2
       derivative%d1val1 = this%d1val1_d1val2
       derivative%d1val2 = this%d2val2
-      derivative%d2val1 = 0_dp
-      derivative%d1val1_d1val2 = 0_dp
-      derivative%d2val2 = 0_dp
+      derivative%d2val1 = 0.0_dp
+      derivative%d1val1_d1val2 = 0.0_dp
+      derivative%d2val2 = 0.0_dp
    end function differentiate_auto_diff_real_2var_order2_2
    
 end module auto_diff_real_2var_order2_module

--- a/auto_diff/private/auto_diff_real_2var_order3_module.f90
+++ b/auto_diff/private/auto_diff_real_2var_order3_module.f90
@@ -393,30 +393,30 @@ module auto_diff_real_2var_order3_module
       type(auto_diff_real_2var_order3), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
-      this%d2val1 = 0_dp
-      this%d1val1_d1val2 = 0_dp
-      this%d2val2 = 0_dp
-      this%d3val1 = 0_dp
-      this%d2val1_d1val2 = 0_dp
-      this%d1val1_d2val2 = 0_dp
-      this%d3val2 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
+      this%d2val1 = 0.0_dp
+      this%d1val1_d1val2 = 0.0_dp
+      this%d2val2 = 0.0_dp
+      this%d3val1 = 0.0_dp
+      this%d2val1_d1val2 = 0.0_dp
+      this%d1val1_d2val2 = 0.0_dp
+      this%d3val2 = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_2var_order3), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
-      this%d2val1 = 0_dp
-      this%d1val1_d1val2 = 0_dp
-      this%d2val2 = 0_dp
-      this%d3val1 = 0_dp
-      this%d2val1_d1val2 = 0_dp
-      this%d1val1_d2val2 = 0_dp
-      this%d3val2 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
+      this%d2val1 = 0.0_dp
+      this%d1val1_d1val2 = 0.0_dp
+      this%d2val2 = 0.0_dp
+      this%d3val1 = 0.0_dp
+      this%d2val1_d1val2 = 0.0_dp
+      this%d1val1_d2val2 = 0.0_dp
+      this%d3val2 = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)
@@ -3317,10 +3317,10 @@ module auto_diff_real_2var_order3_module
       derivative%d2val1 = this%d3val1
       derivative%d1val1_d1val2 = this%d2val1_d1val2
       derivative%d2val2 = this%d1val1_d2val2
-      derivative%d3val1 = 0_dp
-      derivative%d2val1_d1val2 = 0_dp
-      derivative%d1val1_d2val2 = 0_dp
-      derivative%d3val2 = 0_dp
+      derivative%d3val1 = 0.0_dp
+      derivative%d2val1_d1val2 = 0.0_dp
+      derivative%d1val1_d2val2 = 0.0_dp
+      derivative%d3val2 = 0.0_dp
    end function differentiate_auto_diff_real_2var_order3_1
    
    function differentiate_auto_diff_real_2var_order3_2(this) result(derivative)
@@ -3332,10 +3332,10 @@ module auto_diff_real_2var_order3_module
       derivative%d2val1 = this%d2val1_d1val2
       derivative%d1val1_d1val2 = this%d1val1_d2val2
       derivative%d2val2 = this%d3val2
-      derivative%d3val1 = 0_dp
-      derivative%d2val1_d1val2 = 0_dp
-      derivative%d1val1_d2val2 = 0_dp
-      derivative%d3val2 = 0_dp
+      derivative%d3val1 = 0.0_dp
+      derivative%d2val1_d1val2 = 0.0_dp
+      derivative%d1val1_d2val2 = 0.0_dp
+      derivative%d3val2 = 0.0_dp
    end function differentiate_auto_diff_real_2var_order3_2
    
 end module auto_diff_real_2var_order3_module

--- a/auto_diff/private/auto_diff_real_4var_order1_module.f90
+++ b/auto_diff/private/auto_diff_real_4var_order1_module.f90
@@ -393,20 +393,20 @@ module auto_diff_real_4var_order1_module
       type(auto_diff_real_4var_order1), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
-      this%d1val3 = 0_dp
-      this%d1val4 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
+      this%d1val3 = 0.0_dp
+      this%d1val4 = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_4var_order1), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1val2 = 0_dp
-      this%d1val3 = 0_dp
-      this%d1val4 = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1val2 = 0.0_dp
+      this%d1val3 = 0.0_dp
+      this%d1val4 = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)
@@ -1693,40 +1693,40 @@ module auto_diff_real_4var_order1_module
       type(auto_diff_real_4var_order1), intent(in) :: this
       type(auto_diff_real_4var_order1) :: derivative
       derivative%val = this%d1val1
-      derivative%d1val1 = 0_dp
-      derivative%d1val2 = 0_dp
-      derivative%d1val3 = 0_dp
-      derivative%d1val4 = 0_dp
+      derivative%d1val1 = 0.0_dp
+      derivative%d1val2 = 0.0_dp
+      derivative%d1val3 = 0.0_dp
+      derivative%d1val4 = 0.0_dp
    end function differentiate_auto_diff_real_4var_order1_1
    
    function differentiate_auto_diff_real_4var_order1_2(this) result(derivative)
       type(auto_diff_real_4var_order1), intent(in) :: this
       type(auto_diff_real_4var_order1) :: derivative
       derivative%val = this%d1val2
-      derivative%d1val1 = 0_dp
-      derivative%d1val2 = 0_dp
-      derivative%d1val3 = 0_dp
-      derivative%d1val4 = 0_dp
+      derivative%d1val1 = 0.0_dp
+      derivative%d1val2 = 0.0_dp
+      derivative%d1val3 = 0.0_dp
+      derivative%d1val4 = 0.0_dp
    end function differentiate_auto_diff_real_4var_order1_2
    
    function differentiate_auto_diff_real_4var_order1_3(this) result(derivative)
       type(auto_diff_real_4var_order1), intent(in) :: this
       type(auto_diff_real_4var_order1) :: derivative
       derivative%val = this%d1val3
-      derivative%d1val1 = 0_dp
-      derivative%d1val2 = 0_dp
-      derivative%d1val3 = 0_dp
-      derivative%d1val4 = 0_dp
+      derivative%d1val1 = 0.0_dp
+      derivative%d1val2 = 0.0_dp
+      derivative%d1val3 = 0.0_dp
+      derivative%d1val4 = 0.0_dp
    end function differentiate_auto_diff_real_4var_order1_3
    
    function differentiate_auto_diff_real_4var_order1_4(this) result(derivative)
       type(auto_diff_real_4var_order1), intent(in) :: this
       type(auto_diff_real_4var_order1) :: derivative
       derivative%val = this%d1val4
-      derivative%d1val1 = 0_dp
-      derivative%d1val2 = 0_dp
-      derivative%d1val3 = 0_dp
-      derivative%d1val4 = 0_dp
+      derivative%d1val1 = 0.0_dp
+      derivative%d1val2 = 0.0_dp
+      derivative%d1val3 = 0.0_dp
+      derivative%d1val4 = 0.0_dp
    end function differentiate_auto_diff_real_4var_order1_4
    
 end module auto_diff_real_4var_order1_module

--- a/auto_diff/private/auto_diff_real_star_order1_module.f90
+++ b/auto_diff/private/auto_diff_real_star_order1_module.f90
@@ -367,14 +367,14 @@ module auto_diff_real_star_order1_module
       type(auto_diff_real_star_order1), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1Array = 0_dp
+      this%d1Array = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_star_order1), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1Array = 0_dp
+      this%d1Array = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)

--- a/auto_diff/private/auto_diff_real_tdc_module.f90
+++ b/auto_diff/private/auto_diff_real_tdc_module.f90
@@ -376,18 +376,18 @@ module auto_diff_real_tdc_module
       type(auto_diff_real_tdc), intent(out) :: this
       real(dp), intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1Array = 0_dp
-      this%d1val1_d1Array = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1Array = 0.0_dp
+      this%d1val1_d1Array = 0.0_dp
    end subroutine assign_from_real_dp
    
    subroutine assign_from_int(this, other)
       type(auto_diff_real_tdc), intent(out) :: this
       integer, intent(in) :: other
       this%val = other
-      this%d1val1 = 0_dp
-      this%d1Array = 0_dp
-      this%d1val1_d1Array = 0_dp
+      this%d1val1 = 0.0_dp
+      this%d1Array = 0.0_dp
+      this%d1val1_d1Array = 0.0_dp
    end subroutine assign_from_int
    
    function equal_self(this, other) result(z)
@@ -1678,9 +1678,9 @@ module auto_diff_real_tdc_module
       type(auto_diff_real_tdc), intent(in) :: this
       type(auto_diff_real_tdc) :: derivative
       derivative%val = this%d1val1
-      derivative%d1val1 = 0_dp
+      derivative%d1val1 = 0.0_dp
       derivative%d1Array = this%d1val1_d1Array
-      derivative%d1val1_d1Array = 0_dp
+      derivative%d1val1_d1Array = 0.0_dp
    end function differentiate_auto_diff_real_tdc_1
    
 end module auto_diff_real_tdc_module

--- a/colors/test/src/test_colors.f90
+++ b/colors/test/src/test_colors.f90
@@ -61,7 +61,7 @@
          character (len=8) :: vname
          character(len=strlen),dimension(num_results):: colors_name
          logical, parameter :: doing_solar = .true.
-         real(dp), dimension(num_results) :: solar_expected_results = (/ &
+         real(dp), dimension(num_results), parameter :: solar_expected_results = (/ &
          4.75d0, -0.11510d0, -0.14211d0, -0.61768d0, -0.36199d0, -0.68894d0, -1.46926d0, -0.32695d0, -0.78032d0, -0.39024d0, &
          0.05223d0, -0.10512d0,  -0.33801d0, -0.44312d0, -0.44123d0, -0.43080d0 /) 
 

--- a/kap/private/kap_aesopus.f90
+++ b/kap/private/kap_aesopus.f90
@@ -83,9 +83,9 @@ contains
 
     character(len=80) :: group_name ! output buffer
 
-    character(len=30) :: efmt = '(A14, 99ES12.3)'
-    character(len=30) :: ffmt = '(A14, 99F8.3)'
-    character(len=30) :: ifmt = '(A14, I4)'
+    character(len=30), parameter :: efmt = '(A14, 99ES12.3)'
+    character(len=30), parameter :: ffmt = '(A14, 99F8.3)'
+    character(len=30), parameter :: ifmt = '(A14, I4)'
 
     logical :: file_exists 
 

--- a/kap/private/kap_eval.f90
+++ b/kap/private/kap_eval.f90
@@ -416,7 +416,7 @@
 
         real(dp) :: logKap
 
-        logical :: dbg = .false.
+        logical, parameter :: dbg = .false.
 
         ierr = -1 ! should be set by each case, otherwise something is wrong
         frac_Type2 = 0d0

--- a/kap/public/kap_def.f90
+++ b/kap/public/kap_def.f90
@@ -393,7 +393,7 @@ module kap_def
   logical :: clip_to_kap_table_boundaries = .true. ! typically, this should be set true.
    ! if this is set true, then temperature and density args are
    ! clipped to the boundaries of the table.
-  real(dp) :: kap_min_logRho = -40d0
+  real(dp), parameter :: kap_min_logRho = -40d0
    ! below this, clip logRho and set partials wrt logRho to zero
 
 

--- a/math/private/math_pown.f90
+++ b/math/private/math_pown.f90
@@ -89,7 +89,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: powm1_x
 
-    powm1_x = 1_dp / x
+    powm1_x = 1.0_dp / x
 
   end function powm1_
 

--- a/net/test/src/mod_one_zone_burn.f90
+++ b/net/test/src/mod_one_zone_burn.f90
@@ -144,7 +144,7 @@
       
       real(dp) :: starting_logT
       
-      logical :: dbg = .false.
+      logical, parameter :: dbg = .false.
       
       
       contains

--- a/num/test/src/test_integrate.f90
+++ b/num/test/src/test_integrate.f90
@@ -23,7 +23,7 @@
 
          subroutine test_basic
             real(dp) :: xlow=0, xhigh=1
-            real(dp) :: expected = 0.5d0
+            real(dp), parameter :: expected = 0.5d0
             real(dp) :: res
             integer :: ierr
 

--- a/num/test/src/test_support.f90
+++ b/num/test/src/test_support.f90
@@ -106,7 +106,7 @@
          ! stop seaching when x is determined to within epsx
          ! or when abs(f(x)) is less than epsy
          integer :: ierr
-         real(dp) :: expected_root = 0.74800611d0
+         real(dp), parameter :: expected_root = 0.74800611d0
          real(dp), target :: rpar_ary(lrpar)
          integer, target :: ipar_ary(lipar)
          integer, pointer :: ipar(:) ! (lipar)

--- a/rates/private/reaclib_support.f90
+++ b/rates/private/reaclib_support.f90
@@ -385,7 +385,7 @@
          integer, intent(in) :: iso_ids(:)
          character (len=*), intent(out) :: handle
          logical, parameter :: reverse = .true.
-         character (len=1) :: reaction_flag = '-'
+         character (len=1), parameter :: reaction_flag = '-'
          call get1_reaction_handle(num_in, num_out, iso_ids, chem_isos, reverse, reaction_flag, handle)
       end subroutine reverse_reaction_handle         
       
@@ -405,7 +405,7 @@
          type(nuclide_data), intent(in) :: nuclides
          character (len=*), intent(out) :: handle
          logical, parameter :: reverse = .true.
-         character (len=1) :: reaction_flag = '-'
+         character (len=1), parameter :: reaction_flag = '-'
          call get1_reaction_handle(num_in, num_out, pspecies, nuclides, reverse, reaction_flag, handle)
       end subroutine get_reverse_reaction_handle
       

--- a/rates/private/suzuki_tables.f90
+++ b/rates/private/suzuki_tables.f90
@@ -113,7 +113,7 @@ contains
 
     real(dp) :: decay, capture, nu, decay_nu, capture_nu
 
-    logical :: dbg = .false.
+    logical, parameter :: dbg = .false.
 
     logT = log10(T9) + 9d0
 

--- a/rates/private/weaklib_tables.f90
+++ b/rates/private/weaklib_tables.f90
@@ -212,7 +212,7 @@ contains
 
     real(dp) :: decay, capture
 
-    logical :: dbg = .false.
+    logical, parameter :: dbg = .false.
 
     xget = T9
     yget = lYeRho

--- a/rates/public/rates_def.f90
+++ b/rates/public/rates_def.f90
@@ -73,8 +73,8 @@
          r_one_four = 11
 
 
-      integer, dimension(nchapters) :: Nin = (/1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 1/)
-      integer, dimension(nchapters) :: Nout = (/1, 2, 3, 1, 2, 3, 4, 1, 2, 2, 4/)
+      integer, dimension(nchapters), parameter :: Nin = (/1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 1/)
+      integer, dimension(nchapters), parameter :: Nout = (/1, 2, 3, 1, 2, 3, 4, 1, 2, 2, 4/)
 
 
       type reaclib_data

--- a/rates/public/rates_lib.f90
+++ b/rates/public/rates_lib.f90
@@ -519,7 +519,7 @@
          integer, intent(in) :: num_in, num_out
          integer, intent(in) :: iso_ids(:) ! holds chem_ids for input and output species
          character (len=*), intent(out) :: handle
-         character (len=1) :: reaction_flag = '-'
+         character (len=1), parameter :: reaction_flag = '-'
          call reaction_handle(num_in, num_out, iso_ids, reaction_flag, handle)   
       end subroutine reaclib_create_handle
       
@@ -528,7 +528,7 @@
          integer, intent(in) :: num_in, num_out
          integer, intent(in) :: iso_ids(:) ! holds chem_ids for input and output species
          character (len=*), intent(out) :: handle
-         character (len=1) :: reaction_flag = 'e'
+         character (len=1), parameter :: reaction_flag = 'e'
          call reaction_handle(num_in, num_out, iso_ids, reaction_flag, handle)   
       end subroutine reaclib_create_ec_handle
       
@@ -537,7 +537,7 @@
          integer, intent(in) :: num_in, num_out
          integer, intent(in) :: iso_ids(:) ! holds chem_ids for input and output species
          character (len=*), intent(out) :: handle
-         character (len=1) :: reaction_flag = 'w'
+         character (len=1), parameter :: reaction_flag = 'w'
          call reaction_handle(num_in, num_out, iso_ids, reaction_flag, handle)   
       end subroutine reaclib_create_wk_handle
       

--- a/star/other/sample_pgstar_plot.f90
+++ b/star/other/sample_pgstar_plot.f90
@@ -212,7 +212,7 @@ contains
       integer :: grid_min, grid_max, npts, nz
       real, allocatable, dimension(:) :: xvec, yvec, yvec2, yvec3
 
-      logical :: dbg = .false.
+      logical, parameter :: dbg = .false.
 
       include 'formats'
       ierr = 0

--- a/star/private/eps_mdot.f90
+++ b/star/private/eps_mdot.f90
@@ -466,7 +466,7 @@
          integer :: ierr
          
          ! Intermediates
-         logical :: dbg = .false.
+         logical, parameter :: dbg = .false.
          integer :: nz, j
          real(dp) delta_m, change_sum, leak_sum, err, abs_err, mdot_adiabatic_surface, gradT_mid
          real(dp), dimension(:), allocatable :: &

--- a/star/private/hydro_eqns.f90
+++ b/star/private/hydro_eqns.f90
@@ -405,7 +405,7 @@
 
             integer :: i_var, i_var_sink
 
-            real(dp) :: dxa_threshold = 1d-4
+            real(dp), parameter :: dxa_threshold = 1d-4
 
             logical, parameter :: checking = .true.
 

--- a/star/private/overshoot.f90
+++ b/star/private/overshoot.f90
@@ -54,7 +54,7 @@ contains
     type(star_info), pointer :: s
     integer, intent(out)     :: ierr
 
-    logical, parameter :: DEBUG = .FALSE.
+    logical, parameter :: dbg = .false.
 
     integer  :: i
     integer  :: j
@@ -79,7 +79,7 @@ contains
 
     ierr = 0
 
-    if (DEBUG) then
+    if (dbg) then
        write(*, 3) 'add_overshooting; model, n_conv_bdy=', s%model_number, s%num_conv_boundaries
     end if
 
@@ -90,7 +90,7 @@ contains
        ! Skip this boundary if it's too close to the center
 
        if (s%conv_bdy_q(i) < s%min_overshoot_q) then
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'skip since s%conv_bdy_q(i) < min_overshoot_q', i
           endif
           cycle conv_bdy_loop
@@ -100,7 +100,7 @@ contains
        ! overshoot there
 
        if (s%conv_bdy_loc(i) == 1) then
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'skip since s%conv_bdy_loc(i) == 1', i
           endif
           cycle conv_bdy_loop
@@ -127,7 +127,7 @@ contains
                   s%burn_he_conv_region(i) .OR. &
                   s%burn_z_conv_region(i) )              
           case ('any')
-             match_zone_type = .TRUE.
+             match_zone_type = .true.
           case default
              write(*,*) 'Invalid overshoot_zone_type: j, s%overshoot_zone_type(j)=', j, s%overshoot_zone_type(j)
              ierr = -1
@@ -142,7 +142,7 @@ contains
           case ('shell')
              match_zone_loc = .NOT. is_core
           case ('any')
-             match_zone_loc = .TRUE.
+             match_zone_loc = .true.
           case default
              write(*,*) 'Invalid overshoot_zone_loc: j, s%overshoot_zone_loc(j)=', j, s%overshoot_zone_loc(j)
              ierr = -1
@@ -155,7 +155,7 @@ contains
           case ('top')
              match_bdy_loc = s%top_conv_bdy(i)
           case ('any')
-             match_bdy_loc = .TRUE.
+             match_bdy_loc = .true.
           case default
              write(*,*) 'Invalid overshoot_bdy_loc: j, s%overshoot_bdy_loc(j)=', j, s%overshoot_bdy_loc(j)
              ierr = -1
@@ -164,7 +164,7 @@ contains
 
           if (.NOT. (match_zone_type .AND. match_zone_loc .AND. match_bdy_loc)) cycle criteria_loop
 
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'Overshooting at convective boundary: i, j=', i, j
              write(*,*) '  s%overshoot_scheme=', TRIM(s%overshoot_scheme(j))
              write(*,*) '  s%overshoot_zone_type=', TRIM(s%overshoot_zone_type(j))

--- a/star/private/predictive_mix.f90
+++ b/star/private/predictive_mix.f90
@@ -52,7 +52,7 @@ contains
     type(star_info), pointer :: s
     integer, intent(out)     :: ierr
 
-    logical, parameter :: DEBUG = .FALSE.
+    logical, parameter :: dbg = .false.
 
     integer  :: i
     integer  :: j
@@ -71,14 +71,14 @@ contains
 
     ierr = 0
 
-    if (DEBUG) then
+    if (dbg) then
        write(*, *) 'add_predictive_mixing; model, n_conv_bdy=', &
             s%model_number, s%num_conv_boundaries
     end if
 
     ! Loop over convective boundaries, from center to surface
 
-    mix_mask = .FALSE.
+    mix_mask = .false.
 
     conv_bdy_loop : do i = 1, s%num_conv_boundaries
 
@@ -86,7 +86,7 @@ contains
        ! predictively mix there
 
        if (s%conv_bdy_loc(i) == 1) then
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'skip since s%conv_bdy_loc(i) == 1', i
           endif
           cycle conv_bdy_loop
@@ -113,7 +113,7 @@ contains
                   s%burn_he_conv_region(i) .OR. &
                   s%burn_z_conv_region(i) )              
           case ('any')
-             match_zone_type = .TRUE.
+             match_zone_type = .true.
           case default
              write(*,*) 'Invalid predictive_zone_type: j, s%predictive_zone_type(j)=', j, s%predictive_zone_type(j)
              ierr = -1
@@ -136,7 +136,7 @@ contains
           case ('surf')
              match_zone_loc = is_surf_zone
           case ('any')
-             match_zone_loc = .TRUE.
+             match_zone_loc = .true.
           case default
              write(*,*) 'Invalid predictive_zone_loc: j, s%predictive_zone_loc(j)=', j, s%predictive_zone_loc(j)
              ierr = -1
@@ -149,7 +149,7 @@ contains
           case ('top')
              match_bdy_loc = s%top_conv_bdy(i)
           case ('any')
-             match_bdy_loc = .TRUE.
+             match_bdy_loc = .true.
           case default
              write(*,*) 'Invalid predictive_bdy_loc: j, s%predictive_bdy_loc(j)=', j, s%predictive_bdy_loc(j)
              ierr = -1
@@ -161,7 +161,7 @@ contains
           if (s%conv_bdy_q(i) < s%predictive_bdy_q_min(j) .OR. &
               s%conv_bdy_q(i) > s%predictive_bdy_q_max(j)) cycle criteria_loop
           
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'Predictive mixing at convective boundary: i, j=', i, j
              write(*,*) '  s%predictive_zone_type=', TRIM(s%predictive_zone_type(j))
              write(*,*) '  s%predictive_zone_loc=', TRIM(s%predictive_zone_loc(j))
@@ -219,8 +219,8 @@ contains
     integer, intent(out)     :: ierr
     logical, intent(inout)   :: mix_mask(:)
 
-    logical, parameter :: DEBUG = .FALSE.
-    logical, parameter :: DUMP_PREDICTIONS = .FALSE.
+    logical, parameter :: dbg = .false.
+    logical, parameter :: DUMP_PREDICTIONS = .false.
 
     real(dp)       :: superad_thresh 
     real(dp)       :: ingest_factor
@@ -330,7 +330,7 @@ contains
 
     end if
 
-    if (DEBUG) then
+    if (dbg) then
        if (k_bot_cz < s%nz) then
           write(*,*) 'Predictive mixing: i, j, q_top, q_bot:', i, j, s%q(k_top_cz), s%q(k_bot_cz+1)
        else
@@ -401,7 +401,7 @@ contains
 
           if (.NOT. ALL(s%gradr(k_a:k_b) > s%grada_face(k_a:k_b))) then
 
-             ledoux_extension = .FALSE.
+             ledoux_extension = .false.
 
           else
 
@@ -428,7 +428,7 @@ contains
           if (iso_r /= 0) then
 
              if (SIGN(1._dp, xa_mz_burn(iso_r)-xa_ez(iso_r)) /= SIGN(1._dp, xa_ez_burn(iso_r)-xa_ez(iso_r))) then
-                if (DEBUG) then
+                if (dbg) then
                    write(*,*) 'Exiting predictive search due to abundance reversal'
                 end if
                 exit search_loop
@@ -457,7 +457,7 @@ contains
              ! If the mass ingested exceeds the limit, finish the search
 
              if (m_ingest > m_ingest_limit) then
-                if (DEBUG) then
+                if (dbg) then
                    write(*,*) 'Exiting predictive search due to ingestion limit exceeded'
                 end if
                 exit search_loop
@@ -473,7 +473,7 @@ contains
 
        if ((      outward .AND. gradr(k_a) < grada(k_a)) .OR. &
            (.NOT. outward .AND. gradr(k_b) < grada(k_b))) then
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'Exiting predictive search due to non-convective growing boundary'
           endif
           exit search_loop
@@ -491,7 +491,7 @@ contains
        endif
 
        if (superad_min <= superad_thresh) then
-          if (DEBUG) then
+          if (dbg) then
              write(*,*) 'Exiting predictive search due to convection-zone split'
           endif
           exit search_loop
@@ -528,18 +528,18 @@ contains
        end do
        call mesa_error(__FILE__,__LINE__,'Double predictive')
     else
-       mix_mask(k_top_mz:k_bot_mz) = .FALSE.
+       mix_mask(k_top_mz:k_bot_mz) = .false.
     endif
 
     ! Return now if no additional mixing should occur
 
     if (outward .AND. k_top_mz == k_top_cz) then
-       if (DEBUG) then
+       if (dbg) then
           write(*,*) 'No predictive mixing at top of zone; boundary i=', i
        endif
        return
     elseif (.NOT. outward .AND. k_bot_mz == k_bot_cz) then
-       if (DEBUG) then
+       if (dbg) then
           write(*,*) 'No predictive mixing at bottom of zone; boundary i=', i
        endif
        return
@@ -553,7 +553,7 @@ contains
     call eval_mixing_coeffs(s, k_bot_mz, k_top_mz, xa_mz_burn, &
                             k_a, k_b, D, vc, grada, gradr, ierr)
     if (ierr /= 0) then
-       if (DEBUG) write(*,*) 'Non-zero return from eval_mixing_coeffs in do_predictive_mixing/predictive_mix'
+       if (dbg) write(*,*) 'Non-zero return from eval_mixing_coeffs in do_predictive_mixing/predictive_mix'
        return
     endif
 
@@ -638,7 +638,7 @@ contains
 
     end if
 
-    if (DEBUG) then
+    if (dbg) then
        write(*,*) 'Predictive mixing: i, k_a, k_b, q_a, q_b, superad_min=', i, k_a, k_b, s%q(k_a), s%q(k_b), &
             superad_min
     endif
@@ -709,7 +709,7 @@ contains
     real(dp), intent(out)    :: gradr(:)
     integer, intent(out)     :: ierr
 
-    logical, parameter :: DEBUG = .FALSE.
+    logical, parameter :: dbg = .false.
 
     real(dp) :: xh
     real(dp) :: xhe
@@ -912,7 +912,7 @@ contains
     real(dp), intent(out)    :: d_dlnT(:)
     integer, intent(out)     :: ierr
 
-    logical, parameter  :: DEBUG = .FALSE.
+    logical, parameter  :: dbg = .false.
     real(dp), parameter :: LOGRHO_TOL = 1E-8_dp
     real(dp), parameter :: LOGPGAS_TOL = 1E-8_dp
 
@@ -924,7 +924,7 @@ contains
     ! pressure are as specified in the model, but with abundances
     ! given by xa and other input abundance parameters
 
-    ! (NEEDS FIXING TO HANDLE CASE WHEN LNPGAS_FLAG = .TRUE.)
+    ! (NEEDS FIXING TO HANDLE CASE WHEN LNPGAS_FLAG = .true.)
 
     call solve_eos_given_PgasT( &
          s, k, xa, &
@@ -932,7 +932,7 @@ contains
          logRho, res, d_dlnd, d_dlnT, d_dxa, &
        ierr)
     if (ierr /= 0) then
-       if (DEBUG) write(*,*) 'Non-zero return from solve_eos_given_PgasT in eval_eos/predictive_mix'
+       if (dbg) write(*,*) 'Non-zero return from solve_eos_given_PgasT in eval_eos/predictive_mix'
        return
     endif
 

--- a/star/private/pulse_utils.f90
+++ b/star/private/pulse_utils.f90
@@ -61,7 +61,7 @@ contains
     integer, allocatable, intent(out) :: k_b(:)
     logical, intent(in)               :: include_last_face
 
-    logical, parameter :: DEBUG = .FALSE.
+    logical, parameter :: dbg = .false.
 
     real(dp) :: grad_mu(s%nz)
     logical  :: mask(s%nz)
@@ -102,13 +102,13 @@ contains
 
           call qsort(i, s%nz, -ABS(grad_mu))
 
-          mask(i(n_mk+1:)) = .FALSE.
+          mask(i(n_mk+1:)) = .false.
 
        endif
 
     else
        
-       mask = .FALSE.
+       mask = .false.
 
     endif
 
@@ -131,7 +131,7 @@ contains
           sg = sg + 1
           k_a(sg) = k
 
-          if (DEBUG) then
+          if (dbg) then
              write(*, 100) k, grad_mu(k)
 100          format('placing double point at k=', I6, 1X, '(grad_mu=', 1PE10.3, ')')
           endif

--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -33,7 +33,7 @@
 
 
       real(dp), parameter :: min_dlnz = -12
-      real(dp) :: min_z = 1d-12
+      real(dp), parameter :: min_z = 1d-12
 
       ! some relax routines depend on things such as other_energy and other_torque
       ! to which interpolation parameters cannot be passed directly. So for simplicity

--- a/star/private/remove_shells.f90
+++ b/star/private/remove_shells.f90
@@ -1159,7 +1159,7 @@
          real(dp) :: time
          integer :: num_pts, k0, species
          logical :: save_have_mlt_vc
-         logical :: dbg = .false.
+         logical, parameter :: dbg = .false.
 
          ierr = 0
          call get_star_ptr(id, s, ierr)

--- a/star/private/rsp_lina.f90
+++ b/star/private/rsp_lina.f90
@@ -944,7 +944,7 @@
                  WORKx,4*NZN3,INFO)         
       if(INFO/=0)then
          write(*,*) 'FAILED!'
-         write(*,*) 'LAPACK/DGEEV error, ier= ',INFO
+         write(*,*) 'LAPACK/DGEEV error, ierr= ',INFO
          ierr = -1
          return
          stop

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -2514,7 +2514,7 @@
          type (star_info), pointer :: s
          real(dp), intent(in) :: he4_limit
          integer :: nz, h1, he4
-         real(dp) :: small = 1d-4
+         real(dp), parameter :: small = 1d-4
          after_He_burn = .false.
          nz = s% nz
          h1 = s% net_iso(ih1)
@@ -2530,7 +2530,7 @@
          type (star_info), pointer :: s
          real(dp), intent(in) :: c12_limit
          integer :: nz, h1, he4, c12
-         real(dp) :: small = 1d-4
+         real(dp), parameter :: small = 1d-4
          after_C_burn = .false.
          nz = s% nz
          h1 = s% net_iso(ih1)

--- a/stella/src/stl/math_constants.f90
+++ b/stella/src/stl/math_constants.f90
@@ -23,7 +23,7 @@
 
 module math_constants
 
-  use kinds,                           only: dp
+  use kinds, only: dp
 
   implicit none
 
@@ -33,7 +33,7 @@ module math_constants
   public :: deq,dgt,dne,dle,dlt,dge
   public :: dNeqZero, dEqZero, dLtZero, dGtZero
  
-  real(kind=dp), public :: one=1.0_dp,  eps=2*epsilon(one)
+  real(kind=dp), parameter, public :: one=1.0_dp,  eps=2*epsilon(one)
 
   real (kind=dp), parameter :: p_pi = 3.14159265358979323846264338_dp
   real (kind=dp), parameter :: p_pio2 = 1.57079632679489661923132169_dp

--- a/stella/src/util/epsilon.f90
+++ b/stella/src/util/epsilon.f90
@@ -1,7 +1,7 @@
 
  program test_epsilon
-   real :: x = 3.143
-   real(8) :: y = 2.33
+   real, parameter :: x = 3.143
+   real(8), parameter :: y = 2.33
    print *, EPSILON(x)
    print *, EPSILON(y)
 end program test_epsilon

--- a/turb/test/src/test_turb.f90
+++ b/turb/test/src/test_turb.f90
@@ -24,7 +24,7 @@ program test_turb
 
    subroutine check_efficient_MLT_scaling()
       type(auto_diff_real_star_order1) :: chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, gradr, grada, gradL
-      character(len=3) :: MLT_option = 'Cox'
+      character(len=3) :: MLT_option
       real(dp) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param
       type(auto_diff_real_star_order1) :: Gamma, gradT, Y_face, conv_vel, conv_vel2, D, r, L
       integer :: mixing_type, ierr


### PR DESCRIPTION
`Implicit saves` (https://fortran-lang.org/learn/quickstart/gotchas/#implied-save) is a _gotcha_ in Fortran that can lead to unintended behavior. Writing something like `integer :: c=0 ` is a one-shot initialization, where subsequent calls of the function will actually remember the variable value if changed.

As a first pass at identifying possible issues, I am looking for one-shot declarations using: 
`grep -v "parameter" */*/*f90 | grep "::.*=" | grep -v pointer | grep -v save`

These can be solved by adding an explicit `save` or `parameter` keyword when needed. Or, if the variable should not be saved, then set its value in a new line.

So far, I've just added some obvious parameter keywords. In the future we can detect possible issues with compiler flags, but just want to clean up obvious fixes first. There should not be an impact on the code results.

---

There is also the issue that `1_dp` and `1.0_dp` are not the same thing in Fortran (see: https://fortran-lang.org/learn/quickstart/gotchas/#floating-point-literal-constants-again). The former actually becomes a integer literal constant, and can have the wrong consequences if we are using them to compute real numbers. So I made a few changes in the code fixing these. It should not have an effect because the issue usually shows up when you are composing 2 of these integer literal constants, but is better practice to have the `.0_dp` added