### PR TITLE
adjust delta_Pg

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,12 @@ A pseudo drag term ``v_drag`` has been reintroduced for ``u_flag`` to damp spuri
 
 ``hydro_rotation`` now contains the more accurate deformation fits from Fabry+2022, A&A 661, A123
 
+For calculations of the asymptotic gravity mode period spacing ``delta_Pg``,
+a new logical control ``delta_Pg_traditional`` has been introduced allowing users decide
+between adopting the traditional integral of N2 over the entire stellar model, or the 
+methods of (`Bildsten et al. 2012 <https://ui.adsabs.harvard.edu/abs/2012ApJ...744L...6B/abstract>`_).
+Previous MESA versions exlusively adopted the latter.
+
 .. _Bug Fixes main:
 
 Bug Fixes

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -7672,6 +7672,21 @@
     delta_nu_sun = 134.91d0 ! μHz
     astero_Teff_sun = 5772d0 ! kelvin
 
+      ! For calculating the asymptotic g-mode period spacing ``delta_Pg``
+      ! ~~~~~~~~~~~~
+      ! delta_Pg_traditional
+      ! ~~~~~~~~~~
+      
+      ! if ``delta_Pg_traditional`` = ``.true.``, then calculate the
+      ! asymptotic gravity mode period space by directly integrating
+      ! N2 over the entire stellar model.
+      
+      ! if ``delta_Pg_traditional`` = ``.false.`` use the method of
+      ! Bildsten et al. (2012): //ui.adsabs.harvard.edu/abs/2012ApJ...744L...6B/abstract
+
+   delta_Pg_traditional = .true.
+      
+      ! ``delta_Pg_mode_freq`` is only used when ``delta_Pg_traditional`` = ``.false.``
       ! delta_Pg_mode_freq
       ! ~~~~~~~~~~~~~~~~~~
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -7672,28 +7672,26 @@
     delta_nu_sun = 134.91d0 ! μHz
     astero_Teff_sun = 5772d0 ! kelvin
 
-      ! For calculating the asymptotic g-mode period spacing ``delta_Pg``
-      ! ~~~~~~~~~~~~
       ! delta_Pg_traditional
-      ! ~~~~~~~~~~
-      
+      ! ~~~~~~~~~~~~~~~~~~~~
+      ! delta_Pg_mode_freq
+      ! ~~~~~~~~~~~~~~~~~~
+
+      ! For calculating the asymptotic g-mode period spacing ``delta_Pg``
+
       ! if ``delta_Pg_traditional`` = ``.true.``, then calculate the
       ! asymptotic gravity mode period space by directly integrating
       ! N2 over the entire stellar model.
       
       ! if ``delta_Pg_traditional`` = ``.false.`` use the method of
       ! Bildsten et al. (2012): //ui.adsabs.harvard.edu/abs/2012ApJ...744L...6B/abstract
-
-   delta_Pg_traditional = .true.
       
       ! ``delta_Pg_mode_freq`` is only used when ``delta_Pg_traditional`` = ``.false.``
-      ! delta_Pg_mode_freq
-      ! ~~~~~~~~~~~~~~~~~~
-
-      ! uHz. if <=0, use nu_max from scaled solar value
+      ! it is provided in units of uHz. if <=0, use nu_max from scaled solar value
 
       ! ::
 
+    delta_Pg_traditional = .true.
     delta_Pg_mode_freq = 0d0
 
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -331,7 +331,8 @@
     include_L_in_correction_limits, include_v_in_correction_limits, include_u_in_correction_limits, include_w_in_correction_limits, &
 
     ! asteroseismology controls
-    get_delta_nu_from_scaled_solar, nu_max_sun, delta_nu_sun, astero_Teff_sun, delta_Pg_mode_freq, &
+    get_delta_nu_from_scaled_solar, nu_max_sun, delta_nu_sun, astero_Teff_sun, &
+    delta_Pg_mode_freq, delta_Pg_traditional, &
 
     ! hydro parameters
     energy_eqn_option, &
@@ -1815,7 +1816,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% delta_nu_sun = delta_nu_sun
  s% astero_Teff_sun = astero_Teff_sun
  s% delta_Pg_mode_freq = delta_Pg_mode_freq
-
+ s% delta_Pg_traditional = delta_Pg_traditional
 
  ! hydro parameters
  s% energy_eqn_option = energy_eqn_option
@@ -3497,6 +3498,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  delta_nu_sun = s% delta_nu_sun
  astero_Teff_sun = s% astero_Teff_sun
  delta_Pg_mode_freq = s% delta_Pg_mode_freq
+ delta_Pg_traditional = s% delta_Pg_traditional
 
  ! hydro parameters
  energy_eqn_option = s% energy_eqn_option

--- a/star/private/report.f90
+++ b/star/private/report.f90
@@ -362,8 +362,12 @@
          s% acoustic_cutoff = &
             0.25d6/pi*s% grav(1)*sqrt(s% gamma1(1)*s% rho(1)/s% Peos(1))
          nu_for_delta_Pg = s% nu_max
