### PR TITLE
Adding support to max_conv_vel_div_csound (non-TDC MLT options) and adding opacity_min control

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -3378,7 +3378,7 @@
       ! max_conv_vel_div_csound
       ! ~~~~~~~~~~~~~~~~~~~~~~~
 
-      ! convective velocities are limited to local sound speed times this factor
+      ! convective velocities are limited to local sound speed times this factor, not used for ``MLT_option = TDC``
 
       ! ::
 
@@ -7407,6 +7407,15 @@
 
     use_starting_composition_for_kap = .false.
 
+
+      ! opacity_min
+      ! ~~~~~~~~~~~
+
+      ! limit minimum opacities to this value (ignore this is value is < 0)
+
+      ! ::
+
+    opacity_min = -1
 
       ! opacity_max
       ! ~~~~~~~~~~~

--- a/star/job/run_star_support.f90
+++ b/star/job/run_star_support.f90
@@ -2833,6 +2833,9 @@
          if (s% opacity_max > 0) &
             write(*,1) 'opacity_max', s% opacity_max
 
+         if (s% opacity_min > 0) &
+            write(*,1) 'opacity_min', s% opacity_min
+
          if (s% job% show_net_reactions_info) then
             write(*,'(a)') ' net reactions '
             call show_net_reactions_and_info(s% net_handle, 6, ierr)

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -335,7 +335,7 @@
 
     ! hydro parameters
     energy_eqn_option, &
-    opacity_factor, opacity_max, min_logT_for_opacity_factor_off, min_logT_for_opacity_factor_on, &
+    opacity_factor, opacity_min, opacity_max, min_logT_for_opacity_factor_off, min_logT_for_opacity_factor_on, &
     max_logT_for_opacity_factor_on, max_logT_for_opacity_factor_off, &
     non_nuc_neu_factor, &
     use_time_centered_eps_grav, &
@@ -1820,6 +1820,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  ! hydro parameters
  s% energy_eqn_option = energy_eqn_option
  s% opacity_factor = opacity_factor
+ s% opacity_min = opacity_min
  s% opacity_max = opacity_max
  s% min_logT_for_opacity_factor_off = min_logT_for_opacity_factor_off
  s% min_logT_for_opacity_factor_on = min_logT_for_opacity_factor_on
@@ -3500,6 +3501,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  ! hydro parameters
  energy_eqn_option = s% energy_eqn_option
+ opacity_min = s% opacity_min
  opacity_max = s% opacity_max
  opacity_factor = s% opacity_factor
  min_logT_for_opacity_factor_off = s% min_logT_for_opacity_factor_off

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -669,6 +669,12 @@ contains
        s% d_opacity_dlnT(k) = 0
     end if
 
+    if (s% opacity(k) < s% opacity_min .and. s% opacity_min > 0) then
+       s% opacity(k) = s% opacity_min
+       s% d_opacity_dlnd(k) = 0
+       s% d_opacity_dlnT(k) = 0
+    end if
+
     if (is_bad_num(s% opacity(k))) then
        if (s% stop_for_bad_nums) then
           !$omp critical (star_kap_get_bad_num)

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -184,7 +184,7 @@ contains
       integer, intent(out) :: ierr
 
       type(auto_diff_real_star_order1) :: Pr, Pg, grav, Lambda, gradL, beta
-      real(dp) :: conv_vel_start, scale
+      real(dp) :: conv_vel_start, scale, max_conv_vel
 
       ! these are used by use_superad_reduction
       real(dp) :: Gamma_limit, scale_value1, scale_value2, diff_grads_limit, reduction_limit, lambda_limit
@@ -205,6 +205,13 @@ contains
          gradL = grada + gradL_composition_term  ! Ledoux temperature gradient
       else
          gradL = grada
+      end if
+
+      ! maximum convection velocity allowed, not available for TDC
+      if (associated(s% csound_face)) then
+         max_conv_vel = s% csound_face(k) * s% max_conv_vel_div_csound
+      else
+         max_conv_vel = 1.0d99
       end if
 
       ! Initialize with no mixing
