### PR TITLE
use consistent values for constants

### DIFF
--- a/astero/private/adipls_support.f90
+++ b/astero/private/adipls_support.f90
@@ -22,7 +22,7 @@
 
       module adipls_support
 
-      use const_def, only: dp, i8, pi, pi4, four_thirds_pi
+      use const_def, only: dp, i8, pi, pi4, four_thirds_pi, Msun, Rsun, Lsun
       use astero_def
       use star_lib
       use star_def
@@ -982,7 +982,6 @@
          real(dp), pointer :: var(:,:)  ! (ivar,nn)
          integer, intent(out) :: ierr
 
-         real(dp), parameter :: Msun = 1.9892d33, Rsun = 6.9598d10, Lsun = 3.8418d33
          integer :: iounit, k, offset
 
          ierr = 0

--- a/eos/eosCMS_builder/src/cms_mixing.f90
+++ b/eos/eosCMS_builder/src/cms_mixing.f90
@@ -33,11 +33,11 @@
 
 module cms
 
-   use const_def, only: dp, ln10
+   use const_def, only: dp, ln10, avo, amu
 
    implicit none
 
-   logical, parameter :: DBG = .false.
+   logical, parameter :: dbg = .false.
    integer, parameter :: NT = 121
    integer, parameter :: NP = 441
 
@@ -157,8 +157,6 @@ contains
       integer, intent(out) :: ierr
       real(dp), parameter :: tol = 1.0E-5_dp
       real(dp), parameter :: kerg = 1.380649D-16
-      real(dp), parameter :: avo =  6.02214076d23
-      real(dp), parameter :: amu = 1.0_dp/avo
 
       real(dp) :: Nx, Ny, Ntot, Abar
       real(dp) :: rhoXY, rhoX, rhoY

--- a/eos/eosDT_builder/src/helm_opal_scvh_driver.f90
+++ b/eos/eosDT_builder/src/helm_opal_scvh_driver.f90
@@ -22,6 +22,7 @@
 
 module helm_opal_scvh_driver
    use chem_def
+   use const_def, only: pi, clight, avo
    implicit none
 
    character(len=256) :: data_dir
@@ -185,15 +186,8 @@ contains
       integer :: iregion
       double precision :: pa, pb, ea, eb, sa, sb
       double precision :: a, b
-      double precision, parameter :: pi = 3.1415926535897932384d0
       logical :: have_called_helm
       double precision, parameter :: helm_min_temp = 1d3
-
-!..some physical constants
-      double precision :: clight
-      parameter(clight=2.99792458d10)
-      double precision :: avo
-      parameter(avo=6.0221367d23)
 
 !..loading the opal_scvh tables
       integer :: ifirst

--- a/eos/eosDT_builder/src/scvh_core.f90
+++ b/eos/eosDT_builder/src/scvh_core.f90
@@ -21,6 +21,9 @@
 ! ***********************************************************************
 
 module scvh_core
+
+   use const_def, only: clight, avo, kerg
+
    implicit none
 
    logical, parameter :: dbg = .false.
@@ -637,10 +640,9 @@ contains
       double precision :: dpressraddd, dpressraddt, deraddd, deraddt, dsraddd, dsraddt
 
 !..constants
-      double precision :: clight, ssol, asol, asoli3, avo, kerg, xka, mh1, mhe4, third
-      parameter(clight=2.99792458d10, ssol=5.67051d-5, asol=4.0d0*ssol/clight, &
-                asoli3=asol/3.0d0, avo=6.0221367d23, kerg=1.380658d-16, &
-                xka=kerg*avo, mh1=1.67357d-24, mhe4=6.646442d-24, third=1.0d0/3.0d0)
+      double precision ::  ssol, asol, asoli3, xka, mh1, mhe4
+      parameter(ssol=5.67051d-5, asol=4.0d0*ssol/clight, asoli3=asol/3.0d0, &
+                xka=kerg*avo, mh1=1.67357d-24, mhe4=6.646442d-24)
 
       logical, parameter :: pure_splines = .true., DT_flag = .true.
 

--- a/num/test/src/bari_beam.f90
+++ b/num/test/src/bari_beam.f90
@@ -18,12 +18,13 @@
 ! ----------------------------------------------------------------------
 module bari_beam
 
+   use const_def, only: dp
+
    implicit none
 
 contains
 
    subroutine beam_init(neqn, y, yprime, consis)
-      use const_def, only: dp
       integer :: neqn
       real(dp) :: y(neqn), yprime(neqn)
       logical :: consis
@@ -37,7 +38,6 @@ contains
    end subroutine beam_init
 ! ----------------------------------------------------------------------
    subroutine beam_feval(nvar, t, th, df, ierr, rpar, ipar)
-      use const_def, only: dp
       use math_lib
       implicit real(dp) (A - H, O - Z)
       integer :: ierr, nvar, i, ipar(*)
@@ -129,7 +129,6 @@ contains
    end subroutine beam_feval
 ! ----------------------------------------------------------------------
    subroutine beam_jeval(ldim, neqn, t, y, yprime, dfdy, ierr, rpar, ipar)
-      use const_def, only: dp
       integer :: ldim, neqn, ierr, ipar(*)
       real(dp) :: t, y(neqn), yprime(neqn), dfdy(ldim, neqn), rpar(*)
 !
@@ -138,7 +137,6 @@ contains
    end subroutine beam_jeval
 ! ----------------------------------------------------------------------
    subroutine beam_solut(neqn, t, y)
-      use const_def, only: dp
       integer :: neqn
       real(dp), intent(in) :: t
       real(dp), intent(out) :: y(neqn)


### PR DESCRIPTION
Sometimes constants get re-defined (to slightly different values) in parts of the code.  Making things consistent by calling the values from the `const` module.