### PR TITLE
Do not guard calls mesa_error() with report_ierr

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,7 +24,7 @@ New Features
 Bug Fixes
 ---------
 
-
+fixed small bug in star/private/create_initial_model.f90 that will have a small effect on creating inital models
 
 
 .. note:: Before releasing a new version of MESA, move `Changes in main` to a new section below with the version number as the title, and add a new `Changes in main` section at the top of the file (see ```changelog_template.rst```).

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -11216,7 +11216,7 @@
       ! stop_for_bad_nums
       ! ~~~~~~~~~~~~~~~~~
 
-      ! If true and report_ierr is also true, then stop for bad numbers (NaNs or infinity).
+      ! If true and ``report_ierr`` is also true, then stop for bad numbers (NaNs or infinity).
       ! this replaces old control stop_for_NaNs
 
       ! ::

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -11216,7 +11216,7 @@
       ! stop_for_bad_nums
       ! ~~~~~~~~~~~~~~~~~
 
-      ! If true and ``report_ierr`` is also true, then stop for bad numbers (NaNs or infinity).
+      ! If true, then stop for bad numbers (NaNs or infinity).
       ! this replaces old control stop_for_NaNs
 
       ! ::

--- a/star/private/atm_support.f90
+++ b/star/private/atm_support.f90
@@ -532,7 +532,6 @@ contains
        s% retry_message = 'atm get_table: L < 0'
        if (s% report_ierr) then
           write(*,2) 'atm get_table: L < 0', s% model_number, L
-          !call mesa_error(__FILE__,__LINE__)
        end if
        ierr = -1
        return

--- a/star/private/brunt.f90
+++ b/star/private/brunt.f90
@@ -330,7 +330,6 @@
                write(*,2) 'lnP1', k, lnP1
                write(*,2) 'lnP2', k, lnP2
                write(*,'(A)')
-               !call mesa_error(__FILE__,__LINE__,'do_brunt_B_MHM_form')
             end if
             if (s% stop_for_bad_nums) then
                write(*,2) 's% brunt_B(k)', k, s% brunt_B(k)

--- a/star/private/eos_support.f90
+++ b/star/private/eos_support.f90
@@ -87,7 +87,7 @@ contains
     if(logRho < -25) then
       ! Provide some hard lower limit on what we would even try to evalue the eos at
       ! Going to low causes FPE's when we try to evaluate certain derviatives that need (rho**power)
-      s% retry_message = 'eos evaluted at too low a density'
+      s% retry_message = 'eos evaluated at too low a density'
       ierr = -1
       return
     end if

--- a/star/private/eps_grav.f90
+++ b/star/private/eps_grav.f90
@@ -390,10 +390,9 @@
          end if
 
          if (is_bad(eps_grav_composition_term% val)) then
-          if (s% report_ierr) write(*, *) s% retry_message
             if (s% report_ierr) then
+               write(*, *) s% retry_message
                write(*,2) 'eps_grav_composition_term', k, eps_grav_composition_term% val
-               !call mesa_error(__FILE__,__LINE__,'eval_eps_grav_composition')
             end if
             if (s% stop_for_bad_nums) then
                write(*,2) 'include_composition_in_eps_grav -- bad value for eps_grav_composition_term', k, eps_grav_composition_term% val

--- a/star/private/hydro_vars.f90
+++ b/star/private/hydro_vars.f90
@@ -890,8 +890,8 @@
                if (L_surf < 0._dp) then
                   if (s% report_ierr) then
                      write(*,2) 'get_surf_PT: L_surf <= 0', s% model_number, L_surf
-                     call mesa_error(__FILE__,__LINE__)
                   end if
+                  if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__)
                   s% retry_message = 'L_surf < 0'
                   ierr = -1
                   return

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -382,6 +382,7 @@ contains
          s% d_eos_dxa(:,:,k), ierr)
     if (ierr /= 0) then
        if (s% report_ierr) then
+          write(*, *) s% retry_message
           write(*,*) 'do_eos_for_cell: get_eos ierr', ierr
        end if
        if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -357,8 +357,8 @@ contains
        if (ierr /= 0) then
           if (s% report_ierr) then
              write(*,*) 'do_eos_for_cell: solve_eos_given_PT ierr', ierr
-             !call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')
           end if
+          if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')
           return
        end if
 
@@ -383,8 +383,8 @@ contains
     if (ierr /= 0) then
        if (s% report_ierr) then
           write(*,*) 'do_eos_for_cell: get_eos ierr', ierr
-          !call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')
        end if
+       if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')
        return
     end if
 
@@ -404,7 +404,7 @@ contains
        s% solver_call_number == s% solver_test_partials_call_number .and. &
        s% solver_iter == s% solver_test_partials_iter_number) then
        call write_eos_call_info(s,k)
-       call mesa_error(__FILE__,__LINE__,'do_eos_for_cell: write_eos_call_info')
+       if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_eos_for_cell: write_eos_call_info')
     end if
 
   contains
@@ -423,9 +423,8 @@ contains
          if (s% report_ierr) then
             call write_eos_call_info(s,k)
             write(*,2) 'store_eos_for_cell failed', k
