### PR TITLE
Small binary_history_fix

### DIFF
--- a/binary/private/binary_history.f90
+++ b/binary/private/binary_history.f90
@@ -70,7 +70,7 @@ contains
       integer, intent(out) :: ierr
 
       type (binary_info), pointer :: b
-      integer :: c, int_val, i, j
+      integer :: c, int_val, j
       logical :: is_int_val
       real(dp) :: val
 
@@ -121,7 +121,7 @@ contains
       integer, intent(out) :: ierr
 
       character (len = strlen) :: fname, dbl_fmt, int_fmt, txt_fmt
-      integer :: numcols, io, i, nz, col, j, i0, n
+      integer :: numcols, io, i, col, j, i0, n
 
       integer :: num_extra_header_items, num_extra_cols
 
@@ -408,8 +408,7 @@ contains
       subroutine do_col_pass2(j) ! get the column name
          integer, intent(in) :: j
          character (len = 100) :: col_name
-         character (len = 10) :: str
-         integer :: c, i, ii
+         integer :: c
          c = b% binary_history_column_spec(j)
          col_name = trim(binary_history_column_name(c))
          call do_name(j, col_name)
@@ -418,9 +417,9 @@ contains
 
       subroutine do_col_pass3(c) ! get the column value
          integer, intent(in) :: c
-         integer :: i, ii, k, int_val
+         integer :: k, int_val
          logical :: is_int_val
-         real(dp) :: val, val1, Ledd, power_photo, frac
+         real(dp) :: val
          int_val = 0; val = 0; is_int_val = .false.
          call binary_history_getval(&
             b, c, val, int_val, is_int_val, ierr)
@@ -521,7 +520,6 @@ contains
       integer, intent(out) :: int_val
       logical, intent(out) :: is_int_val
       integer, intent(out) :: ierr
-      integer :: k, i
 
       include 'formats'
 
@@ -768,7 +766,6 @@ contains
 
       integer :: i, ierr, n, j, iounit, t
       character (len = strlen) :: buffer, string
-      logical :: special_case
 
       include 'formats'
       ierr = 0
@@ -788,10 +785,9 @@ contains
             ierr = 0
             cycle
          end if
-         special_case = .false.
          specs(i) = do1_binary_history_spec(&
             iounit, t, n, j, string, buffer, report, ierr)
-         if (ierr /= 0 .or. special_case) then
+         if (ierr /= 0) then
             if (report) write(*, *) 'get_binary_history_specs failed for ' // trim(names(i))
             specs(i) = -1
             ierr = 0
@@ -816,10 +812,7 @@ contains
       real(dp), intent(inout) :: values(:)
       logical, intent(out) :: failed_to_find_value(:)
 
-      integer :: i, c, int_val, ierr, n, t, j, iounit
-      real(dp) :: val
-      logical :: is_int_val, special_case
-      character (len = strlen) :: buffer, string
+      integer :: i, c, ierr
 
       include 'formats'
       ierr = 0
@@ -848,10 +841,8 @@ contains
       character (len = *) :: name
       real(dp), intent(out) :: val
       integer :: i, ierr, num_extra_cols
-      character (len = 80), pointer, dimension(:) :: &
-         extra_col_names, binary_col_names
-      real(dp), pointer, dimension(:) :: &
-         extra_col_vals, binary_col_vals
+      character (len = 80), pointer, dimension(:) :: extra_col_names
+      real(dp), pointer, dimension(:) :: extra_col_vals
       include 'formats'
 
       get1_binary_hist_value = .false.

--- a/binary/private/binary_history_specs.f90
+++ b/binary/private/binary_history_specs.f90
@@ -53,7 +53,7 @@ contains
       character (len = *), intent(in) :: history_columns_file
       integer, intent(out) :: ierr
 
-      integer :: iounit, n, i, t, id, j, cnt, ii, nxt_spec
+      integer :: iounit, n, i, t, j, nxt_spec
       character (len = 256) :: buffer, string, filename
       integer, parameter :: max_level = 20
       logical :: bad_item
@@ -196,7 +196,7 @@ contains
       use utils_def
       use chem_lib
 
-      integer :: iounit, t, n, i, j, id
+      integer :: iounit, t, n, i, j
       character (len = *) :: string, buffer
       logical, intent(in) :: report
       integer, intent(out) :: ierr

