### PR TITLE
Porting the flux-limiter prescription from r9793 to the latest MESA version

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -8260,7 +8260,7 @@
       !|     if (use_flux_limiting_with_dPrad_dm_form)
       !|         flxR = 4 * pi * r^2 * abs(dT^4/dm) / kap
       !|         flxLambda = (6 + 3*flxR) / (6 + 3*flxR + flxR^2) (see Levermore & Pomraning 1981)
-      !|         L_rad = flxLambda * L_rad
+      !|         L_rad = L_rad / flxLambda
       !|         
 
       ! With the resulting ``L_rad``, determine the expected dT/dm by

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -8228,8 +8228,11 @@
 
       ! use_dPrad_dm_form_of_T_gradient_eqn
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! use_flux_limiting_with_dPrad_dm_form
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ! use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
       ! These are for alternatives ways to determine the T gradient.
       ! The standard form of the equation is
@@ -8254,6 +8257,11 @@
       !|            use L_rad = L*gradT/gradr (see, e.g., Cox&Giuli 14.109)
       !|         else
       !|            use L_rad = L
+      !|     if (use_flux_limiting_with_dPrad_dm_form)
+      !|         flxR = 4 * pi * r^2 * abs(dT^4/dm) / kap
+      !|         flxLambda = (6 + 3*flxR) / (6 + 3*flxR + flxR^2) (see Levermore & Pomraning 1981)
+      !|         L_rad = flxLambda * L_rad
+      !|         
 
       ! With the resulting ``L_rad``, determine the expected dT/dm by
 
@@ -8262,6 +8270,7 @@
       ! ::
 
     use_dPrad_dm_form_of_T_gradient_eqn = .false.
+    use_flux_limiting_with_dPrad_dm_form = .false.
     use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = .false.    
   
   

--- a/star/defaults/profile_columns.list
+++ b/star/defaults/profile_columns.list
@@ -148,6 +148,8 @@
    !pgas ! gas pressure at center of zone (electrons and ions)
    !logPgas ! log10(pgas)
    !pgas_div_ptotal ! pgas/pressure
+   !flux_limit_lambda ! flux limiter defined as in Levermore & Pomraning 1981
+   !flux_limit_R ! flux ratio defined as in Levermore & Pomraning 1981
 
    !eta ! electron degeneracy parameter (eta >> 1 for significant degeneracy)
    !mu ! mean molecular weight per gas particle (ions + free electrons)

--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -766,6 +766,11 @@
             call do1(s% dr_div_csound, c% dr_div_csound)
             if (failed('dr_div_csound')) exit
 
+            call do1(s% flux_limit_R, c% flux_limit_R)
+            if (failed('flux_limit_R')) exit
+            call do1(s% flux_limit_lambda, c% flux_limit_lambda)
+            if (failed('flux_limit_lambda')) exit
+
             call do1(s% ergs_error, c% ergs_error)
             if (failed('ergs_error')) exit
             call do1(s% gradr_factor, c% gradr_factor)

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -344,7 +344,7 @@
     include_composition_in_eps_grav, no_dedt_form_during_relax, &
     max_abs_rel_change_surf_lnS, &
     max_num_surf_revisions, Gamma_lnS_eps_grav_full_off, Gamma_lnS_eps_grav_full_on, &
-    use_dPrad_dm_form_of_T_gradient_eqn, use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn, dedt_eqn_r_scale, &
+    use_dPrad_dm_form_of_T_gradient_eqn, use_flux_limiting_with_dPrad_dm_form, use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn, dedt_eqn_r_scale, &
     RTI_A, RTI_B, RTI_C, RTI_D, RTI_max_alpha, RTI_C_X_factor, RTI_C_X0_frac, steps_before_use_velocity_time_centering, &
     RTI_dm_for_center_eta_nondecreasing, RTI_min_dm_behind_shock_for_full_on, RTI_energy_floor, &
     RTI_D_mix_floor, RTI_min_m_for_D_mix_floor, RTI_log_max_boost, RTI_m_full_boost, RTI_m_no_boost, &
@@ -1847,6 +1847,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% Gamma_lnS_eps_grav_full_on = Gamma_lnS_eps_grav_full_on
 
  s% use_dPrad_dm_form_of_T_gradient_eqn = use_dPrad_dm_form_of_T_gradient_eqn
+ s% use_flux_limiting_with_dPrad_dm_form = use_flux_limiting_with_dPrad_dm_form
  s% use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn
  s% include_P_in_velocity_time_centering = include_P_in_velocity_time_centering
  s% include_L_in_velocity_time_centering = include_L_in_velocity_time_centering
@@ -3531,6 +3532,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  Gamma_lnS_eps_grav_full_on = s% Gamma_lnS_eps_grav_full_on
 
  use_dPrad_dm_form_of_T_gradient_eqn = s% use_dPrad_dm_form_of_T_gradient_eqn
+ use_flux_limiting_with_dPrad_dm_form = s% use_flux_limiting_with_dPrad_dm_form
  use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = s% use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn
  steps_before_use_velocity_time_centering = s% steps_before_use_velocity_time_centering
  include_P_in_velocity_time_centering = s% include_P_in_velocity_time_centering