-            if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')
-            return
          end if
+         if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_eos_for_cell')
          return
       end if
 
@@ -465,9 +464,9 @@ contains
              write(*,2) 'd_dlnT ' // trim(eosDT_result_names(i)), k, d_dlnT(i)
              write(*,'(A)')
              call write_eos_call_info(s,k)
-             if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'store_eos_for_cell')
              !$OMP end critical (micro_crit0)
           end if
+          if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'store_eos_for_cell')
           return
        end if
     end do
@@ -558,9 +557,9 @@ contains
           write(*,2) 'zbar', k, s% zbar(k)
           write(*,*)
           call write_eos_call_info(s,k)
-          call mesa_error(__FILE__,__LINE__,'store_eos_for_cell')
           !$OMP end critical (micro_crit1)
        end if
+       if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'store_eos_for_cell')
        ierr = -1
     end if
 
@@ -636,9 +635,9 @@ contains
           write(*,*) 'do_kap_for_cell: get_kap ierr', ierr
           !$omp critical (star_kap_get)
           call show_stuff()
-          if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_kap_for_cell')
           !$omp end critical (star_kap_get)
        end if
+       if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do_kap_for_cell')
        ierr = -1
        return
     end if

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -493,7 +493,7 @@ contains
     s% grada(k) = res(i_grad_ad)
     s% dE_dRho(k) = res(i_dE_drho)
     s% Cv(k) = res(i_Cv)
-    s% cp(k) = res(i_cp)
+    s% Cp(k) = res(i_Cp)
     s% chiRho(k) = res(i_chiRho)
     s% chiT(k) = res(i_chiT)
     s% gamma1(k) = res(i_gamma1)
@@ -544,7 +544,7 @@ contains
     if (ierr /= 0) then
        if (s% report_ierr) then
           !$OMP critical (micro_crit1)
-          write(*,2) 's% cp(k)', k, s% cp(k)
+          write(*,2) 's% Cp(k)', k, s% Cp(k)
           write(*,2) 's% csound(k)', k, s% csound(k)
           write(*,2) 's% lnPeos(k)', k, s% lnPeos(k)
           write(*,2) 's% gam(k)', k, s% gam(k)

--- a/star/private/rsp.f90
+++ b/star/private/rsp.f90
@@ -680,8 +680,8 @@
          if (s% dt > max_dt) then
             if (s% RSP_report_limit_dt) then
                write(*,4) 'limit to RSP_max_dt_times_min_dr_div_cs', s% model_number, max_dt, s% dt
-               call mesa_error(__FILE__,__LINE__,'do1_step 1')
             end if
+            call mesa_error(__FILE__,__LINE__,'do1_step 1')
             s% dt = max_dt
          end if
          

--- a/star/private/rsp.f90
+++ b/star/private/rsp.f90
@@ -681,7 +681,7 @@
             if (s% RSP_report_limit_dt) then
                write(*,4) 'limit to RSP_max_dt_times_min_dr_div_cs', s% model_number, max_dt, s% dt
             end if
-            call mesa_error(__FILE__,__LINE__,'do1_step 1')
+            if (s% stop_for_bad_nums) call mesa_error(__FILE__,__LINE__,'do1_step 1')
             s% dt = max_dt
          end if
          

--- a/star/private/rsp_step.f90
+++ b/star/private/rsp_step.f90
@@ -254,8 +254,8 @@
                   write(*,2) 'old dt', s% model_number, s% dt
                   write(*,2) 'reduced dt', s% model_number, dt_max
                   write(*,'(A)')
-                  call mesa_error(__FILE__,__LINE__,'HYD compressing innermost cell')
                end if
+               call mesa_error(__FILE__,__LINE__,'HYD compressing innermost cell')
                s% dt = dt_max
                if (call_is_bad) then
                   if (is_bad(s% dt)) then

--- a/star/private/star_profile_def.f90
+++ b/star/private/star_profile_def.f90
@@ -211,8 +211,8 @@
       integer, parameter :: p_grada = p_logE + 1
       integer, parameter :: p_dE_dRho = p_grada + 1
       integer, parameter :: p_Cv = p_dE_dRho + 1
-      integer, parameter :: p_cp = p_Cv + 1
-      integer, parameter :: p_thermal_time_to_surface = p_cp + 1
+      integer, parameter :: p_Cp = p_Cv + 1
+      integer, parameter :: p_thermal_time_to_surface = p_Cp + 1
       integer, parameter :: p_log_thermal_time_to_surface = p_thermal_time_to_surface + 1
       integer, parameter :: p_log_CpT = p_log_thermal_time_to_surface + 1
       integer, parameter :: p_log_CpT_absMdot_div_L = p_log_CpT + 1
@@ -505,8 +505,8 @@
       integer, parameter :: p_mixing_type = p_mix_type + 1
 
       integer, parameter :: p_log_mlt_D_mix = p_mixing_type + 1