--- a/binary/private/binary_history_specs.f90
+++ b/binary/private/binary_history_specs.f90
@@ -41,7 +41,7 @@ module binary_history_specs
 contains
 
    recursive subroutine add_binary_history_columns(&
-      b, level, capacity, spec, history_columns_file, ierr)
+      b, level, capacity, spec, history_columns_file, report, ierr)
       use utils_lib
       use utils_def
       use const_def, only : mesa_dir
@@ -49,10 +49,11 @@ contains
       integer, intent(in) :: level
       integer, intent(inout) :: capacity
       integer, pointer :: spec(:)
+      logical, intent(in) :: report
       character (len = *), intent(in) :: history_columns_file
       integer, intent(out) :: ierr
 
-      integer :: iounit, n, i, t, j, nxt_spec
+      integer :: iounit, n, i, t, id, j, cnt, ii, nxt_spec
       character (len = 256) :: buffer, string, filename
       integer, parameter :: max_level = 20
       logical :: bad_item
@@ -107,7 +108,7 @@ contains
             if (t /= string_token) then
                call error; return
             end if
-            call add_binary_history_columns(b, level + 1, capacity, spec, string, ierr)
+            call add_binary_history_columns(b, level + 1, capacity, spec, string, report, ierr)
             if (ierr /= 0) then
                write(*, *) 'failed for included log columns list ' // trim(string)
                bad_item = .true.
@@ -116,7 +117,7 @@ contains
             cycle
          end if
 
-         nxt_spec = do1_binary_history_spec(iounit, t, n, i, string, buffer, ierr)
+         nxt_spec = do1_binary_history_spec(iounit, t, n, i, string, buffer, report, ierr)
          if (ierr /= 0) bad_item = .true.
          if (.not. bad_item) then
             call insert_spec(nxt_spec, string, ierr)
@@ -190,13 +191,14 @@ contains
 
 
    integer function do1_binary_history_spec(&
-      iounit, t, n, i, string, buffer, ierr) result(spec)
+      iounit, t, n, i, string, buffer, report, ierr) result(spec)
       use utils_lib
       use utils_def
       use chem_lib
 
-      integer :: iounit, t, n, i, j
+      integer :: iounit, t, n, i, j, id
       character (len = *) :: string, buffer
+      logical, intent(in) :: report
       integer, intent(out) :: ierr
 
       ierr = 0
@@ -209,15 +211,16 @@ contains
          end if
       end do
 
-      write(*, *) 'bad history list name: ' // trim(string)
+      if (report) write(*, *) 'bad history list name: ' // trim(string)
       ierr = -1
 
    end function do1_binary_history_spec
 
-   subroutine set_binary_history_columns(b, binary_history_columns_file, ierr)
+   subroutine set_binary_history_columns(b, binary_history_columns_file, report, ierr)
       use utils_lib, only : realloc_integer
       type(binary_info), pointer :: b
       character (len = *), intent(in) :: binary_history_columns_file
+      logical, intent(in) :: report
       integer, intent(out) :: ierr
       integer :: capacity, cnt, i
       logical, parameter :: dbg = .false.
@@ -235,7 +238,7 @@ contains
       if (ierr /= 0) return
       b% binary_history_column_spec(:) = 0
       call add_binary_history_columns(b, 1, capacity, &
-         b% binary_history_column_spec, binary_history_columns_file, ierr)
+         b% binary_history_column_spec, binary_history_columns_file, report, ierr)
       if (ierr /= 0) then
          if (associated(old_binary_history_column_spec)) &
             deallocate(old_binary_history_column_spec)

--- a/binary/private/pgbinary_summary.f90
+++ b/binary/private/pgbinary_summary.f90
@@ -403,7 +403,7 @@ contains
          real(dp) :: val
 
          call get_binary_history_specs(&
-            b, num_rows, Text_Summary_name(:, col), specs)
+            b, num_rows, Text_Summary_name(:, col), specs, .false.)
          call get_binary_history_values(&
             b, num_rows, specs, &
             is_int_value, int_values, values, failed_to_find_value)

--- a/binary/private/run_binary_support.f90
+++ b/binary/private/run_binary_support.f90
@@ -290,7 +290,7 @@ contains
       call binarydata_init(b, doing_restart)
       call binary_private_def_init
       call binary_history_column_names_init(ierr)
-      call set_binary_history_columns(b, b% job% binary_history_columns_file, ierr)
+      call set_binary_history_columns(b, b% job% binary_history_columns_file, .true., ierr)
 
       ! setup pgbinary
       if (.not. doing_restart) then


### PR DESCRIPTION
Akin to `star/history.f90,` this stop the warning that user-defined columns are not being found when fetching data for `pgbinary`