--- a/star/private/profile_getval.f90
+++ b/star/private/profile_getval.f90
@@ -767,7 +767,15 @@
                val = (s% Prad(k)/s% Pgas(k))/max(1d-12,s% L(k)/get_Ledd(s,k))
             case (p_pgas_div_p)
                val = s% Pgas(k)/s% Peos(k)
-
+            case (p_flux_limit_R)
+               if (s% use_dPrad_dm_form_of_T_gradient_eqn .and. k > 1) &
+                  val = s% flux_limit_R(k)
+            case (p_flux_limit_lambda)
+               if (s% use_dPrad_dm_form_of_T_gradient_eqn .and. k > 1) then
+                  val = s% flux_limit_lambda(k)
+               else
+                  val = 1d0
+               end if
             case (p_cell_collapse_time)
                if (s% v_flag) then
                   if (k == s% nz) then

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -150,6 +150,9 @@
             call fill_ad_with_zeros(s% P_face_ad,1,-1)
          end if
 
+         s% flux_limit_R(1:nz) = 0
+         s% flux_limit_lambda(1:nz) = 0
+         
          if (s% RSP_flag) then
             call RSP_setup_part1(s, restart, ierr)
             if (ierr /= 0) then

--- a/star/private/star_profile_def.f90
+++ b/star/private/star_profile_def.f90
@@ -710,7 +710,10 @@
 
       integer, parameter :: p_lum_rad_div_L_Edd_sub_fourPrad_div_PchiT = p_log_du_kick_div_du + 1
 
-      integer, parameter :: p_col_id_max = p_lum_rad_div_L_Edd_sub_fourPrad_div_PchiT
+      integer, parameter :: p_flux_limit_R = p_lum_rad_div_L_Edd_sub_fourPrad_div_PchiT + 1
+      integer, parameter :: p_flux_limit_lambda = p_flux_limit_R + 1
+      
+      integer, parameter :: p_col_id_max = p_flux_limit_lambda
 
       character (len=maxlen_profile_column_name) :: profile_column_name(p_col_id_max)
       type (integer_dict), pointer :: profile_column_names_dict
@@ -1396,6 +1399,9 @@
          profile_column_name(p_tau_cool) = 'tau_cool'
 
          profile_column_name(p_lum_rad_div_L_Edd_sub_fourPrad_div_PchiT) = 'lum_rad_div_L_Edd_sub_fourPrad_div_PchiT'
+
+         profile_column_name(p_flux_limit_R) = 'flux_limit_R'
+         profile_column_name(p_flux_limit_lambda) = 'flux_limit_lambda'
 
          cnt = 0
          do i=1,p_col_id_max

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -824,6 +824,7 @@
 
          logical :: use_gravity_rotation_correction, &
             use_dPrad_dm_form_of_T_gradient_eqn, &
+            use_flux_limiting_with_dPrad_dm_form, &
             use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn, &
             no_dedt_form_during_relax, &
             include_P_in_velocity_time_centering, &

--- a/star_data/public/star_data_step_work.inc
+++ b/star_data/public/star_data_step_work.inc
@@ -102,6 +102,10 @@
       real(dp), pointer :: chiT(:) ! dlnPeos_dlnT at constant Rho
       real(dp), pointer :: QQ(:) ! thermal expansion coefficient
 
+      ! flux-limited radiation transport
+      real(dp), pointer :: flux_limit_lambda(:) ! flux limiter defined as in Levermore & Pomraning 1981
+      real(dp), pointer :: flux_limit_R(:) ! flux ratio defined as in Levermore & Pomraning 1981
+
       ! eos blend information
       real(dp), pointer :: eos_frac_OPAL_SCVH(:)
       real(dp), pointer :: eos_frac_HELM(:)


### PR DESCRIPTION
This PR ports the flux-limiter prescription from Levermore & Pomraning (1981), originally available in MESA r9793, to the latest version. It addresses the following:

- Models radiative transport in the transition from an optically thick to optically thin medium (i.e., from diffusion to free-streaming).
- Prevents photons from escaping at superluminal velocities in the optically thin regime.

The code introduces the following boolean control:
`use_flux_limiting_with_dPrad_dm_form`

When set to .true. and use_dPrad_dm_form_of_T_gradient_eqn = .true., it applies the flux-limiter prescription to compute the radiative pressure gradient in terms of the flux-limiter flxLambda as:
`flxR = 4 * pi * r^2 * abs(dT^4/dm) / kap`
`flxLambda = (6 + 3*flxR) / (6 + 3*flxR + flxR^2)`
Then, the expected radiative pressure gradient is updated as:
`d_Prad_expected = d_Prad_expected / flxLambda`

Additionally, the flux-limiter and flux ratio (flxR) values are stored in the stellar properties as:
`flux_limit_lambda`
`flux_limit_R`
These values can be saved in profile files by uncommenting the corresponding entries in profile_columns.list