### PR TITLE
fix bug in adjust_mass.f90

### DIFF
--- a/star/private/adjust_mass.f90
+++ b/star/private/adjust_mass.f90
@@ -1499,7 +1499,10 @@
          ierr = 0
 
          mass_lost = s% mstar_old - s% mstar
-         if (mass_lost <= 0) return
+         if (mass_lost <= 0) then
+            s% adjust_J_q = 1d0  ! nothing to do
+            return
+         end if
 
          ! can use a different j to account for things like wind braking
          if (s% use_other_j_for_adjust_J_lost) then


### PR DESCRIPTION
There's a subtle bug in the adjust_mass/adjust_J_lost routine.
When the star is hardly losing mass (say `s% star_mdot < -1d-99`, which is possible when eg using "Kolb" mass transfer without winds), the `mass_lost` in the routine still reads `0d0` to floating point precision, and `s% adjust_J_q` is untouched at `0d0`
Later, in `timestep.f90`, the check is whether `s% mstar_dot < 0d0`, which it is, it's `-1d-99`, and then any hard limit is always hit, causing infinite retries.

this is a simple fix to this bug.