-         if (s% delta_Pg_mode_freq > 0) nu_for_delta_Pg = s% delta_Pg_mode_freq
-         call get_delta_Pg(s, nu_for_delta_Pg, s% delta_Pg)
+         if ( .not. s% delta_Pg_traditional) then
+            if (s% delta_Pg_mode_freq > 0) nu_for_delta_Pg = s% delta_Pg_mode_freq
+            call get_delta_Pg_bildsten2012(s, nu_for_delta_Pg, s% delta_Pg)
+         else
+            call get_delta_Pg_traditional(s, s% delta_Pg)
+         end if
 
          if (s% rsp_flag) return
 

--- a/star/private/report.f90
+++ b/star/private/report.f90
@@ -362,8 +362,8 @@
          s% acoustic_cutoff = &
             0.25d6/pi*s% grav(1)*sqrt(s% gamma1(1)*s% rho(1)/s% Peos(1))
          nu_for_delta_Pg = s% nu_max
+         if (s% delta_Pg_mode_freq > 0) nu_for_delta_Pg = s% delta_Pg_mode_freq
          if ( .not. s% delta_Pg_traditional) then
-            if (s% delta_Pg_mode_freq > 0) nu_for_delta_Pg = s% delta_Pg_mode_freq
             call get_delta_Pg_bildsten2012(s, nu_for_delta_Pg, s% delta_Pg)
          else
             call get_delta_Pg_traditional(s, s% delta_Pg)

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -793,7 +793,7 @@
          type (star_info), pointer :: s
          real(dp), intent(out) :: delta_Pg ! seconds
          ! g-mode period spacing for l=1
-         real(dp) :: dr, delta_Pg, N2, integral, r
+         real(dp) :: dr, N2, integral, r
          integer :: k
          logical, parameter :: dbg = .false.
          include 'formats'

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -789,7 +789,47 @@
       end function find_cell_for_mass
 
 
-      subroutine get_delta_Pg(s, nu_max, delta_Pg)
+      subroutine get_delta_Pg_traditional(s, delta_Pg)
+         type (star_info), pointer :: s
+         real(dp), intent(out) :: delta_Pg ! seconds
+         ! g-mode period spacing for l=1
+         real(dp) :: dr, delta_Pg, N2, integral, r
+         integer :: k
+         logical, parameter :: dbg = .false.
+         include 'formats'
+         if (dbg) then
+            write(*,2) 's% star_mass', s% model_number, s% star_mass
+            write(*,2) 's% photosphere_r', s% model_number, s% photosphere_r
+            write(*,2) 's% Teff', s% model_number, s% Teff
+         end if
+         delta_Pg = 0._dp
+         if (.not. s% calculate_Brunt_N2) return
+         k = 0
+         r = 0._dp
+         N2 = 0._dp
+         dr = 0._dp
+         integral = 0._dp
+
+         ! we integrate at cell edges.
+         do k = 2, s% nz
+         N2 = s% brunt_N2(k) ! brunt_N2 at cell_face
+         r  = s% r(k) ! r evalulated at cell_face
+         dr = s% rmid(k-1) - s% rmid(k) ! dr evalulated at cell face.
+         if (N2 > 0d0) integral = integral + sqrt(N2)*dr/r
+         end do
+
+         if (dbg) write(*,2) ' integral ', &
+            s% model_number,integral
+
+         if (integral == 0) return
+         delta_Pg = sqrt(2._dp)*pi*pi/integral
+         if (is_bad(delta_Pg)) delta_Pg = 0._dp
+
+         if (dbg) write(*,2) 'delta_Pg', s% model_number, delta_Pg
+
+      end subroutine get_delta_Pg_traditional
+
+      subroutine get_delta_Pg_bildsten2012(s, nu_max, delta_Pg)
          type (star_info), pointer :: s
          real(dp), intent(in) :: nu_max ! microHz
          real(dp), intent(out) :: delta_Pg ! seconds
@@ -851,7 +891,7 @@
 
          if (dbg) write(*,2) 'delta_Pg', s% model_number, delta_Pg
 
-      end subroutine get_delta_Pg
+      end subroutine get_delta_Pg_bildsten2012
 
 
       subroutine set_rmid(s, nzlo, nzhi, ierr)

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -812,6 +812,7 @@
 
          logical :: get_delta_nu_from_scaled_solar
          real(dp) :: nu_max_sun, delta_nu_sun, astero_Teff_sun, delta_Pg_mode_freq
+         logical :: delta_Pg_traditional
 
 
       ! hydro parameters


### PR DESCRIPTION
Resolving https://github.com/MESAHub/mesa/issues/467 raised by @earlbellinger, by adopting @warrickball's suggestion. I introduced a logical control that allows users to choose which method they'd like to use for calculating delta_Pg. The default will now be ``delta_Pg_traditional = .true.``.

I attempted to document the controls and included a changelog. As I am not an asteroseismologist, I'd appreciate someone double checking my explanations.

If this passes testing, we can merge.