@@ -296,7 +303,7 @@ contains
          call set_MLT(MLT_option, mixing_length_alpha, s% Henyey_MLT_nu_param, s% Henyey_MLT_y_param, &
                         chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                         gradr, grada, gradL, &
-                        Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                        Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
 
          if (ierr /= 0) then
             if (s% report_ierr) write(*,*) 'ierr from set_MLT'
@@ -313,7 +320,7 @@ contains
                call set_MLT(MLT_option, mixing_length_alpha, s% Henyey_MLT_nu_param, s% Henyey_MLT_y_param, &
                               chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                               gradr_scaled, grada, gradL, &
-                              Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                              Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
                if (ierr /= 0) then
                   if (s% report_ierr) write(*,*) 'ierr from set_MLT when using superad_reduction'
                   return

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -796,7 +796,7 @@
          logical :: use_simple_es_for_kap, use_starting_composition_for_kap
 
          real(dp) :: min_kap_for_dPrad_dm_eqn
-         real(dp) :: opacity_max, opacity_factor
+         real(dp) :: opacity_min, opacity_max, opacity_factor
          real(dp) :: min_logT_for_opacity_factor_off
          real(dp) :: min_logT_for_opacity_factor_on
          real(dp) :: max_logT_for_opacity_factor_on

--- a/turb/private/mlt.f90
+++ b/turb/private/mlt.f90
@@ -60,14 +60,14 @@ contains
    subroutine calc_MLT(MLT_option, mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, &
                      chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                      gradr, grada, gradL, &
-                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
       use const_def
       use num_lib
       use utils_lib
       use auto_diff
       type(auto_diff_real_star_order1), intent(in) :: chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, gradr, grada, gradL
       character(len=*), intent(in) :: MLT_option
-      real(dp), intent(in) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param
+      real(dp), intent(in) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, max_conv_vel
       type(auto_diff_real_star_order1), intent(out) :: Gamma, gradT, Y_face, conv_vel, D
       integer, intent(out) :: mixing_type, ierr
 
@@ -153,6 +153,9 @@ contains
 
          ! average convection velocity   C&G 14.86b
          conv_vel = mixing_length_alpha*sqrt(Q*P/(8d0*rho))*Gamma / A
+
+         if (conv_vel%val > max_conv_vel) conv_vel%val = max_conv_vel
+
          D = conv_vel*Lambda/3d0     ! diffusion coefficient [cm^2/sec]
 
          !Zeta = pow3(Gamma)/Bcubed  ! C&G 14.80

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -117,7 +117,7 @@ module turb
       call set_MLT('Cox', mixing_length_alpha, 0d0, 0d0, &
                      chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                      gradr, grada, gradL, &
-                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, 1.0d99, ierr)
 
       ! Pack TDC info
       info%report = report
@@ -225,18 +225,18 @@ module turb
    subroutine set_MLT(MLT_option, mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, &
                      chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                      gradr, grada, gradL, &
-                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
       use mlt
       type(auto_diff_real_star_order1), intent(in) :: chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, gradr, grada, gradL
       character(len=*), intent(in) :: MLT_option
-      real(dp), intent(in) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param
+      real(dp), intent(in) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, max_conv_vel
       type(auto_diff_real_star_order1), intent(out) :: Gamma, gradT, Y_face, conv_vel, D
       integer, intent(out) :: mixing_type, ierr
 
       call calc_MLT(MLT_option, mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, &
                      chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                      gradr, grada, gradL, &
-                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                     Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
    end subroutine set_MLT
 
 end module turb

--- a/turb/test/src/test_turb.f90
+++ b/turb/test/src/test_turb.f90
@@ -25,7 +25,7 @@ program test_turb
    subroutine check_efficient_MLT_scaling()
       type(auto_diff_real_star_order1) :: chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, gradr, grada, gradL
       character(len=3) :: MLT_option
-      real(dp) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param
+      real(dp) :: mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, max_conv_vel
       type(auto_diff_real_star_order1) :: Gamma, gradT, Y_face, conv_vel, conv_vel2, D, r, L
       integer :: mixing_type, ierr
 
@@ -54,10 +54,12 @@ program test_turb
       L = 1d5*Lsun
       gradr = 3d0 * P * opacity * L / (64 * pi * boltz_sigma * pow4(T) * grav * pow2(r))
 
+      max_conv_vel = 1.0d99
+
       call set_MLT(MLT_option, mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, &
                         chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                         gradr, grada, gradL, &
-                        Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                        Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
 
       write(*,1) 'vc at 1d5 Lsun',conv_vel%val
 
@@ -67,7 +69,7 @@ program test_turb
       call set_MLT(MLT_option, mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, &
                         chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                         gradr, grada, gradL, &
-                        Gamma, gradT, Y_face, conv_vel2, D, mixing_type, ierr)
+                        Gamma, gradT, Y_face, conv_vel2, D, mixing_type, max_conv_vel, ierr)
 
       write(*,1) 'vc at 1d8 Lsun',conv_vel2%val
 
@@ -80,7 +82,7 @@ program test_turb
       type(auto_diff_real_star_order1) :: &
          r, L, T, P, opacity, rho, dV, chiRho, chiT, Cp, gradr, grada, scale_height, gradL, grav, Lambda
       type(auto_diff_real_star_order1) :: gradT, Y_face, conv_vel, D, Gamma
-      real(dp) :: Henyey_MLT_nu_param, Henyey_MLT_y_param
+      real(dp) :: Henyey_MLT_nu_param, Henyey_MLT_y_param, max_conv_vel
       character(len=3) :: MLT_option
       integer :: mixing_type, ierr, tdc_num_iters
       logical :: report
@@ -126,6 +128,8 @@ program test_turb
       report = .false.
       dt = 1d40 ! Long time-step so we get into equilibrium
 
+      max_conv_vel = 1.0d99
+
       ! MLT
       MLT_option = 'Cox'
       Henyey_MLT_nu_param = 0d0
@@ -143,7 +147,7 @@ program test_turb
       call set_MLT(MLT_option, mixing_length_alpha, Henyey_MLT_nu_param, Henyey_MLT_y_param, &
                         chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
                         gradr, grada, gradL, &
-                        Gamma, gradT, Y_face, conv_vel, D, mixing_type, ierr)
+                        Gamma, gradT, Y_face, conv_vel, D, mixing_type, max_conv_vel, ierr)
 
       write(*,1) 'MLT: Y, conv_vel_start, conv_vel, Gamma', Y_face%val, conv_vel_start, conv_vel% val, Gamma%val
 


### PR DESCRIPTION
- Limiting convection velocities

As mentioned in #776, the control `max_conv_vel_div_csound ` is mentioned in the documentation but not used. I added support for this control to limit convection velocities for non-TDC MLT options. The main motivation for using this control relies on the assumptions on MLT prescriptions, as the ones from Cox and Mihalas, are not valid for supersonic convection velocities. 

- Introducing opacity floor

As well I add in this patch the control `opacity_min` to be able to have an opacity floor. The motivation for this control comes from the underestimation of line opacities from expanding material by the Ferguson et al. (2005) tables (see section 2.2 in [Morozova et al. (2015)](https://iopscience.iop.org/article/10.1088/0004-637X/814/1/63/meta) for a more detailed discussion).

