### PR TITLE
Introduce mass ratio

### DIFF
--- a/binary/defaults/binary_history_columns.list
+++ b/binary/defaults/binary_history_columns.list
@@ -72,6 +72,8 @@
       star_2_mass ! mass of second star in msun
       !lg_star_2_mass ! log10 mass of second star in msun
       !sum_of_masses ! star_1_mass + star_2_mass
+      !mass_ratio ! star_2_mass / star_1_mass
+      !obs_mass_ratio ! min(m2/m1, m2/m1)
       lg_mtransfer_rate ! log10 of abs(mass transfer rate) in Msun/yr
                      ! this considers the amount of mass lost from the donor due to RLOF
                      ! not the actual mass that ends up accreted

--- a/binary/defaults/pgbinary.defaults
+++ b/binary/defaults/pgbinary.defaults
@@ -1897,8 +1897,8 @@
       ! ::
 
    Text_Summary1_win_flag = .false.
-   Text_Summary1_win_width = 10
-   Text_Summary1_win_aspect_ratio = 0.15
+   Text_Summary1_win_width = 7
+   Text_Summary1_win_aspect_ratio = 0.6
 
       ! ::
 
@@ -1906,7 +1906,7 @@
    Text_Summary1_xright = 0.98
    Text_Summary1_ybot = 0.08
    Text_Summary1_ytop = 0.98
-   Text_Summary1_txt_scale = 4.5
+   Text_Summary1_txt_scale = 3.0
    Text_Summary1_title = ''
 
       ! setup default

--- a/binary/defaults/pgbinary.defaults
+++ b/binary/defaults/pgbinary.defaults
@@ -1913,13 +1913,17 @@
 
       ! ::
 
-   Text_Summary1_num_rows = 8
-   Text_Summary1_num_cols = 4
+   Text_Summary1_num_rows = 5
+   Text_Summary1_num_cols = 1
    Text_Summary1_name(:, :) = ''
 
       ! ::
 
    Text_Summary1_name(1, 1) = 'model_number'
+   Text_Summary1_name(2, 1) = 'jdot'
+   Text_Summary1_name(3, 1) = 'mass_ratio'
+   Text_Summary1_name(4, 1) = 'period_days'
+   Text_Summary1_name(5, 1) = 'rl_relative_overflow_1'
 
       ! file output
 

--- a/binary/private/binary_history.f90
+++ b/binary/private/binary_history.f90
@@ -595,6 +595,10 @@ contains
          val = safe_log10(b% m(2) / Msun)
       case(bh_sum_of_masses)
          val = (b% m(1) + b% m(2)) / Msun
+      case(bh_mass_ratio)
+         val = b% m(2) / b% m(1)
+      case(bh_obs_mass_ratio)
+         val = min(b% m(2) / b% m(1), b% m(1) / b% m(2))
       case(bh_lg_mtransfer_rate)
          val = safe_log10(abs(b% step_mtransfer_rate) / Msun * secyer)
       case(bh_lg_mstar_dot_1)

--- a/binary/private/binary_private_def.f90
+++ b/binary/private/binary_private_def.f90
@@ -57,7 +57,9 @@
       integer, parameter :: bh_star_2_mass = bh_lg_star_1_mass + 1
       integer, parameter :: bh_lg_star_2_mass = bh_star_2_mass + 1
       integer, parameter :: bh_sum_of_masses = bh_lg_star_2_mass + 1
-      integer, parameter :: bh_lg_mtransfer_rate = bh_sum_of_masses + 1
+      integer, parameter :: bh_mass_ratio = bh_sum_of_masses + 1
+      integer, parameter :: bh_obs_mass_ratio = bh_mass_ratio + 1
+      integer, parameter :: bh_lg_mtransfer_rate = bh_obs_mass_ratio + 1
       integer, parameter :: bh_lg_mstar_dot_1 = bh_lg_mtransfer_rate + 1
       integer, parameter :: bh_lg_mstar_dot_2 = bh_lg_mstar_dot_1 + 1
       integer, parameter :: bh_lg_system_mdot_1 = bh_lg_mstar_dot_2 + 1

--- a/binary/private/binary_private_def.f90
+++ b/binary/private/binary_private_def.f90
@@ -147,6 +147,8 @@
          binary_history_column_name(bh_star_2_mass) = 'star_2_mass'
          binary_history_column_name(bh_lg_star_2_mass) = 'lg_star_2_mass'
          binary_history_column_name(bh_sum_of_masses) = 'sum_of_masses'
+         binary_history_column_name(bh_mass_ratio) = 'mass_ratio'
+         binary_history_column_name(bh_obs_mass_ratio) = 'obs_mass_ratio'
          binary_history_column_name(bh_lg_mtransfer_rate) = 'lg_mtransfer_rate'
          binary_history_column_name(bh_lg_mstar_dot_1) = 'lg_mstar_dot_1'
          binary_history_column_name(bh_lg_mstar_dot_2) = 'lg_mstar_dot_2'


### PR DESCRIPTION
Small QOL improvement for binary runs.

In binary simulations, the mass ratio is important enough to have a history column available out of the box in mesa (and it required for plotting with `pgbinary`).
I understand the definition of `q` is not universal, some fields use `m1/m2`, others `m2/m1` (I chose the latter, typically the initially less massive over the initially more mass star). Hence I also implemented `min(m2/m1, m1/m2)` as an "observational" mass ratio.