-      integer, parameter :: p_log_cp_T_div_t_sound = p_log_mlt_D_mix + 1
-      integer, parameter :: p_log_t_thermal = p_log_cp_T_div_t_sound + 1
+      integer, parameter :: p_log_Cp_T_div_t_sound = p_log_mlt_D_mix + 1
+      integer, parameter :: p_log_t_thermal = p_log_Cp_T_div_t_sound + 1
       integer, parameter :: p_log_t_sound = p_log_t_thermal + 1
       integer, parameter :: p_pressure_scale_height_cm = p_log_t_sound + 1
       integer, parameter :: p_pressure_scale_height = p_pressure_scale_height_cm + 1
@@ -904,10 +904,10 @@
          profile_column_name(p_logE) = 'logE'
          profile_column_name(p_grada) = 'grada'
          profile_column_name(p_dE_dRho) = 'dE_dRho'
-         profile_column_name(p_cv) = 'cv'
+         profile_column_name(p_Cv) = 'cv'
          profile_column_name(p_thermal_time_to_surface) = 'thermal_time_to_surface'
          profile_column_name(p_log_thermal_time_to_surface) = 'log_thermal_time_to_surface'
-         profile_column_name(p_cp) = 'cp'
+         profile_column_name(p_Cp) = 'cp'
          profile_column_name(p_log_CpT) = 'log_CpT'
          profile_column_name(p_log_CpT_absMdot_div_L) = 'log_CpT_absMdot_div_L'
          profile_column_name(p_logS) = 'logS'
@@ -1191,7 +1191,7 @@
          profile_column_name(p_mix_type) = 'mix_type'
          profile_column_name(p_mixing_type) = 'mixing_type'
          profile_column_name(p_log_mlt_D_mix) = 'log_mlt_D_mix'
-         profile_column_name(p_log_cp_T_div_t_sound) = 'log_cp_T_div_t_sound'
+         profile_column_name(p_log_Cp_T_div_t_sound) = 'log_cp_T_div_t_sound'
          profile_column_name(p_log_t_thermal) = 'log_t_thermal'
          profile_column_name(p_log_t_sound) = 'log_t_sound'
          profile_column_name(p_pressure_scale_height_cm) = 'pressure_scale_height_cm'

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -935,7 +935,6 @@
             do_burn = retry
             if (trace .or. s% report_ierr) then
                write(*,*) 'do_burn ierr'
-               !call mesa_error(__FILE__,__LINE__,'do_burn')
             end if
             call restore
             return

--- a/star/private/timestep.f90
+++ b/star/private/timestep.f90
@@ -352,8 +352,8 @@
                write(*,2) 's% dt', s% model_number, s% dt
                write(*,2) 'max_timestep_factor', s% model_number, max_timestep_factor
                write(*,2) 's% dt_next', s% model_number, s% dt_next
-               if (s% dt_next == 0d0) call mesa_error(__FILE__,__LINE__,'filter_dt_next')
             end if
+            if (s% dt_next == 0d0) call mesa_error(__FILE__,__LINE__,'filter_dt_next')
             if (i_limit == Tlim_struc) i_limit = Tlim_max_timestep_factor
          end if
 
@@ -363,8 +363,8 @@
                write(*,2) 's% dt', s% model_number, s% dt
                write(*,2) 'min_timestep_factor', s% model_number, s% min_timestep_factor
                write(*,2) 's% dt_next', s% model_number, s% dt_next
-               if (s% dt_next == 0d0) call mesa_error(__FILE__,__LINE__,'filter_dt_next')
             end if
+            if (s% dt_next == 0d0) call mesa_error(__FILE__,__LINE__,'filter_dt_next')
             if (i_limit == Tlim_struc) i_limit = Tlim_min_timestep_factor
          end if
 
@@ -2430,8 +2430,8 @@
                write(*,2) 'dt_limit_ratio_target', s% model_number, dt_limit_ratio_target
                write(*,2) 'dt_limit_ratio', s% model_number, dt_limit_ratio
                write(*,2) 'filter_dt_next', s% model_number, s% dt_next
-               if (s% dt_next == 0d0) call mesa_error(__FILE__,__LINE__,'filter_dt_next')
             end if
+            if (s% dt_next == 0d0) call mesa_error(__FILE__,__LINE__,'filter_dt_next')
          end if
 
 


### PR DESCRIPTION

The user flag `report_ierr = .true.` is used as a debugging tool to report diagnostics on internal errors in Mesa but not stop the code. Flipping the switch to true should not change the outcome of the simulation. Therefore, we should not call `mesa_error()` inside `if(report_ierr == .true.)` if statements. Either always just halt the code, or use guards like `if(stop_for_bad_nums == .true.)`. 

There are just a handful of cases in the code where this pattern was not followed. This is dangerous because it can cause non-reproducible results when someone is trying to debug their run switches `report_ierr = .true.` on. Particularly in simulations that chain more than one inlist. For example, running `./run_all` for the `20M_pre_ms_to_core_collapse` test problem with `report_ierr = .true.` was yielding a different result than switching diagnostics off because one of the inlists in the middle of the chain was ending prematurely and the next inlist restarted the simulation from the last photo written.

**TL;DR:** fix so that switching on diagnostics reporting does not change outcome of the simulation 
