### PR TITLE
bugfix for missing binary variables not being saved in photos

### DIFF
--- a/binary/private/binary_photos.f90
+++ b/binary/private/binary_photos.f90
@@ -132,6 +132,8 @@ contains
          b% CE_lambda2, b% CE_lambda2_old, &
          b% CE_Ebind1, b% CE_Ebind1_old, &
          b% CE_Ebind2, b% CE_Ebind2_old, &
+         b% CE_years_detached, b% CE_years_detached_old, &
+         b% generations, &
          b% ixtra(:), b% ixtra_old(:), &
          b% xtra(:), b% xtra_old(:), &
          b% lxtra(:), b% lxtra_old(:)
@@ -253,6 +255,8 @@ contains
          b% CE_lambda2, b% CE_lambda2_old, &
          b% CE_Ebind1, b% CE_Ebind1_old, &
          b% CE_Ebind2, b% CE_Ebind2_old, &
+         b% CE_years_detached, b% CE_years_detached_old, &
+         b% generations, &
          b% ixtra(:), b% ixtra_old(:), &
          b% xtra(:), b% xtra_old(:), &
          b% lxtra(:), b% lxtra_old(:)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -58,9 +58,12 @@ been introduced.
 Bug Fixes
 ---------
 
-Fixed small bug in star/private/create_initial_model.f90 that will have a small effect on creating initial models
+Fixed small bug in star/private/create_initial_model.f90 that will have a small effect on creating initial models (variable ``dP`` was supposed to be ``d_P``)
 
 Fixed bug in ``star/private/hydro_rotation.f90`` where the sigmoid function to cap ``w_div_w_crit`` was incorrectly implemented. This only influences models with `w_div_wc_flag = .true.`
+
+Fixed bug in binary photos. They were not saving the variables: ``CE_years_detached``, ``CE_years_detached_old``, ``generations``.
+
 
 .. note:: Before releasing a new version of MESA, move `Changes in main` to a new section below with the version number as the title, and add a new `Changes in main` section at the top of the file (see ```changelog_template.rst```).
 


### PR DESCRIPTION
discovered during the Tardis Connector 25 workshop