### PR TITLE
Make pgplot color indices static

### DIFF
--- a/astero/private/pgstar_astero_plots.f90
+++ b/astero/private/pgstar_astero_plots.f90
@@ -127,6 +127,7 @@
 
          use utils_lib
          use const_def, only: dp
+         use pgstar_colors
 
          integer, intent(in) :: id, device_id
          real, intent(in) :: xleft, xright, ybot, ytop, txt_scale
@@ -399,6 +400,7 @@
 
          use utils_lib
          use const_def, only: dp
+         use pgstar_colors
 
          integer, intent(in) :: id, device_id
          real, intent(in) :: xleft, xright, ybot, ytop, txt_scale

--- a/astero/private/pgstar_astero_plots.f90
+++ b/astero/private/pgstar_astero_plots.f90
@@ -182,7 +182,7 @@
          call pgsvp(xleft, xright, ybot, ytop)
          call pgswin(xmin, xmax, ymin, ymax)
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgstar_show_box(s,'BCNST1','BCNSTV1')
          call pgstar_show_xaxis_label(s, &
             "Frequency mod \(0530)\d\(0639)\u (\(0638)Hz) (duplicated at x+\(0530)\d\(0639)\u)")
@@ -224,7 +224,7 @@
          call pgsci(freq_color(0))
          call pgsch(1.6*txt_scale)
          call pgpt1(x_obs, y_obs, freq_shape(0))
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(txt_scale)
          call pgptxt(x_obs, y_txt, 0.0, 0.5, 'l=0')
 
@@ -232,7 +232,7 @@
          call pgsci(freq_color(1))
          call pgsch(1.6*txt_scale)
          call pgpt1(x_obs, y_obs, freq_shape(1))
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(1.0*txt_scale)
          call pgptxt(x_obs, y_txt, 0.0, 0.5, 'l=1')
 
@@ -240,7 +240,7 @@
          call pgsci(freq_color(2))
          call pgsch(1.6*txt_scale)
          call pgpt1(x_obs, y_obs, freq_shape(2))
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(1.0*txt_scale)
          call pgptxt(x_obs, y_txt, 0.0, 0.5, 'l=2')
 
@@ -249,7 +249,7 @@
             call pgsci(freq_color(3))
             call pgsch(1.6*txt_scale)
             call pgpt1(x_obs, y_obs, freq_shape(3))
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(1.0*txt_scale)
             call pgptxt(x_obs, y_txt, 0.0, 0.5, 'l=3')
          end if
@@ -475,7 +475,7 @@
          call pgsvp(xleft, xright, ybot, ytop)
          call pgswin(xmin, xmax, ymin, ymax)
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgstar_show_box(s,'BCNST1','BCNSTV1')
          call pgstar_show_xaxis_label(s,"Ratio")
          call pgstar_show_left_yaxis_label(s,"Frequency (\(0638)Hz)")
@@ -508,7 +508,7 @@
          call pgsci(r01_color)
          call pgsch(1.6*txt_scale)
          call pgpt1(x_obs, y_obs, r01_shape)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(1.0*txt_scale)
          call pgptxt(x_obs, y_txt, 0.0, 0.5, 'r01')
 
@@ -516,7 +516,7 @@
          call pgsci(r10_color)
          call pgsch(1.6*txt_scale)
          call pgpt1(x_obs, y_obs, r10_shape)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(1.0*txt_scale)
          call pgptxt(x_obs, y_txt, 0.0, 0.5, 'r10')
 
@@ -524,7 +524,7 @@
          call pgsci(r02_color)
          call pgsch(1.6*txt_scale)
          call pgpt1(x_obs, y_obs, r02_shape)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(1.0*txt_scale)
          call pgptxt(x_obs, y_txt, 0.0, 0.5, 'r02')
 

--- a/binary/private/pgbinary_hist_track.f90
+++ b/binary/private/pgbinary_hist_track.f90
@@ -626,6 +626,7 @@ contains
 
       use utils_lib
       use pgstar_support, only : set_xleft_xright, set_ytop_ybot
+      use pgstar_colors
 
       type (binary_info), pointer :: b
       integer, intent(in) :: &

--- a/binary/private/pgbinary_hist_track.f90
+++ b/binary/private/pgbinary_hist_track.f90
@@ -722,7 +722,7 @@ contains
       call pgsvp(vp_xleft, vp_xright, vp_ybot, vp_ytop)
       call pgswin(xleft, xright, ybot, ytop)
       call pgscf(1)
-      call pgsci(1)
+      call pgsci(clr_Foreground)
       call show_box_pgbinary(b, 'BCNST1', 'BCNSTV1')
 
       if (log_xaxis) then

--- a/binary/private/pgbinary_history_panels.f90
+++ b/binary/private/pgbinary_history_panels.f90
@@ -780,7 +780,7 @@ contains
             !write(*,1) trim(other_yname), other_ybot, other_ytop
             call pgswin(xleft, xright, other_ybot, other_ytop)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_box_pgbinary(b, '', 'CMSTV')
             call pgsci(other_y_color)
             if (hist_other_yaxis_log(j)) then
@@ -825,7 +825,7 @@ contains
             !write(*,1) trim(yname), ybot, ytop
             call pgswin(xleft, xright, ybot, ytop)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (j < hist_num_panels) then
                if (.not. have_other_yaxis) then
                   call show_box_pgbinary(b, 'BCST1', 'BCMNSTV1')
@@ -890,7 +890,7 @@ contains
             call pgslw(1)
          end if
 
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call show_pgbinary_decorator(b% binary_id, use_decorator, pgbinary_decorator, j, ierr)
       end do
 

--- a/binary/private/pgbinary_history_panels.f90
+++ b/binary/private/pgbinary_history_panels.f90
@@ -593,6 +593,7 @@ contains
 
       use utils_lib
       use pgstar_support, only : set_xleft_xright, set_ytop_ybot
+      use pgstar_colors
 
       type (binary_info), pointer :: b
       integer, intent(in) :: id, device_id, hist_num_panels

--- a/binary/private/pgbinary_orbit.f90
+++ b/binary/private/pgbinary_orbit.f90
@@ -72,6 +72,7 @@ contains
       use num_lib, only : safe_root_with_guess
       use math_lib, only : pow
       use const_def, only : dp, pi
+      use pgstar_colors
 
       type (binary_info), pointer :: b
       integer, intent(in) :: device_id

--- a/binary/private/pgbinary_orbit.f90
+++ b/binary/private/pgbinary_orbit.f90
@@ -215,7 +215,7 @@ contains
       end if
 
       call pgsave
-      call pgsci(1)
+      call pgsci(clr_Foreground)
       call pgscf(1)
       call pgsch(txt_scale)
       call pgslw(b% pg% pgbinary_lw / 2)
@@ -247,7 +247,7 @@ contains
       call pgslw(1)
       call pgmtxt('T', -2.0 - 1.3, 0.05, 0.0, 'Star 2')
 
-      call pgsci(1)
+      call pgsci(clr_Foreground)
       call pgpt1(0.0, 0.0, 5)
       call pgunsa
 

--- a/binary/private/pgbinary_summary.f90
+++ b/binary/private/pgbinary_summary.f90
@@ -347,6 +347,7 @@ contains
       Text_Summary_name, ierr)
 
       use utils_lib
+      use pgstar_colors, only: clr_Foreground
       use pgstar_support, only : write_info_line_exp, write_info_line_flt, &
          write_info_line_int
 
@@ -373,7 +374,7 @@ contains
       call pgsch(txt_scale)
 
       call pgsvp(winxmin, winxmax, winymin, winymax)
-      call pgsci(1)
+      call pgsci(clr_Foreground)
       call pgscf(1)
       call pgswin(0.0, 1.0, 0.0, 1.0)
       call show_title_pgbinary(b, title)

--- a/binary/private/pgbinary_summary_history.f90
+++ b/binary/private/pgbinary_summary_history.f90
@@ -65,6 +65,7 @@ contains
       use chem_def
       use net_def
       use const_def, only : Msun, Rsun
+      use pgstar_colors
 
       type (binary_info), pointer :: b
       integer, intent(in) :: id, device_id

--- a/binary/private/pgbinary_summary_history.f90
+++ b/binary/private/pgbinary_summary_history.f90
@@ -170,7 +170,7 @@ contains
          ybot = 0
          call pgswin(xmin, xmax, ymin + ybot, ymax)
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call show_box_pgbinary(b, 'BCNST', 'BCNSTV')
          call show_left_yaxis_label_pgbinary(b, 'rel=(val-min)/(max-min)')
 
@@ -216,7 +216,7 @@ contains
 
          end do
 
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call show_xaxis_label_pgbinary(b, 'model number')
 
          ! show the legend
@@ -278,7 +278,7 @@ contains
          call pgslw(lw)
          call pgline(2, xpts, ypts)
          call pgslw(lw_sav)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(txt_scale * 0.70)
          call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, name)
          summary_history_line_legend = cnt + 1

--- a/binary/private/pgbinary_support.f90
+++ b/binary/private/pgbinary_support.f90
@@ -412,9 +412,10 @@ contains
 
 
    subroutine draw_rect()
+      use pgstar_colors, only: clr_Foreground
       real, dimension(5) :: xs, ys
       call pgsave
-      call pgsci(1)
+      call pgsci(clr_Foreground)
       xs = [0.0, 0.0, 1.0, 1.0, 0.0]
       ys = [0.0, 1.0, 1.0, 0.0, 0.0]
       call pgswin(0.0, 1.0, 0.0, 1.0)

--- a/binary/private/pgbinary_support.f90
+++ b/binary/private/pgbinary_support.f90
@@ -29,7 +29,7 @@ module pgbinary_support
    use const_def, only: dp, secyer
    use rates_def, only : i_rate
    use utils_lib
-   use pgstar_support, only : Set_Colours, do1_pgmtxt, &
+   use pgstar_support, only : set_device_colors, do1_pgmtxt, &
       clr_no_mixing, clr_convection, clr_leftover_convection, clr_semiconvection, &
       clr_thermohaline, clr_overshoot, clr_rotation, clr_minimum, clr_rayleigh_taylor, &
       clr_anonymous, colormap_offset, colormap_last, colormap_size, &
@@ -245,7 +245,7 @@ contains
          p% prev_win_width = p% win_width
          p% prev_win_aspect_ratio = p% win_aspect_ratio
       end if
-      call Set_Colours(white_on_black_flag, ierr)
+      call set_device_colors(white_on_black_flag, ierr)
    end subroutine open_device
 
 

--- a/binary/private/pgbinary_support.f90
+++ b/binary/private/pgbinary_support.f90
@@ -29,12 +29,7 @@ module pgbinary_support
    use const_def, only: dp, secyer
    use rates_def, only : i_rate
    use utils_lib
-   use pgstar_support, only : set_device_colors, do1_pgmtxt, &
-      clr_no_mixing, clr_convection, clr_leftover_convection, clr_semiconvection, &
-      clr_thermohaline, clr_overshoot, clr_rotation, clr_minimum, clr_rayleigh_taylor, &
-      clr_anonymous, colormap_offset, colormap_last, colormap_size, &
-      colormap, Line_Type_Solid, Line_Type_Dash, Line_Type_Dash_Dot, Line_Type_Dot_Dash, &
-      Line_Type_Dot  ! inherit colors/linetypes + some routines from pgstar
+   use pgstar_support, only : do1_pgmtxt
    use star_pgstar
 
    implicit none
@@ -210,6 +205,7 @@ contains
 
 
    subroutine open_device(b, p, is_file, dev, id, ierr)
+      use pgstar_colors, only: set_device_colors
       type (binary_info), pointer :: b
       type (pgbinary_win_file_data), pointer :: p
       logical, intent(in) :: is_file
@@ -245,7 +241,7 @@ contains
          p% prev_win_width = p% win_width
          p% prev_win_aspect_ratio = p% win_aspect_ratio
       end if
-      call set_device_colors(white_on_black_flag, ierr)
+      call set_device_colors(white_on_black_flag)
    end subroutine open_device
 
 

--- a/star/make/makefile_base
+++ b/star/make/makefile_base
@@ -17,6 +17,7 @@ ifeq ($(USE_PGSTAR),YES)
       pgstar_decorator.f90 \
       pgstar_ctrls_io.f90 \
       pgstar_support.f90 \
+      pgstar_colors.f90 \
       pgstar_hist_track.f90 \
       pgstar_kipp.f90 \
       pgstar_dpg_dnu.f90 \

--- a/star/other/pgstar_decorator.f90
+++ b/star/other/pgstar_decorator.f90
@@ -54,6 +54,7 @@ contains
 !      subroutine Abundance_pgstar_decorator(id, xmin, xmax, ymin, ymax, plot_num, ierr)
 !         use star_def
 !         use const_def, only: dp
+!         use pgstar_colors
 !         integer, intent(in) :: id
 !         !Not dp
 !         real,intent(in) :: xmin, xmax, ymin, ymax

--- a/star/other/sample_pgstar_plot.f90
+++ b/star/other/sample_pgstar_plot.f90
@@ -276,7 +276,7 @@ contains
          call pgmtxt('T', 1.8, 0.9, 0.5, str)
 
          ! xlabel
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(label_scale)
          call show_pgstar_xaxis_by(s, my_xaxis_by, ierr)
          if (ierr /= 0) return
@@ -319,7 +319,7 @@ contains
 
          call pgswin(xleft, xright, ymin, ymax)
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(label_scale)
          call pgbox('', 0.0, 0, 'BNSTV', 0.0, 0)
 
@@ -378,7 +378,7 @@ contains
          call pgswin(xleft, xright, ymin, ymax)
 
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgsch(label_scale)
          call pgbox('BCNST', 0.0, 0, 'CMSTV', 0.0, 0)
 

--- a/star/other/sample_pgstar_plot.f90
+++ b/star/other/sample_pgstar_plot.f90
@@ -248,6 +248,7 @@ contains
    contains
 
       subroutine plot(ierr)
+         use pgstar_colors
          use rates_def, only: i_rate
          use chem_def, only: ipp, icno
          integer, intent(out) :: ierr

--- a/star/private/pgstar_abundance.f90
+++ b/star/private/pgstar_abundance.f90
@@ -85,6 +85,7 @@
          use chem_def
          use net_def
          use const_def, only: Msun, Rsun
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/private/pgstar_abundance.f90
+++ b/star/private/pgstar_abundance.f90
@@ -207,7 +207,7 @@
                   call show_age_pgstar(s)
                end if
                call show_title_pgstar(s, title)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_xaxis_name(s,xaxis_name,ierr)
                if (ierr /= 0) return
             end if
@@ -215,7 +215,7 @@
             ybot = -0.05
             call pgswin(xleft, xright, ymin+ybot, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (xaxis_numeric_labels_flag) then
                call show_box_pgstar(s,'BCNST','BCNSTV')
             else
@@ -398,7 +398,7 @@
             call pgslw(lw)
             call pgline(2, xpts, ypts)
             call pgslw(lw_sav)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*s% pg% Abundance_legend_txt_scale_factor)
             call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, trim(str))
             abundance_line_legend = cnt + 1

--- a/star/private/pgstar_color_magnitude.f90
+++ b/star/private/pgstar_color_magnitude.f90
@@ -611,6 +611,7 @@
             ierr)
          use utils_lib
          use star_def
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id, color_num_panels

--- a/star/private/pgstar_color_magnitude.f90
+++ b/star/private/pgstar_color_magnitude.f90
@@ -815,7 +815,7 @@
                      color_other_dymin(j), other_ybot, other_ytop)
                call pgswin(xleft, xright, other_ybot, other_ytop)
                call pgscf(1)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_box_pgstar(s,'','CMSTV')
                call pgsci(other_y_color)
 
@@ -837,7 +837,7 @@
                      color_dymin(j), ybot, ytop)
                call pgswin(xleft, xright, ybot, ytop)
                call pgscf(1)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                if (j < color_num_panels) then
                   if (.not. have_other_yaxis) then
                      call show_box_pgstar(s,'BCST1','BCMNSTV1')
@@ -862,7 +862,7 @@
                call pgslw(1)
             end if
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
 
             call show_pgstar_decorator(s%id,color_use_decorator,color_pgstar_decorator, j, ierr)
 

--- a/star/private/pgstar_colors.f90
+++ b/star/private/pgstar_colors.f90
@@ -2,24 +2,18 @@
 !
 !   Copyright (C) 2010-2025  The MESA Team
 !
-!   MESA is free software; you can use it and/or modify
-!   it under the combined terms and restrictions of the MESA MANIFESTO
-!   and the GNU General Library Public License as published
-!   by the Free Software Foundation; either version 2 of the License,
-!   or (at your option) any later version.
+!   This program is free software: you can redistribute it and/or modify
+!   it under the terms of the GNU Lesser General Public License
+!   as published by the Free Software Foundation,
+!   either version 3 of the License, or (at your option) any later version.
 !
-!   You should have received a copy of the MESA MANIFESTO along with
-!   this software; if not, it is available at the mesa website:
-!   https://mesastar.org/
-!
-!   MESA is distributed in the hope that it will be useful,
+!   This program is distributed in the hope that it will be useful,
 !   but WITHOUT ANY WARRANTY; without even the implied warranty of
 !   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-!   See the GNU Library General Public License for more details.
+!   See the GNU Lesser General Public License for more details.
 !
-!   You should have received a copy of the GNU Library General Public License
-!   along with this software; if not, write to the Free Software
-!   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+!   You should have received a copy of the GNU Lesser General Public License
+!   along with this program. If not, see <https://www.gnu.org/licenses/>.
 !
 ! ***********************************************************************
 

--- a/star/private/pgstar_colors.f90
+++ b/star/private/pgstar_colors.f90
@@ -1,0 +1,262 @@
+! ***********************************************************************
+!
+!   Copyright (C) 2010-2025  The MESA Team
+!
+!   MESA is free software; you can use it and/or modify
+!   it under the combined terms and restrictions of the MESA MANIFESTO
+!   and the GNU General Library Public License as published
+!   by the Free Software Foundation; either version 2 of the License,
+!   or (at your option) any later version.
+!
+!   You should have received a copy of the MESA MANIFESTO along with
+!   this software; if not, it is available at the mesa website:
+!   https://mesastar.org/
+!
+!   MESA is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+!   See the GNU Library General Public License for more details.
+!
+!   You should have received a copy of the GNU Library General Public License
+!   along with this software; if not, write to the Free Software
+!   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+!
+! ***********************************************************************
+
+module pgstar_colors
+   implicit none
+   public
+
+   integer, parameter :: clr_Background = 0
+   integer, parameter :: clr_Foreground = 1
+   ! Values are set for backwards compat
+   integer, private, parameter :: clr_RedAlt = 2
+   integer, private, parameter :: clr_GreenAlt = 3
+   integer, private, parameter :: clr_BlueAlt = 4
+   integer, parameter :: clr_Cyan = 5
+   integer, parameter :: clr_Magenta = 6
+   integer, parameter :: clr_Yellow = 7
+   integer, parameter :: clr_Orange = 8
+   integer, parameter :: clr_LimeGreen = 9
+   integer, parameter :: clr_GreenYellow = 10
+   integer, parameter :: clr_DodgerBlue = 11
+   integer, parameter :: clr_MagentaDark = 12
+   integer, parameter :: clr_Plum = 13
+   integer, parameter :: clr_SandyBrown = 14
+   integer, parameter :: clr_Salmon = 15
+   integer, parameter :: clr_Grey59 = 16
+   integer, parameter :: clr_Grey30 = 17
+   integer, parameter :: clr_Black = 18
+   integer, parameter :: clr_Blue = 19
+   integer, parameter :: clr_BrightBlue = 20
+   integer, parameter :: clr_Goldenrod = 21
+   integer, parameter :: clr_Lilac = 22
+   integer, parameter :: clr_Coral = 23
+   integer, parameter :: clr_FireBrick = 24
+   integer, parameter :: clr_RoyalPurple = 25
+   integer, parameter :: clr_Gold = 26
+   integer, parameter :: clr_Crimson = 27
+   integer, parameter :: clr_SlateGray = 28
+   integer, parameter :: clr_Teal = 29
+   integer, parameter :: clr_LightSteelBlue = 30
+   integer, parameter :: clr_MediumSlateBlue = 31
+   integer, parameter :: clr_MediumSpringGreen = 32
+   integer, parameter :: clr_MediumBlue = 33
+   integer, parameter :: clr_RoyalBlue = 34
+   integer, parameter :: clr_LightGray = 35
+   integer, parameter :: clr_Silver = 36
+   integer, parameter :: clr_DarkGray = 37
+   integer, parameter :: clr_Gray = 38
+   integer, parameter :: clr_LightSkyBlue = 39
+   integer, parameter :: clr_LightSkyGreen = 40
+   integer, parameter :: clr_SeaGreen = 41
+   integer, parameter :: clr_Tan = 42
+   integer, parameter :: clr_IndianRed = 43
+   integer, parameter :: clr_LightOliveGreen = 44
+   integer, parameter :: clr_CadetBlue = 45
+   integer, parameter :: clr_Beige = 46
+
+   integer, parameter :: colormap_offset = 46
+   integer, parameter :: colormap_length = 101
+
+   integer, parameter :: clr_no_mixing = clr_SeaGreen
+   integer, parameter :: clr_convection = clr_LightSkyBlue
+   integer, parameter :: clr_leftover_convection = clr_BrightBlue
+   integer, parameter :: clr_semiconvection = clr_SlateGray
+   integer, parameter :: clr_thermohaline = clr_Lilac
+   integer, parameter :: clr_overshoot = clr_Beige
+   integer, parameter :: clr_rotation = clr_LightSkyGreen
+   integer, parameter :: clr_rayleigh_taylor = clr_IndianRed
+   integer, parameter :: clr_minimum = clr_Coral
+   integer, parameter :: clr_anonymous = clr_Tan
+contains
+   subroutine set_device_colors(white_on_black_flag)
+      logical, intent(in) :: white_on_black_flag
+      integer :: i
+      real, dimension(3, colormap_length) :: colormap
+
+      if (white_on_black_flag) then
+         call pgscr(clr_Background, 0., 0., 0.)
+         call pgscr(clr_Foreground, 1., 1., 1.)
+      else
+         call pgscr(clr_Foreground, 0., 0., 0.)
+         call pgscr(clr_Background, 1., 1., 1.)
+      end if
+      ! These are duplicated later, but we keep them for backwards compatibility
+      call pgscr(clr_RedAlt, 1., 0., 0.)
+      call pgscr(clr_GreenAlt, 0., 1., 0.)
+      call pgscr(clr_BlueAlt, 0., 0., 1.)
+
+      call pgscr(clr_Cyan, 0., 1., 1.)
+      call pgscr(clr_Magenta, 1., 0., 1.)
+      call pgscr(clr_Yellow, 1., 1., 0.)
+      call pgscr(clr_Orange, 1., 0.65, 0.)
+      call pgscr(clr_LimeGreen, 0.2, 0.8, 0.2)
+      call pgscr(clr_GreenYellow, 0.68, 1., 0.18)
+      call pgscr(clr_DodgerBlue, 0.12, 0.56, 1.0)
+      call pgscr(clr_MagentaDark, 0.55, 0., 0.55)
+      call pgscr(clr_Plum, 0.87, 0.63, 0.87)
+      call pgscr(clr_SandyBrown, 0.96, 0.64, 0.38)
+      call pgscr(clr_Salmon, 0.91, 0.59, 0.48)
+      call pgscr(clr_Grey59, 0.59, 0.59, 0.59)
+      call pgscr(clr_Grey30, 0.3, 0.3, 0.3)
+
+      ! Tioga colors
+      call pgscr(clr_Black, 0.0, 0.0, 0.0)
+      call pgscr(clr_Blue, 0.0, 0.0, 1.0)
+      call pgscr(clr_BrightBlue, 0.0, 0.4, 1.0)
+      call pgscr(clr_LightSkyBlue, 0.53, 0.808, 0.98)
+      call pgscr(clr_LightSkyGreen, 0.125, 0.698, 0.668)
+      call pgscr(clr_MediumSpringGreen, 0.0, 0.98, 0.604)
+      call pgscr(clr_Goldenrod, 0.855, 0.648, 0.125)
+      call pgscr(clr_Lilac, 0.8, 0.6, 1.0)
+      call pgscr(clr_Coral, 1.0, 0.498, 0.312)
+      call pgscr(clr_FireBrick, 0.698, 0.132, 0.132)
+      call pgscr(clr_RoyalPurple, 0.4, 0.0, 0.6)
+      call pgscr(clr_Gold, 1.0, 0.844, 0.0)
+      call pgscr(clr_Crimson, 0.8, 0.0, 0.2)
+      call pgscr(clr_SlateGray, 0.44, 0.5, 0.565)
+      call pgscr(clr_SeaGreen, 0.18, 0.545, 0.34)
+      call pgscr(clr_Teal, 0.0, 0.5, 0.5)
+      call pgscr(clr_LightSteelBlue, 0.69, 0.77, 0.87)
+      call pgscr(clr_MediumSlateBlue, 0.484, 0.408, 0.932)
+      call pgscr(clr_MediumBlue, 0.0, 0.0, 0.804)
+      call pgscr(clr_RoyalBlue, 0.255, 0.41, 0.884)
+      call pgscr(clr_LightGray, 0.828, 0.828, 0.828)
+      call pgscr(clr_Silver, 0.752, 0.752, 0.752)
+      call pgscr(clr_DarkGray, 0.664, 0.664, 0.664)
+      call pgscr(clr_Gray, 0.5, 0.5, 0.5)
+      call pgscr(clr_IndianRed, 0.804, 0.36, 0.36)
+      call pgscr(clr_Tan, 0.824, 0.705, 0.55)
+      call pgscr(clr_LightOliveGreen, 0.6, 0.8, 0.6)
+      call pgscr(clr_CadetBlue, 0.372, 0.62, 0.628)
+      call pgscr(clr_Beige, 0.96, 0.96, 0.864)
+
+      colormap(1:3, 1) = [ 0.0, 0.0, 1.0 ]
+      colormap(1:3, 2) = [ 0.0196078431372549, 0.0196078431372549, 1.0 ]
+      colormap(1:3, 3) = [ 0.0352941176470588, 0.0352941176470588, 1.0 ]
+      colormap(1:3, 4) = [ 0.0588235294117647, 0.0588235294117647, 1.0 ]
+      colormap(1:3, 5) = [ 0.0705882352941176, 0.0705882352941176, 1.0 ]
+      colormap(1:3, 6) = [ 0.0941176470588235, 0.0941176470588235, 1.0 ]
+      colormap(1:3, 7) = [ 0.105882352941176, 0.105882352941176, 1.0 ]
+      colormap(1:3, 8) = [ 0.129411764705882, 0.129411764705882, 1.0 ]
+      colormap(1:3, 9) = [ 0.141176470588235, 0.141176470588235, 1.0 ]
+      colormap(1:3, 10) = [ 0.164705882352941, 0.164705882352941, 1.0 ]
+      colormap(1:3, 11) = [ 0.184313725490196, 0.184313725490196, 1.0 ]
+      colormap(1:3, 12) = [ 0.2, 0.2, 1.0 ]
+      colormap(1:3, 13) = [ 0.219607843137255, 0.219607843137255, 1.0 ]
+      colormap(1:3, 14) = [ 0.235294117647059, 0.235294117647059, 1.0 ]
+      colormap(1:3, 15) = [ 0.254901960784314, 0.254901960784314, 1.0 ]
+      colormap(1:3, 16) = [ 0.270588235294118, 0.270588235294118, 1.0 ]
+      colormap(1:3, 17) = [ 0.294117647058824, 0.294117647058824, 1.0 ]
+      colormap(1:3, 18) = [ 0.305882352941176, 0.305882352941176, 1.0 ]
+      colormap(1:3, 19) = [ 0.329411764705882, 0.329411764705882, 1.0 ]
+      colormap(1:3, 20) = [ 0.341176470588235, 0.341176470588235, 1.0 ]
+      colormap(1:3, 21) = [ 0.364705882352941, 0.364705882352941, 1.0 ]
+      colormap(1:3, 22) = [ 0.384313725490196, 0.384313725490196, 1.0 ]
+      colormap(1:3, 23) = [ 0.4, 0.4, 1.0 ]
+      colormap(1:3, 24) = [ 0.419607843137255, 0.419607843137255, 1.0 ]
+      colormap(1:3, 25) = [ 0.435294117647059, 0.435294117647059, 1.0 ]
+      colormap(1:3, 26) = [ 0.454901960784314, 0.454901960784314, 1.0 ]
+      colormap(1:3, 27) = [ 0.470588235294118, 0.470588235294118, 1.0 ]
+      colormap(1:3, 28) = [ 0.490196078431373, 0.490196078431373, 1.0 ]
+      colormap(1:3, 29) = [ 0.505882352941176, 0.505882352941176, 1.0 ]
+      colormap(1:3, 30) = [ 0.529411764705882, 0.529411764705882, 1.0 ]
+      colormap(1:3, 31) = [ 0.549019607843137, 0.549019607843137, 1.0 ]
+      colormap(1:3, 32) = [ 0.564705882352941, 0.564705882352941, 1.0 ]
+      colormap(1:3, 33) = [ 0.584313725490196, 0.584313725490196, 1.0 ]
+      colormap(1:3, 34) = [ 0.6, 0.6, 1.0 ]
+      colormap(1:3, 35) = [ 0.619607843137255, 0.619607843137255, 1.0 ]
+      colormap(1:3, 36) = [ 0.635294117647059, 0.635294117647059, 1.0 ]
+      colormap(1:3, 37) = [ 0.654901960784314, 0.654901960784314, 1.0 ]
+      colormap(1:3, 38) = [ 0.670588235294118, 0.670588235294118, 1.0 ]
+      colormap(1:3, 39) = [ 0.690196078431373, 0.690196078431373, 1.0 ]
+      colormap(1:3, 40) = [ 0.705882352941177, 0.705882352941177, 1.0 ]
+      colormap(1:3, 41) = [ 0.725490196078431, 0.725490196078431, 1.0 ]
+      colormap(1:3, 42) = [ 0.749019607843137, 0.749019607843137, 1.0 ]
+      colormap(1:3, 43) = [ 0.764705882352941, 0.764705882352941, 1.0 ]
+      colormap(1:3, 44) = [ 0.784313725490196, 0.784313725490196, 1.0 ]
+      colormap(1:3, 45) = [ 0.8, 0.8, 1.0 ]
+      colormap(1:3, 46) = [ 0.831372549019608, 0.831372549019608, 1.0 ]
+      colormap(1:3, 47) = [ 0.854901960784314, 0.854901960784314, 1.0 ]
+      colormap(1:3, 48) = [ 0.890196078431372, 0.890196078431372, 1.0 ]
+      colormap(1:3, 49) = [ 0.913725490196078, 0.913725490196078, 1.0 ]
+      colormap(1:3, 50) = [ 0.949019607843137, 0.949019607843137, 1.0 ]
+      colormap(1:3, 51) = [ 1.0, 0.972549019607843, 0.972549019607843 ]
+      colormap(1:3, 52) = [ 1.0, 0.949019607843137, 0.949019607843137 ]
+      colormap(1:3, 53) = [ 1.0, 0.913725490196078, 0.913725490196078 ]
+      colormap(1:3, 54) = [ 1.0, 0.890196078431372, 0.890196078431372 ]
+      colormap(1:3, 55) = [ 1.0, 0.854901960784314, 0.854901960784314 ]
+      colormap(1:3, 56) = [ 1.0, 0.831372549019608, 0.831372549019608 ]
+      colormap(1:3, 57) = [ 1.0, 0.8, 0.8 ]
+      colormap(1:3, 58) = [ 1.0, 0.784313725490196, 0.784313725490196 ]
+      colormap(1:3, 59) = [ 1.0, 0.764705882352941, 0.764705882352941 ]
+      colormap(1:3, 60) = [ 1.0, 0.749019607843137, 0.749019607843137 ]
+      colormap(1:3, 61) = [ 1.0, 0.725490196078431, 0.725490196078431 ]
+      colormap(1:3, 62) = [ 1.0, 0.705882352941177, 0.705882352941177 ]
+      colormap(1:3, 63) = [ 1.0, 0.690196078431373, 0.690196078431373 ]
+      colormap(1:3, 64) = [ 1.0, 0.670588235294118, 0.670588235294118 ]
+      colormap(1:3, 65) = [ 1.0, 0.654901960784314, 0.654901960784314 ]
+      colormap(1:3, 66) = [ 1.0, 0.635294117647059, 0.635294117647059 ]
+      colormap(1:3, 67) = [ 1.0, 0.619607843137255, 0.619607843137255 ]
+      colormap(1:3, 68) = [ 1.0, 0.6, 0.6 ]
+      colormap(1:3, 69) = [ 1.0, 0.584313725490196, 0.584313725490196 ]
+      colormap(1:3, 70) = [ 1.0, 0.564705882352941, 0.564705882352941 ]
+      colormap(1:3, 71) = [ 1.0, 0.541176470588235, 0.541176470588235 ]
+      colormap(1:3, 72) = [ 1.0, 0.529411764705882, 0.529411764705882 ]
+      colormap(1:3, 73) = [ 1.0, 0.505882352941176, 0.505882352941176 ]
+      colormap(1:3, 74) = [ 1.0, 0.490196078431373, 0.490196078431373 ]
+      colormap(1:3, 75) = [ 1.0, 0.470588235294118, 0.470588235294118 ]
+      colormap(1:3, 76) = [ 1.0, 0.454901960784314, 0.454901960784314 ]
+      colormap(1:3, 77) = [ 1.0, 0.435294117647059, 0.435294117647059 ]
+      colormap(1:3, 78) = [ 1.0, 0.419607843137255, 0.419607843137255 ]
+      colormap(1:3, 79) = [ 1.0, 0.4, 0.4 ]
+      colormap(1:3, 80) = [ 1.0, 0.384313725490196, 0.384313725490196 ]
+      colormap(1:3, 81) = [ 1.0, 0.364705882352941, 0.364705882352941 ]
+      colormap(1:3, 82) = [ 1.0, 0.341176470588235, 0.341176470588235 ]
+      colormap(1:3, 83) = [ 1.0, 0.329411764705882, 0.329411764705882 ]
+      colormap(1:3, 84) = [ 1.0, 0.305882352941176, 0.305882352941176 ]
+      colormap(1:3, 85) = [ 1.0, 0.294117647058824, 0.294117647058824 ]
+      colormap(1:3, 86) = [ 1.0, 0.270588235294118, 0.270588235294118 ]
+      colormap(1:3, 87) = [ 1.0, 0.254901960784314, 0.254901960784314 ]
+      colormap(1:3, 88) = [ 1.0, 0.235294117647059, 0.235294117647059 ]
+      colormap(1:3, 89) = [ 1.0, 0.219607843137255, 0.219607843137255 ]
+      colormap(1:3, 90) = [ 1.0, 0.2, 0.2 ]
+      colormap(1:3, 91) = [ 1.0, 0.176470588235294, 0.176470588235294 ]
+      colormap(1:3, 92) = [ 1.0, 0.164705882352941, 0.164705882352941 ]
+      colormap(1:3, 93) = [ 1.0, 0.141176470588235, 0.141176470588235 ]
+      colormap(1:3, 94) = [ 1.0, 0.129411764705882, 0.129411764705882 ]
+      colormap(1:3, 95) = [ 1.0, 0.105882352941176, 0.105882352941176 ]
+      colormap(1:3, 96) = [ 1.0, 0.0941176470588235, 0.0941176470588235 ]
+      colormap(1:3, 97) = [ 1.0, 0.0705882352941176, 0.0705882352941176 ]
+      colormap(1:3, 98) = [ 1.0, 0.0588235294117647, 0.0588235294117647 ]
+      colormap(1:3, 99) = [ 1.0, 0.0352941176470588, 0.0352941176470588 ]
+      colormap(1:3, 100) = [ 1.0, 0.0196078431372549, 0.0196078431372549 ]
+      colormap(1:3, 101) = [ 1.0, 0.0, 0.0 ]
+
+      do i = 1, colormap_length
+         call pgscr(colormap_offset + i, colormap(1, i), colormap(2, i), colormap(3, i))
+      end do
+   end subroutine set_device_colors
+end module pgstar_colors
+

--- a/star/private/pgstar_dynamo.f90
+++ b/star/private/pgstar_dynamo.f90
@@ -164,6 +164,7 @@
          subroutine plot(ierr)
             use pgstar_support, only: show_convective_section, show_semiconvective_section, &
                show_thermohaline_section, show_overshoot_section
+            use pgstar_colors
             integer, intent(out) :: ierr
 
             integer :: lw, lw_sav, k

--- a/star/private/pgstar_dynamo.f90
+++ b/star/private/pgstar_dynamo.f90
@@ -185,7 +185,7 @@
                   call show_model_number_pgstar(s)
                   call show_age_pgstar(s)
                end if
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_xaxis_name(s,Dyn_xaxis_name,ierr)
                if (ierr /= 0) return
             end if
@@ -222,7 +222,7 @@
 
             call pgswin(xleft, xright, ymin, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_box_pgstar(s,'','BNSTV')
 
             call pgsci(clr_Teal)
@@ -277,7 +277,7 @@
             call pgswin(xleft, xright, ymin, ymax)
 
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (xaxis_numeric_labels_flag) then
                call show_box_pgstar(s,'BCNST','CMSTV')
             else

--- a/star/private/pgstar_hist_track.f90
+++ b/star/private/pgstar_hist_track.f90
@@ -623,6 +623,7 @@
             use_decorator, pgstar_decorator, &
             decorate, ierr)
          use utils_lib
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: &
@@ -813,6 +814,7 @@
 
 
          subroutine show_file_track
+            use pgstar_colors
             integer :: k
             if (len_trim(fname) == 0) return
             if (.not. read_values_from_file(fname, &

--- a/star/private/pgstar_hist_track.f90
+++ b/star/private/pgstar_hist_track.f90
@@ -734,7 +734,7 @@
          call pgsvp(vp_xleft, vp_xright, vp_ybot, vp_ytop)
          call pgswin(xleft, xright, ybot, ytop)
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call show_box_pgstar(s,'BCNST1','BCNSTV1')
 
          if (log_xaxis) then

--- a/star/private/pgstar_history_panels.f90
+++ b/star/private/pgstar_history_panels.f90
@@ -853,7 +853,7 @@
                !write(*,1) trim(other_yname), other_ybot, other_ytop
                call pgswin(xleft, xright, other_ybot, other_ytop)
                call pgscf(1)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_box_pgstar(s,'','CMSTV')
                call pgsci(other_y_color)
                if (hist_other_yaxis_log(j)) then
@@ -876,7 +876,7 @@
                !write(*,1) trim(yname), ybot, ytop
                call pgswin(xleft, xright, ybot, ytop)
                call pgscf(1)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                if (j < hist_num_panels) then
                   if (.not. have_other_yaxis) then
                      call show_box_pgstar(s,'BCST1','BCMNSTV1')
@@ -944,7 +944,7 @@
                call pgslw(1)
             end if
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_pgstar_decorator(s%id,use_decorator,pgstar_decorator, j, ierr)
          end do
 

--- a/star/private/pgstar_history_panels.f90
+++ b/star/private/pgstar_history_panels.f90
@@ -614,6 +614,7 @@
          use net_def
          use net_lib, only: get_net_reaction_table
          use const_def, only: Msun, Rsun
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id, hist_num_panels

--- a/star/private/pgstar_hr.f90
+++ b/star/private/pgstar_hr.f90
@@ -60,6 +60,7 @@
 
 
       subroutine HR_decorate(id, ierr)
+         use pgstar_colors
          integer, intent(in) :: id
          integer, intent(out) :: ierr
          type (star_info), pointer :: s

--- a/star/private/pgstar_kipp.f90
+++ b/star/private/pgstar_kipp.f90
@@ -29,8 +29,12 @@
       use const_def, only: dp, msun, anonymous_mixing, minimum_mixing, rayleigh_taylor_mixing
       use pgstar_support
       use star_pgstar
+      use pgstar_colors
 
       implicit none
+      private
+
+      public :: Kipp_Plot, do_Kipp_Plot
 
       contains
 
@@ -488,7 +492,7 @@
             include 'formats'
             xmass = mass - mass_center
             burn_qbot = 0
-            mid_map = colormap_size/2
+            mid_map = colormap_length/2
             do k = i_burn_type_first, i_burn_type_last, 2
                burn_type = pg% vals(k)
                burn_qtop = pg% vals(k+1)
@@ -499,7 +503,7 @@
                   if (burn_type > 0.0) then
                      color_frac = 1.0 - max(0.0, min(1.0, burn_type/bmax))
                      colormap_index = &
-                        colormap_size - int(0.6*color_frac*(colormap_size - mid_map))
+                        colormap_length - int(0.6*color_frac*(colormap_length - mid_map))
                   else  ! burn_type < 0.0
                      color_frac = 1.0 - max(0.0, min(1.0, burn_type/bmin))
                      colormap_index = 1 + int(0.6*color_frac*mid_map)
@@ -688,11 +692,11 @@
             call pgsave
             call pgslw(2)
 
-            colormap_index = int(colormap_size*0.85)
+            colormap_index = int(colormap_length*0.85)
             call pgsci(colormap_offset + colormap_index)
             call show_xaxis_label_pgmtxt_pgstar(s, 0.17, 0.5, 'burning', 1.0)
 
-            colormap_index = int(colormap_size*0.15)
+            colormap_index = int(colormap_length*0.15)
             call pgsci(colormap_offset + colormap_index)
             call show_xaxis_label_pgmtxt_pgstar(s, 0.82, 0.5, 'cooling', 1.0)
 

--- a/star/private/pgstar_kipp.f90
+++ b/star/private/pgstar_kipp.f90
@@ -378,7 +378,7 @@
             if (s% pg% Kipp_lgL_max /= -101d0) ymax = ymax + s% pg% Kipp_lgL_margin*dy
             call pgswin(xleft, xright, ymin, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             ymin_L_axis = ymin
             ymax_L_axis = ymax
          end subroutine setup_L_yaxis
@@ -396,7 +396,7 @@
             if (s% pg% Kipp_mass_max /= -101d0) ymax = ymax + s% pg% Kipp_mass_margin*dy
             call pgswin(xleft, xright, ymin, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             ymin_mass_axis = ymin
             ymax_mass_axis = ymax
          end subroutine setup_mass_yaxis

--- a/star/private/pgstar_mixing_ds.f90
+++ b/star/private/pgstar_mixing_ds.f90
@@ -220,7 +220,7 @@
                   call show_age_pgstar(s)
                end if
                call show_title_pgstar(s, title)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_xaxis_name(s,MixDs_xaxis_name,ierr)
                if (ierr /= 0) return
             end if
@@ -335,7 +335,7 @@
 
             call pgswin(xleft, xright, ymin, ymax)
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (xaxis_numeric_labels_flag) then
                call show_box_pgstar(s,'BCNST','BCNSTV')
             else
@@ -543,6 +543,7 @@
 
          integer function mixing_line_legend( &
                cnt, clr, lw, lw_sav, txt_scale, str)
+            use pgstar_colors, only: clr_Foreground
             integer, intent(in) :: cnt, clr, lw, lw_sav
             real, intent(in) :: txt_scale
             character (len=*), intent(in) :: str
@@ -557,7 +558,7 @@
             call pgslw(lw)
             call pgline(2, xpts, ypts)
             call pgslw(lw_sav)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*s% pg% Mixing_legend_txt_scale_factor)
             call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, trim(str))
             mixing_line_legend = cnt + 1

--- a/star/private/pgstar_mixing_ds.f90
+++ b/star/private/pgstar_mixing_ds.f90
@@ -189,6 +189,7 @@
 
 
          subroutine plot(ierr)
+            use pgstar_colors
             integer, intent(out) :: ierr
 
             integer :: lw, lw_sav

--- a/star/private/pgstar_mode_prop.f90
+++ b/star/private/pgstar_mode_prop.f90
@@ -81,6 +81,7 @@
          use utils_lib
          use chem_def
          use net_def
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/private/pgstar_mode_prop.f90
+++ b/star/private/pgstar_mode_prop.f90
@@ -212,7 +212,7 @@
             ybot = -0.05
             call pgswin(xleft, xright, ymin+ybot, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (xaxis_numeric_labels_flag) then
                call show_box_pgstar(s,'BCNST','BCNSTV')
             else
@@ -239,7 +239,7 @@
             call pgslw(lw_sav)
 
             if (.not. panel_flag) then
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_xaxis_name(s,xaxis_name,ierr)
                if (ierr == 0) then  ! show mix regions at bottom of plot
                   call pgslw(10)
@@ -286,7 +286,7 @@
             call pgslw(lw)
             call pgline(2, xpts, ypts)
             call pgslw(lw_sav)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*0.70)
             call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, name)
             mode_propagation_line_legend = cnt + 1

--- a/star/private/pgstar_network.f90
+++ b/star/private/pgstar_network.f90
@@ -29,8 +29,12 @@
       use const_def, only: dp
       use pgstar_support
       use star_pgstar
+      use pgstar_colors
 
       implicit none
+      private
+
+      public :: network_plot, do_network_plot
 
       contains
 
@@ -183,7 +187,7 @@
             end if
             call show_title_pgstar(s, title)
 
-            mid_map = colormap_size/2
+            mid_map = colormap_length/2
             do i=1,s%species
 
                Z=chem_isos%Z(s%chem_id(i))
@@ -203,11 +207,11 @@
                !Plot colored dots for mass fractions
                if(s% pg% Network_show_mass_fraction) then
                   if(abun>log10_min_abun .and. abun < log10_max_abun)THEN
-                     do j=mid_map,colormap_size
-                        xlow=log10_min_abun+(j-mid_map)*(log10_max_abun-log10_min_abun)/(colormap_size-mid_map)
-                        xhigh=log10_min_abun+(j-mid_map+1)*(log10_max_abun-log10_min_abun)/(colormap_size-mid_map)
+                     do j=mid_map,colormap_length
+                        xlow=log10_min_abun+(j-mid_map)*(log10_max_abun-log10_min_abun)/(colormap_length-mid_map)
+                        xhigh=log10_min_abun+(j-mid_map+1)*(log10_max_abun-log10_min_abun)/(colormap_length-mid_map)
                         if(abun>=xlow .and. abun<xhigh)THEN
-                           clr = colormap_offset + (colormap_size-(j-mid_map))
+                           clr = colormap_offset + (colormap_length-(j-mid_map))
                            call pgsci(clr)
                         end if
                      end do
@@ -252,8 +256,8 @@
          legend_ymin = winymin
          legend_ymax = winymax
 
-         mid_map = colormap_size/2
-         num_cms=colormap_size-mid_map
+         mid_map = colormap_length/2
+         num_cms=colormap_length-mid_map
          dyline = (ymax-ymin)/num_cms
          dx = 0.1
 
@@ -263,9 +267,9 @@
          call pgsave
          call pgsvp(legend_xmin, legend_xmax, legend_ymin, legend_ymax)
          call pgswin(0.0, 1.0, ymin, ymax)
-         do j=mid_map,colormap_size
+         do j=mid_map,colormap_length
             i=j-mid_map
-            clr = colormap_offset + (colormap_size-i+1)
+            clr = colormap_offset + (colormap_length-i+1)
             call pgsci(clr)
             yt = ymin + (i)*dyline
             yb = ymin + (i-1)*dyline

--- a/star/private/pgstar_network.f90
+++ b/star/private/pgstar_network.f90
@@ -200,7 +200,7 @@
                if(z<ymin .or. z>ymax .or. n<xleft .or.n>xright)CYCLE
 
                if (s% pg% Network_show_element_names) THEN
-                  call pgsci(1)
+                  call pgsci(clr_Foreground)
                   call pgtext(xleft-3.5,z*1.0-0.25,el_name(Z))
                end if
 
@@ -221,7 +221,7 @@
                end if
 
                !Plot box centered on the (N,Z)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call pgline(5,[n-step,n+step,n+step,n-step,n-step],[z-step,z-step,z+step,z+step,z-step])
             end do
 
@@ -277,7 +277,7 @@
             call pgrect(xpts(1),xpts(2),yb,yt)
          end do
 
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          do j=1,5
             text=abun_min+(j-1)*(abun_max-abun_min)/4.0
             write(str,'(F8.3)') text

--- a/star/private/pgstar_power.f90
+++ b/star/private/pgstar_power.f90
@@ -84,6 +84,7 @@
          use chem_def
          use net_def
          use const_def, only: Msun, Rsun
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/private/pgstar_power.f90
+++ b/star/private/pgstar_power.f90
@@ -198,7 +198,7 @@
                   call show_age_pgstar(s)
                end if
                call show_title_pgstar(s, title)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_xaxis_name(s,xaxis_name,ierr)
                if (ierr /= 0) return
             end if
@@ -206,7 +206,7 @@
             ybot = -0.05
             call pgswin(xleft, xright, ymin+ybot, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (xaxis_numeric_labels_flag) then
                call show_box_pgstar(s,'BCNST','BCNSTV')
             else
@@ -273,7 +273,7 @@
             call pgslw(lw)
             call pgline(2, xpts, ypts)
             call pgslw(lw_sav)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*s% pg% Power_legend_txt_scale_factor)
             call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, &
                trim(adjustl(category_name(icat))))

--- a/star/private/pgstar_production.f90
+++ b/star/private/pgstar_production.f90
@@ -81,6 +81,7 @@
          use chem_def
          use net_def
          use const_def, only: Msun
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/private/pgstar_profile_panels.f90
+++ b/star/private/pgstar_profile_panels.f90
@@ -551,6 +551,7 @@
          use pgstar_mixing_Ds, only: do_Mixing_panel
          use pgstar_mode_prop, only: do_mode_propagation_panel
          use pgstar_summary_profile, only: do_summary_profile_panel
+         use pgstar_colors
          use utils_lib
          use profile_getval, only: get_profile_val, get_profile_id
 

--- a/star/private/pgstar_profile_panels.f90
+++ b/star/private/pgstar_profile_panels.f90
@@ -923,7 +923,7 @@
             if (len_trim(panels_other_yaxis_name(j)) > 0) then
                call pgswin(xleft, xright, other_ybot, other_ytop)
                call pgscf(1)
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_box_pgstar(s,'','CMSTV')
                call pgsci(other_y_color)
                if (panels_other_yaxis_log(j)) then
@@ -951,7 +951,7 @@
 
             call pgswin(xleft, xright, ybot, ytop)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (j < panels_num_panels) then
                if (other_yaxis_id <= 0 .and. other_yfile_data_len <= 0) then
                   call show_box_pgstar(s,'BCST','BCMNSTV')
@@ -991,7 +991,7 @@
                end if
             end if
             call pgslw(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
 
             call show_pgstar_decorator(s% id, use_decorator, pgstar_decorator, j, ierr)
          end do

--- a/star/private/pgstar_rti.f90
+++ b/star/private/pgstar_rti.f90
@@ -239,6 +239,7 @@
          end subroutine dealloc
 
          subroutine plot_total_mass_line
+            use pgstar_colors
             call pgsave
             call pgsch(txt_scale*0.8)
             call pgsci(clr_Gray)
@@ -382,6 +383,7 @@
 
          subroutine draw_rti_for_step( &
                pg, step, i_rti_type_first, i_rti_type_last, xval, mass, mass_center)
+            use pgstar_colors
             type (pgstar_hist_node), pointer :: pg
             integer, intent(in) :: step, i_rti_type_first, i_rti_type_last
             real, intent(in) :: xval, mass, mass_center
@@ -421,6 +423,7 @@
 
 
          subroutine plot_mass_lines
+            use pgstar_colors
             integer :: i
 
             include 'formats'

--- a/star/private/pgstar_rti.f90
+++ b/star/private/pgstar_rti.f90
@@ -275,7 +275,7 @@
             if (s% pg% rti_mass_max /= -101d0) ymax = ymax + s% pg% rti_mass_margin*dy
             call pgswin(xleft, xright, ymin, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             ymin_mass_axis = ymin
             ymax_mass_axis = ymax
          end subroutine setup_mass_yaxis

--- a/star/private/pgstar_summary.f90
+++ b/star/private/pgstar_summary.f90
@@ -345,6 +345,7 @@
             Text_Summary_num_rows, Text_Summary_num_cols, &
             Text_Summary_name, ierr)
 
+         use pgstar_colors, only: clr_Foreground
          use utils_lib
          use chem_def
          use net_def
@@ -372,7 +373,7 @@
          call pgsch(txt_scale)
 
          call pgsvp(winxmin, winxmax, winymin, winymax)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call pgscf(1)
          call pgswin(0.0,1.0,0.0,1.0)
          call show_title_pgstar(s, title)

--- a/star/private/pgstar_summary_burn.f90
+++ b/star/private/pgstar_summary_burn.f90
@@ -158,7 +158,7 @@
             call pgswin(xleft, xright, ymin+ybot, ymax)
 
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale)
             call pgbox('BCNST',0.0,0,'CMSTV',0.0,0)
             call pgsci(clr_Goldenrod)
@@ -193,7 +193,7 @@
 
             call pgswin(xleft, xright, ymin+ybot, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale)
             call pgbox('',0.0,0,'BNSTV',0.0,0)
 
@@ -231,7 +231,7 @@
                   xnuc_cat(num_cat) = maxv
                end if
             end do
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*0.8)
             do ii = 1, num_cat
                eps_max = -100; i = 0
@@ -290,7 +290,7 @@
                end if
             end do
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             ierr = 0
             call show_xaxis_name(s,xaxis_name,ierr)
             if (ierr == 0) then  ! show mix regions at bottom of plot

--- a/star/private/pgstar_summary_burn.f90
+++ b/star/private/pgstar_summary_burn.f90
@@ -122,6 +122,7 @@
 
          subroutine plot(ierr)
             use rates_def
+            use pgstar_colors
             integer, intent(out) :: ierr
 
             integer :: j, ii, jj, i, cnt, k

--- a/star/private/pgstar_summary_history.f90
+++ b/star/private/pgstar_summary_history.f90
@@ -169,7 +169,7 @@
             ybot = 0
             call pgswin(xmin, xmax, ymin+ybot, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_box_pgstar(s,'BCNST','BCNSTV')
             call show_left_yaxis_label_pgstar(s, 'rel=(val-min)/(max-min)')
 
@@ -215,7 +215,7 @@
 
             end do
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_xaxis_label_pgstar(s,'model number')
 
             ! show the legend
@@ -278,7 +278,7 @@
             call pgslw(lw)
             call pgline(2, xpts, ypts)
             call pgslw(lw_sav)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*0.70)
             call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, name)
             summary_history_line_legend = cnt + 1

--- a/star/private/pgstar_summary_history.f90
+++ b/star/private/pgstar_summary_history.f90
@@ -64,6 +64,7 @@
          use chem_def
          use net_def
          use const_def, only: Msun, Rsun
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/private/pgstar_summary_profile.f90
+++ b/star/private/pgstar_summary_profile.f90
@@ -179,7 +179,7 @@
             ybot = -0.02
             call pgswin(xleft, xright, ymin+ybot, ymax)
             call pgscf(1)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             if (xaxis_numeric_labels_flag) then
                call show_box_pgstar(s,'BCNST','BCNSTV')
             else
@@ -240,7 +240,7 @@
             end do
 
             if (.not. panel_flag) then  ! show xaxis info
-               call pgsci(1)
+               call pgsci(clr_Foreground)
                call show_xaxis_name(s,xaxis_name,ierr)
                if (ierr == 0) then  ! show mix regions at bottom of plot
                   call pgslw(10)
@@ -302,7 +302,7 @@
             call pgslw(lw)
             call pgline(2, xpts, ypts)
             call pgslw(lw_sav)
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call pgsch(txt_scale*0.70)
             call pgptxt(xpts(2) + dx, ypos, 0.0, 0.0, name)
             summary_profile_line_legend = cnt + 1

--- a/star/private/pgstar_summary_profile.f90
+++ b/star/private/pgstar_summary_profile.f90
@@ -83,6 +83,7 @@
          use chem_def
          use net_def
          use const_def, only: Msun, Rsun
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/private/pgstar_support.f90
+++ b/star/private/pgstar_support.f90
@@ -582,124 +582,15 @@ contains
       end function set_c
 
 
-      integer function setcolour(i, name, ierr)
-         integer :: i
+      integer function setcolour(index, name, ierr)
+         integer :: index
          character (len = *) :: name
          integer, intent(out) :: ierr
-         call Set_Pgplot_Colour(i, name, ierr)
-         setcolour = i + 1
+         call pgscrn(index, name, ierr)
+         setcolour = index + 1
       end function setcolour
 
    end subroutine Set_Colours
-
-
-   subroutine Set_Pgplot_Colour(index, name, ierr)
-      use utils_lib
-
-      integer :: index
-      character (len = *) :: name
-      integer, intent(out) :: ierr
-
-      logical, save :: have_colour_list = .false.
-      real, allocatable, dimension(:), save :: red, green, blue
-      character (len = 64), allocatable, dimension(:), save :: colournames
-      integer, save :: nrgbcolours, low, hi
-      integer :: i
-
-      ierr = 0
-      if (.not.have_colour_list) then
-         call loadRGBtxt(ierr)
-         if (ierr /= 0) return
-         have_colour_list = .true.
-         call pgqcol(low, hi)
-      end if
-
-      if (.not. (low<=index .and. index<=hi)) then
-         write(*, '(a,i4,a,i3,a,i3)') "Set_Pgplot_Colour: requested index of ", index, &
-            " not in ", low, " to ", hi
-         return
-      end if
-
-      do i = 1, nrgbcolours
-         if (colournames(i) == name) exit
-      end do
-      if (i>nrgbcolours) then
-         write(*, *) "Set_Pgplot_Colour: colour ", trim(name), " not found"
-         ierr = -1
-         return
-      end if
-      call pgscr(index, red(i), green(i), blue(i))
-
-
-   contains
-
-
-      subroutine loadRGBtxt(ierr)
-         integer, intent(out) :: ierr
-
-         logical :: fexist
-         integer :: iounit, i, j, r, g, b, len
-         character (len = 1024) :: msg, fname, pgplotdir, line
-         ierr = 0
-
-         call GET_ENVIRONMENT_VARIABLE("PGPLOT_DIR", pgplotdir)
-         if (len_trim(pgplotdir)==0) then
-            write(*, *) "PGPLOT_DIR is not set in your shell"
-            ierr = -1
-            return
-         end if
-
-         fname = trim(pgplotdir) // "/rgb.txt"
-         inquire(file = trim(fname), exist = fexist)
-         if (.not.fexist) then
-            write(*, *) 'loadRGBtxt: pgplot ', trim(fname), " does not exist"
-            write(*, *) 'loadRGBtxt: pgplot rgb.txt file does not exist'
-            ierr = -1
-            return
-         end if
-
-         open(newunit = iounit, file = trim(fname), status = "old", iostat = ierr, iomsg = msg)
-
-         if (ierr/=0) then
-            write(*, *) trim(msg)
-            write(*, *) 'loadRGBtxt: cannot open the pgplot rgb.txt file'
-            ierr = -1
-            return
-         end if
-
-         ! count colours
-         len = 0
-         do while(.true.)
-            read(iounit, *, iostat = ierr) i
-            if (ierr/=0) exit
-            len = len + 1
-         end do
-         nrgbcolours = len
-         close(iounit)
-
-         allocate(red(nrgbcolours), green(nrgbcolours), blue(nrgbcolours))
-         allocate(colournames(nrgbcolours))
-         open(newunit = iounit, file = trim(fname), status = "old", iostat = ierr, iomsg = msg)
-         do i = 1, nrgbcolours
-            read(iounit, '(a)') line
-            read(line, *) r, g, b
-            j = 1
-            do while(line(j:j)==char(32) .or. &
-               (line(j:j)>=char(48) .and. line(j:j)<=char(57)))
-               j = j + 1
-            end do
-            read(line(j:), '(a)') colournames(i)
-            red(i) = r / 255.0
-            green(i) = g / 255.0
-            blue(i) = b / 255.0
-         end do
-         close(iounit)
-
-      end subroutine loadRGBtxt
-
-
-   end subroutine Set_Pgplot_Colour
-
 
    subroutine read_TRho_data(fname, logTs, logRhos, ierr)
       use utils_lib

--- a/star/private/pgstar_support.f90
+++ b/star/private/pgstar_support.f90
@@ -280,7 +280,7 @@ contains
          p% prev_win_width = p% win_width
          p% prev_win_aspect_ratio = p% win_aspect_ratio
       end if
-      call Set_Colours(white_on_black_flag, ierr)
+      call set_device_colors(white_on_black_flag, ierr)
    end subroutine open_device
 
 
@@ -364,7 +364,7 @@ contains
 
    ! remaining routines for setting colours in PGPLOT
    ! by X11 name
-   subroutine Set_Colours(white_on_black_flag, ierr)
+   subroutine set_device_colors(white_on_black_flag, ierr)
       logical, intent(in) :: white_on_black_flag
       integer, intent(out) :: ierr
       integer :: index, i, k
@@ -374,79 +374,79 @@ contains
       index = 0
       ierr = 0
       if (white_on_black_flag) then
-         index = setcolour(index, "black", ierr)
+         index = set_index_to_name(index, "black", ierr)
          if (ierr /= 0) return
-         index = setcolour(index, "white", ierr)
+         index = set_index_to_name(index, "white", ierr)
          if (ierr /= 0) return
       else
-         index = setcolour(index, "white", ierr)
+         index = set_index_to_name(index, "white", ierr)
          if (ierr /= 0) return
-         index = setcolour(index, "black", ierr)
+         index = set_index_to_name(index, "black", ierr)
          if (ierr /= 0) return
       end if
-      index = setcolour(index, "red", ierr)
+      index = set_index_to_name(index, "red", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "green", ierr)
+      index = set_index_to_name(index, "green", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "blue", ierr)
+      index = set_index_to_name(index, "blue", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "cyan", ierr)
+      index = set_index_to_name(index, "cyan", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "magenta", ierr)
+      index = set_index_to_name(index, "magenta", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "yellow", ierr)
+      index = set_index_to_name(index, "yellow", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "orange", ierr)
+      index = set_index_to_name(index, "orange", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "lime green", ierr)
+      index = set_index_to_name(index, "lime green", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "green yellow", ierr)
+      index = set_index_to_name(index, "green yellow", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "dodger blue", ierr)
+      index = set_index_to_name(index, "dodger blue", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "magenta4", ierr)
+      index = set_index_to_name(index, "magenta4", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "plum", ierr)
+      index = set_index_to_name(index, "plum", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "sandy brown", ierr)
+      index = set_index_to_name(index, "sandy brown", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "salmon", ierr)
+      index = set_index_to_name(index, "salmon", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "grey59", ierr)
+      index = set_index_to_name(index, "grey59", ierr)
       if (ierr /= 0) return
-      index = setcolour(index, "grey30", ierr)
+      index = set_index_to_name(index, "grey30", ierr)
       if (ierr /= 0) return
 
       ! Tioga colors
-      index = set_c(index, clr_Black, 0.0, 0.0, 0.0)
-      index = set_c(index, clr_Blue, 0.0, 0.0, 1.0)
-      index = set_c(index, clr_BrightBlue, 0.0, 0.4, 1.0)
-      index = set_c(index, clr_LightSkyBlue, 0.53, 0.808, 0.98)
-      index = set_c(index, clr_LightSkyGreen, 0.125, 0.698, 0.668)
-      index = set_c(index, clr_MediumSpringGreen, 0.0, 0.98, 0.604)
-      index = set_c(index, clr_Goldenrod, 0.855, 0.648, 0.125)
-      index = set_c(index, clr_Lilac, 0.8, 0.6, 1.0)
-      index = set_c(index, clr_Coral, 1.0, 0.498, 0.312)
-      index = set_c(index, clr_FireBrick, 0.698, 0.132, 0.132)
-      index = set_c(index, clr_RoyalPurple, 0.4, 0.0, 0.6)
-      index = set_c(index, clr_Gold, 1.0, 0.844, 0.0)
-      index = set_c(index, clr_Crimson, 0.8, 0.0, 0.2)
-      index = set_c(index, clr_SlateGray, 0.44, 0.5, 0.565)
-      index = set_c(index, clr_SeaGreen, 0.18, 0.545, 0.34)
-      index = set_c(index, clr_Teal, 0.0, 0.5, 0.5)
-      index = set_c(index, clr_LightSteelBlue, 0.69, 0.77, 0.87)
-      index = set_c(index, clr_MediumSlateBlue, 0.484, 0.408, 0.932)
-      index = set_c(index, clr_MediumBlue, 0.0, 0.0, 0.804)
-      index = set_c(index, clr_RoyalBlue, 0.255, 0.41, 0.884)
-      index = set_c(index, clr_LightGray, 0.828, 0.828, 0.828)
-      index = set_c(index, clr_Silver, 0.752, 0.752, 0.752)
-      index = set_c(index, clr_DarkGray, 0.664, 0.664, 0.664)
-      index = set_c(index, clr_Gray, 0.5, 0.5, 0.5)
-      index = set_c(index, clr_IndianRed, 0.804, 0.36, 0.36)
-      index = set_c(index, clr_Tan, 0.824, 0.705, 0.55)
-      index = set_c(index, clr_LightOliveGreen, 0.6, 0.8, 0.6)
-      index = set_c(index, clr_CadetBlue, 0.372, 0.62, 0.628)
-      index = set_c(index, clr_Beige, 0.96, 0.96, 0.864)
+      index = set_index_to_rgb(index, clr_Black, 0.0, 0.0, 0.0)
+      index = set_index_to_rgb(index, clr_Blue, 0.0, 0.0, 1.0)
+      index = set_index_to_rgb(index, clr_BrightBlue, 0.0, 0.4, 1.0)
+      index = set_index_to_rgb(index, clr_LightSkyBlue, 0.53, 0.808, 0.98)
+      index = set_index_to_rgb(index, clr_LightSkyGreen, 0.125, 0.698, 0.668)
+      index = set_index_to_rgb(index, clr_MediumSpringGreen, 0.0, 0.98, 0.604)
+      index = set_index_to_rgb(index, clr_Goldenrod, 0.855, 0.648, 0.125)
+      index = set_index_to_rgb(index, clr_Lilac, 0.8, 0.6, 1.0)
+      index = set_index_to_rgb(index, clr_Coral, 1.0, 0.498, 0.312)
+      index = set_index_to_rgb(index, clr_FireBrick, 0.698, 0.132, 0.132)
+      index = set_index_to_rgb(index, clr_RoyalPurple, 0.4, 0.0, 0.6)
+      index = set_index_to_rgb(index, clr_Gold, 1.0, 0.844, 0.0)
+      index = set_index_to_rgb(index, clr_Crimson, 0.8, 0.0, 0.2)
+      index = set_index_to_rgb(index, clr_SlateGray, 0.44, 0.5, 0.565)
+      index = set_index_to_rgb(index, clr_SeaGreen, 0.18, 0.545, 0.34)
+      index = set_index_to_rgb(index, clr_Teal, 0.0, 0.5, 0.5)
+      index = set_index_to_rgb(index, clr_LightSteelBlue, 0.69, 0.77, 0.87)
+      index = set_index_to_rgb(index, clr_MediumSlateBlue, 0.484, 0.408, 0.932)
+      index = set_index_to_rgb(index, clr_MediumBlue, 0.0, 0.0, 0.804)
+      index = set_index_to_rgb(index, clr_RoyalBlue, 0.255, 0.41, 0.884)
+      index = set_index_to_rgb(index, clr_LightGray, 0.828, 0.828, 0.828)
+      index = set_index_to_rgb(index, clr_Silver, 0.752, 0.752, 0.752)
+      index = set_index_to_rgb(index, clr_DarkGray, 0.664, 0.664, 0.664)
+      index = set_index_to_rgb(index, clr_Gray, 0.5, 0.5, 0.5)
+      index = set_index_to_rgb(index, clr_IndianRed, 0.804, 0.36, 0.36)
+      index = set_index_to_rgb(index, clr_Tan, 0.824, 0.705, 0.55)
+      index = set_index_to_rgb(index, clr_LightOliveGreen, 0.6, 0.8, 0.6)
+      index = set_index_to_rgb(index, clr_CadetBlue, 0.372, 0.62, 0.628)
+      index = set_index_to_rgb(index, clr_Beige, 0.96, 0.96, 0.864)
 
       clr_no_mixing = clr_SeaGreen
       clr_convection = clr_LightSkyBlue
@@ -566,31 +566,31 @@ contains
       do i = 1, 101, 2
          !write(*,3) 'colormap clr', i, &
          !   index, colormap(1,i), colormap(2,i), colormap(3,i)
-         index = set_c(index, k, colormap(1, i), colormap(2, i), colormap(3, i))
+         index = set_index_to_rgb(index, k, colormap(1, i), colormap(2, i), colormap(3, i))
       end do
       colormap_last = index - 1
       colormap_size = colormap_last - colormap_offset
 
    contains
 
-      integer function set_c(index, clr_i, r, g, b)
+      integer function set_index_to_rgb(index, clr_i, r, g, b)
          integer :: index, clr_i
          real :: r, g, b
          call pgscr(index, r, g, b)
          clr_i = index
-         set_c = index + 1
-      end function set_c
+         set_index_to_rgb = index + 1
+      end function set_index_to_rgb
 
 
-      integer function setcolour(index, name, ierr)
+      integer function set_index_to_name(index, name, ierr)
          integer :: index
          character (len = *) :: name
          integer, intent(out) :: ierr
          call pgscrn(index, name, ierr)
-         setcolour = index + 1
-      end function setcolour
+         set_index_to_name = index + 1
+      end function set_index_to_name
 
-   end subroutine Set_Colours
+   end subroutine set_device_colors
 
    subroutine read_TRho_data(fname, logTs, logRhos, ierr)
       use utils_lib

--- a/star/private/pgstar_support.f90
+++ b/star/private/pgstar_support.f90
@@ -56,16 +56,10 @@ module pgstar_support
    real, dimension(:), allocatable :: opal_clip_logT, opal_clip_logRho
    real, dimension(:), allocatable :: scvh_clip_logT, scvh_clip_logRho
 
-   integer :: clr_no_mixing, clr_convection, clr_leftover_convection, clr_semiconvection, &
-      clr_thermohaline, clr_overshoot, clr_rotation, clr_minimum, clr_rayleigh_taylor, &
-      clr_anonymous, colormap_offset, colormap_last, colormap_size
-   real :: colormap(3, 101)
-
    ! Tioga line types
    integer, parameter :: Line_Type_Solid = 1
    integer, parameter :: Line_Type_Dash = 2
    integer, parameter :: Line_Type_Dot_Dash = 3
-   integer, parameter :: Line_Type_Dash_Dot = Line_Type_Dot_Dash
    integer, parameter :: Line_Type_Dot = 4
 
 contains
@@ -245,6 +239,7 @@ contains
 
 
    subroutine open_device(s, p, is_file, dev, id, ierr)
+      use pgstar_colors, only: set_device_colors
       type (star_info), pointer :: s
       type (pgstar_win_file_data), pointer :: p
       logical, intent(in) :: is_file
@@ -280,7 +275,7 @@ contains
          p% prev_win_width = p% win_width
          p% prev_win_aspect_ratio = p% win_aspect_ratio
       end if
-      call set_device_colors(white_on_black_flag, ierr)
+      call set_device_colors(white_on_black_flag)
    end subroutine open_device
 
 
@@ -360,237 +355,6 @@ contains
       end if
 
    end subroutine read_support_info
-
-
-   ! remaining routines for setting colours in PGPLOT
-   ! by X11 name
-   subroutine set_device_colors(white_on_black_flag, ierr)
-      logical, intent(in) :: white_on_black_flag
-      integer, intent(out) :: ierr
-      integer :: index, i, k
-
-      include 'formats'
-
-      index = 0
-      ierr = 0
-      if (white_on_black_flag) then
-         index = set_index_to_name(index, "black", ierr)
-         if (ierr /= 0) return
-         index = set_index_to_name(index, "white", ierr)
-         if (ierr /= 0) return
-      else
-         index = set_index_to_name(index, "white", ierr)
-         if (ierr /= 0) return
-         index = set_index_to_name(index, "black", ierr)
-         if (ierr /= 0) return
-      end if
-      index = set_index_to_name(index, "red", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "green", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "blue", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "cyan", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "magenta", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "yellow", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "orange", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "lime green", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "green yellow", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "dodger blue", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "magenta4", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "plum", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "sandy brown", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "salmon", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "grey59", ierr)
-      if (ierr /= 0) return
-      index = set_index_to_name(index, "grey30", ierr)
-      if (ierr /= 0) return
-
-      ! Tioga colors
-      index = set_index_to_rgb(index, clr_Black, 0.0, 0.0, 0.0)
-      index = set_index_to_rgb(index, clr_Blue, 0.0, 0.0, 1.0)
-      index = set_index_to_rgb(index, clr_BrightBlue, 0.0, 0.4, 1.0)
-      index = set_index_to_rgb(index, clr_LightSkyBlue, 0.53, 0.808, 0.98)
-      index = set_index_to_rgb(index, clr_LightSkyGreen, 0.125, 0.698, 0.668)
-      index = set_index_to_rgb(index, clr_MediumSpringGreen, 0.0, 0.98, 0.604)
-      index = set_index_to_rgb(index, clr_Goldenrod, 0.855, 0.648, 0.125)
-      index = set_index_to_rgb(index, clr_Lilac, 0.8, 0.6, 1.0)
-      index = set_index_to_rgb(index, clr_Coral, 1.0, 0.498, 0.312)
-      index = set_index_to_rgb(index, clr_FireBrick, 0.698, 0.132, 0.132)
-      index = set_index_to_rgb(index, clr_RoyalPurple, 0.4, 0.0, 0.6)
-      index = set_index_to_rgb(index, clr_Gold, 1.0, 0.844, 0.0)
-      index = set_index_to_rgb(index, clr_Crimson, 0.8, 0.0, 0.2)
-      index = set_index_to_rgb(index, clr_SlateGray, 0.44, 0.5, 0.565)
-      index = set_index_to_rgb(index, clr_SeaGreen, 0.18, 0.545, 0.34)
-      index = set_index_to_rgb(index, clr_Teal, 0.0, 0.5, 0.5)
-      index = set_index_to_rgb(index, clr_LightSteelBlue, 0.69, 0.77, 0.87)
-      index = set_index_to_rgb(index, clr_MediumSlateBlue, 0.484, 0.408, 0.932)
-      index = set_index_to_rgb(index, clr_MediumBlue, 0.0, 0.0, 0.804)
-      index = set_index_to_rgb(index, clr_RoyalBlue, 0.255, 0.41, 0.884)
-      index = set_index_to_rgb(index, clr_LightGray, 0.828, 0.828, 0.828)
-      index = set_index_to_rgb(index, clr_Silver, 0.752, 0.752, 0.752)
-      index = set_index_to_rgb(index, clr_DarkGray, 0.664, 0.664, 0.664)
-      index = set_index_to_rgb(index, clr_Gray, 0.5, 0.5, 0.5)
-      index = set_index_to_rgb(index, clr_IndianRed, 0.804, 0.36, 0.36)
-      index = set_index_to_rgb(index, clr_Tan, 0.824, 0.705, 0.55)
-      index = set_index_to_rgb(index, clr_LightOliveGreen, 0.6, 0.8, 0.6)
-      index = set_index_to_rgb(index, clr_CadetBlue, 0.372, 0.62, 0.628)
-      index = set_index_to_rgb(index, clr_Beige, 0.96, 0.96, 0.864)
-
-      clr_no_mixing = clr_SeaGreen
-      clr_convection = clr_LightSkyBlue
-      clr_leftover_convection = clr_BrightBlue
-      clr_semiconvection = clr_SlateGray
-      clr_thermohaline = clr_Lilac
-      clr_overshoot = clr_Beige
-      clr_rotation = clr_LightSkyGreen
-      clr_rayleigh_taylor = clr_IndianRed
-      clr_minimum = clr_Coral
-      clr_anonymous = clr_Tan
-
-      colormap(1:3, 1) = [ 0.0, 0.0, 1.0 ]
-      colormap(1:3, 2) = [ 0.0196078431372549, 0.0196078431372549, 1.0 ]
-      colormap(1:3, 3) = [ 0.0352941176470588, 0.0352941176470588, 1.0 ]
-      colormap(1:3, 4) = [ 0.0588235294117647, 0.0588235294117647, 1.0 ]
-      colormap(1:3, 5) = [ 0.0705882352941176, 0.0705882352941176, 1.0 ]
-      colormap(1:3, 6) = [ 0.0941176470588235, 0.0941176470588235, 1.0 ]
-      colormap(1:3, 7) = [ 0.105882352941176, 0.105882352941176, 1.0 ]
-      colormap(1:3, 8) = [ 0.129411764705882, 0.129411764705882, 1.0 ]
-      colormap(1:3, 9) = [ 0.141176470588235, 0.141176470588235, 1.0 ]
-      colormap(1:3, 10) = [ 0.164705882352941, 0.164705882352941, 1.0 ]
-      colormap(1:3, 11) = [ 0.184313725490196, 0.184313725490196, 1.0 ]
-      colormap(1:3, 12) = [ 0.2, 0.2, 1.0 ]
-      colormap(1:3, 13) = [ 0.219607843137255, 0.219607843137255, 1.0 ]
-      colormap(1:3, 14) = [ 0.235294117647059, 0.235294117647059, 1.0 ]
-      colormap(1:3, 15) = [ 0.254901960784314, 0.254901960784314, 1.0 ]
-      colormap(1:3, 16) = [ 0.270588235294118, 0.270588235294118, 1.0 ]
-      colormap(1:3, 17) = [ 0.294117647058824, 0.294117647058824, 1.0 ]
-      colormap(1:3, 18) = [ 0.305882352941176, 0.305882352941176, 1.0 ]
-      colormap(1:3, 19) = [ 0.329411764705882, 0.329411764705882, 1.0 ]
-      colormap(1:3, 20) = [ 0.341176470588235, 0.341176470588235, 1.0 ]
-      colormap(1:3, 21) = [ 0.364705882352941, 0.364705882352941, 1.0 ]
-      colormap(1:3, 22) = [ 0.384313725490196, 0.384313725490196, 1.0 ]
-      colormap(1:3, 23) = [ 0.4, 0.4, 1.0 ]
-      colormap(1:3, 24) = [ 0.419607843137255, 0.419607843137255, 1.0 ]
-      colormap(1:3, 25) = [ 0.435294117647059, 0.435294117647059, 1.0 ]
-      colormap(1:3, 26) = [ 0.454901960784314, 0.454901960784314, 1.0 ]
-      colormap(1:3, 27) = [ 0.470588235294118, 0.470588235294118, 1.0 ]
-      colormap(1:3, 28) = [ 0.490196078431373, 0.490196078431373, 1.0 ]
-      colormap(1:3, 29) = [ 0.505882352941176, 0.505882352941176, 1.0 ]
-      colormap(1:3, 30) = [ 0.529411764705882, 0.529411764705882, 1.0 ]
-      colormap(1:3, 31) = [ 0.549019607843137, 0.549019607843137, 1.0 ]
-      colormap(1:3, 32) = [ 0.564705882352941, 0.564705882352941, 1.0 ]
-      colormap(1:3, 33) = [ 0.584313725490196, 0.584313725490196, 1.0 ]
-      colormap(1:3, 34) = [ 0.6, 0.6, 1.0 ]
-      colormap(1:3, 35) = [ 0.619607843137255, 0.619607843137255, 1.0 ]
-      colormap(1:3, 36) = [ 0.635294117647059, 0.635294117647059, 1.0 ]
-      colormap(1:3, 37) = [ 0.654901960784314, 0.654901960784314, 1.0 ]
-      colormap(1:3, 38) = [ 0.670588235294118, 0.670588235294118, 1.0 ]
-      colormap(1:3, 39) = [ 0.690196078431373, 0.690196078431373, 1.0 ]
-      colormap(1:3, 40) = [ 0.705882352941177, 0.705882352941177, 1.0 ]
-      colormap(1:3, 41) = [ 0.725490196078431, 0.725490196078431, 1.0 ]
-      colormap(1:3, 42) = [ 0.749019607843137, 0.749019607843137, 1.0 ]
-      colormap(1:3, 43) = [ 0.764705882352941, 0.764705882352941, 1.0 ]
-      colormap(1:3, 44) = [ 0.784313725490196, 0.784313725490196, 1.0 ]
-      colormap(1:3, 45) = [ 0.8, 0.8, 1.0 ]
-      colormap(1:3, 46) = [ 0.831372549019608, 0.831372549019608, 1.0 ]
-      colormap(1:3, 47) = [ 0.854901960784314, 0.854901960784314, 1.0 ]
-      colormap(1:3, 48) = [ 0.890196078431372, 0.890196078431372, 1.0 ]
-      colormap(1:3, 49) = [ 0.913725490196078, 0.913725490196078, 1.0 ]
-      colormap(1:3, 50) = [ 0.949019607843137, 0.949019607843137, 1.0 ]
-      colormap(1:3, 51) = [ 1.0, 0.972549019607843, 0.972549019607843 ]
-      colormap(1:3, 52) = [ 1.0, 0.949019607843137, 0.949019607843137 ]
-      colormap(1:3, 53) = [ 1.0, 0.913725490196078, 0.913725490196078 ]
-      colormap(1:3, 54) = [ 1.0, 0.890196078431372, 0.890196078431372 ]
-      colormap(1:3, 55) = [ 1.0, 0.854901960784314, 0.854901960784314 ]
-      colormap(1:3, 56) = [ 1.0, 0.831372549019608, 0.831372549019608 ]
-      colormap(1:3, 57) = [ 1.0, 0.8, 0.8 ]
-      colormap(1:3, 58) = [ 1.0, 0.784313725490196, 0.784313725490196 ]
-      colormap(1:3, 59) = [ 1.0, 0.764705882352941, 0.764705882352941 ]
-      colormap(1:3, 60) = [ 1.0, 0.749019607843137, 0.749019607843137 ]
-      colormap(1:3, 61) = [ 1.0, 0.725490196078431, 0.725490196078431 ]
-      colormap(1:3, 62) = [ 1.0, 0.705882352941177, 0.705882352941177 ]
-      colormap(1:3, 63) = [ 1.0, 0.690196078431373, 0.690196078431373 ]
-      colormap(1:3, 64) = [ 1.0, 0.670588235294118, 0.670588235294118 ]
-      colormap(1:3, 65) = [ 1.0, 0.654901960784314, 0.654901960784314 ]
-      colormap(1:3, 66) = [ 1.0, 0.635294117647059, 0.635294117647059 ]
-      colormap(1:3, 67) = [ 1.0, 0.619607843137255, 0.619607843137255 ]
-      colormap(1:3, 68) = [ 1.0, 0.6, 0.6 ]
-      colormap(1:3, 69) = [ 1.0, 0.584313725490196, 0.584313725490196 ]
-      colormap(1:3, 70) = [ 1.0, 0.564705882352941, 0.564705882352941 ]
-      colormap(1:3, 71) = [ 1.0, 0.541176470588235, 0.541176470588235 ]
-      colormap(1:3, 72) = [ 1.0, 0.529411764705882, 0.529411764705882 ]
-      colormap(1:3, 73) = [ 1.0, 0.505882352941176, 0.505882352941176 ]
-      colormap(1:3, 74) = [ 1.0, 0.490196078431373, 0.490196078431373 ]
-      colormap(1:3, 75) = [ 1.0, 0.470588235294118, 0.470588235294118 ]
-      colormap(1:3, 76) = [ 1.0, 0.454901960784314, 0.454901960784314 ]
-      colormap(1:3, 77) = [ 1.0, 0.435294117647059, 0.435294117647059 ]
-      colormap(1:3, 78) = [ 1.0, 0.419607843137255, 0.419607843137255 ]
-      colormap(1:3, 79) = [ 1.0, 0.4, 0.4 ]
-      colormap(1:3, 80) = [ 1.0, 0.384313725490196, 0.384313725490196 ]
-      colormap(1:3, 81) = [ 1.0, 0.364705882352941, 0.364705882352941 ]
-      colormap(1:3, 82) = [ 1.0, 0.341176470588235, 0.341176470588235 ]
-      colormap(1:3, 83) = [ 1.0, 0.329411764705882, 0.329411764705882 ]
-      colormap(1:3, 84) = [ 1.0, 0.305882352941176, 0.305882352941176 ]
-      colormap(1:3, 85) = [ 1.0, 0.294117647058824, 0.294117647058824 ]
-      colormap(1:3, 86) = [ 1.0, 0.270588235294118, 0.270588235294118 ]
-      colormap(1:3, 87) = [ 1.0, 0.254901960784314, 0.254901960784314 ]
-      colormap(1:3, 88) = [ 1.0, 0.235294117647059, 0.235294117647059 ]
-      colormap(1:3, 89) = [ 1.0, 0.219607843137255, 0.219607843137255 ]
-      colormap(1:3, 90) = [ 1.0, 0.2, 0.2 ]
-      colormap(1:3, 91) = [ 1.0, 0.176470588235294, 0.176470588235294 ]
-      colormap(1:3, 92) = [ 1.0, 0.164705882352941, 0.164705882352941 ]
-      colormap(1:3, 93) = [ 1.0, 0.141176470588235, 0.141176470588235 ]
-      colormap(1:3, 94) = [ 1.0, 0.129411764705882, 0.129411764705882 ]
-      colormap(1:3, 95) = [ 1.0, 0.105882352941176, 0.105882352941176 ]
-      colormap(1:3, 96) = [ 1.0, 0.0941176470588235, 0.0941176470588235 ]
-      colormap(1:3, 97) = [ 1.0, 0.0705882352941176, 0.0705882352941176 ]
-      colormap(1:3, 98) = [ 1.0, 0.0588235294117647, 0.0588235294117647 ]
-      colormap(1:3, 99) = [ 1.0, 0.0352941176470588, 0.0352941176470588 ]
-      colormap(1:3, 100) = [ 1.0, 0.0196078431372549, 0.0196078431372549 ]
-      colormap(1:3, 101) = [ 1.0, 0.0, 0.0 ]
-
-      colormap_offset = index - 1
-      !write(*,2) 'colormap_offset', colormap_offset
-      do i = 1, 101, 2
-         !write(*,3) 'colormap clr', i, &
-         !   index, colormap(1,i), colormap(2,i), colormap(3,i)
-         index = set_index_to_rgb(index, k, colormap(1, i), colormap(2, i), colormap(3, i))
-      end do
-      colormap_last = index - 1
-      colormap_size = colormap_last - colormap_offset
-
-   contains
-
-      integer function set_index_to_rgb(index, clr_i, r, g, b)
-         integer :: index, clr_i
-         real :: r, g, b
-         call pgscr(index, r, g, b)
-         clr_i = index
-         set_index_to_rgb = index + 1
-      end function set_index_to_rgb
-
-
-      integer function set_index_to_name(index, name, ierr)
-         integer :: index
-         character (len = *) :: name
-         integer, intent(out) :: ierr
-         call pgscrn(index, name, ierr)
-         set_index_to_name = index + 1
-      end function set_index_to_name
-
-   end subroutine set_device_colors
 
    subroutine read_TRho_data(fname, logTs, logRhos, ierr)
       use utils_lib
@@ -1305,6 +1069,7 @@ contains
 
 
    subroutine show_no_mixing_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1314,6 +1079,7 @@ contains
 
 
    subroutine show_convective_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1324,6 +1090,7 @@ contains
 
 
    subroutine show_leftover_convective_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1334,6 +1101,7 @@ contains
 
 
    subroutine show_semiconvective_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1344,6 +1112,7 @@ contains
 
 
    subroutine show_thermohaline_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1354,6 +1123,7 @@ contains
 
 
    subroutine show_rotation_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1364,6 +1134,7 @@ contains
 
 
    subroutine show_overshoot_section(s, ybot, grid_min, grid_max, xvec)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: ybot
       integer, intent(in) :: grid_min, grid_max
@@ -1412,6 +1183,7 @@ contains
       s, xvec, yvec, txt_scale, xmin, xmax, ymin, ymax, &
       show_legend, legend_coord, legend_disp1, legend_del_disp, legend_fjust, &
       show_mass_pts)
+      use pgstar_colors
       type (star_info), pointer :: s
       real, intent(in) :: xvec(:), yvec(:), txt_scale, xmin, xmax, ymin, ymax, &
          legend_coord, legend_disp1, legend_del_disp, legend_fjust

--- a/star/private/pgstar_tmaxrho.f90
+++ b/star/private/pgstar_tmaxrho.f90
@@ -94,6 +94,7 @@
 
 
       subroutine do_degeneracy_line(id, ierr)
+         use pgstar_colors
          integer, intent(in) :: id
          integer, intent(out) :: ierr
          type (star_info), pointer :: s

--- a/star/private/pgstar_trho.f90
+++ b/star/private/pgstar_trho.f90
@@ -94,6 +94,7 @@
 
 
       subroutine do_degeneracy_line(id, ierr)
+         use pgstar_colors
          integer, intent(in) :: id
          integer, intent(out) :: ierr
          type (star_info), pointer :: s

--- a/star/private/pgstar_trho_profile.f90
+++ b/star/private/pgstar_trho_profile.f90
@@ -117,7 +117,7 @@
          call pgsvp(xleft, xright, ybot, ytop)
          call pgswin(xmin, xmax, ymin, ymax)
          call pgscf(1)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          call show_box_pgstar(s,'BCNST1','BCMNSTV1')
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          if (s% pg% show_TRho_accretion_mesh_borders) then
@@ -283,7 +283,7 @@
             call add_TR_line(1.0, freg_blend_logT2, -8.0, freg_blend_logT2)
             call add_TR_line(1.0, 8.2, -8.0, 8.2)
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call add_TR_line(-8.0, logT_hi, -8.0, logT_max)
             call add_TR_line(-8.0, logT_max, 8.0, logT_max)
             !call add_TR_line(8.0, logT_lo, 8.0, logT_hi)
@@ -300,7 +300,7 @@
             call pgdraw(-8.8,1.88)
 
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_label(-4.9, 2.47, 0.0, 0.5, 'FREEDMAN')
             call show_label(-8.5, 3.3, 0.0, 0.5, 'FERGUSON')
             call show_label(-7.5, 5.1, 0.0, 0.5, 'OPAL/OP')
@@ -310,7 +310,7 @@
             call show_label(0.2, 3.9, 0.0, 1.0, '\(0636)\drad\u = \(0636)\dcond\u')
             call pgsci(clr_Crimson)
             call show_label(3.8, 9.4, 0.0, 0.5, 'e\u-\de\u+\d')
-            call pgsci(1)
+            call pgsci(clr_Foreground)
 
             call show_label(-6.8, 6.9, 0.0, 0.5, 'logR = -8')
             call show_label(5.0, 6.9, 0.0, 0.5, 'logR = 1')
@@ -389,7 +389,7 @@
             call stroke_line(logRho0, logT5, logRho6, logT6)
             call stroke_line(logRho5, logT6, logRho6, logT6)
 
-            call pgsci(1)
+            call pgsci(clr_Foreground)
             call show_label(1.0, 3.2, 0.0, 0.5, 'HELM')
             call show_label(-7.2, 5.8, 0.0, 0.5, 'FreeEOS')
             call show_label(-1.5, 3.7, 0.0, 0.5, 'OPAL/SCVH')
@@ -483,6 +483,7 @@
       subroutine do_show_Profile_text_info( &
             s, txt_scale, xmin, xmax, ymin, ymax, xfac, dxfac, yfac, dyfac, &
             xaxis_reversed, yaxis_reversed)
+         use pgstar_colors, only: clr_Foreground
          type (star_info), pointer :: s
          real, intent(in) :: txt_scale, xmin, xmax, ymin, ymax, xfac, dxfac, yfac, dyfac
          logical, intent(in) :: xaxis_reversed, yaxis_reversed
@@ -495,7 +496,7 @@
 
          call pgsave
          call pgsch(0.7*txt_scale)
-         call pgsci(1)
+         call pgsci(clr_Foreground)
          dxpos = 0
          xpos0 = xmin + xfac*(xmax-xmin)
          dxval = dxfac*(xmax-xmin)

--- a/star/private/pgstar_trho_profile.f90
+++ b/star/private/pgstar_trho_profile.f90
@@ -62,6 +62,7 @@
       subroutine do_TRho_Profile_plot(s, id, device_id, &
             xleft, xright, ybot, ytop, subplot, title, txt_scale_in, ierr)
          use utils_lib
+         use pgstar_colors
 
          type (star_info), pointer :: s
          integer, intent(in) :: id, device_id

--- a/star/test_suite/custom_colors/src/run_star_extras.f90
+++ b/star/test_suite/custom_colors/src/run_star_extras.f90
@@ -65,6 +65,7 @@
 
 #ifdef USE_PGPLOT
       subroutine col_mag1_decorator(id, xmin, xmax, ymin, ymax, plot_num, ierr)
+         use pgstar_colors, only: clr_Coral
          integer, intent(in) :: id
          !Not dp
          real,intent(in) :: xmin, xmax, ymin, ymax

--- a/star_data/public/star_pgstar.f90
+++ b/star_data/public/star_pgstar.f90
@@ -189,38 +189,6 @@ module star_pgstar
    integer, parameter :: max_num_rows_Text_Summary = 20
    integer, parameter :: max_num_cols_Text_Summary = 20
    integer, parameter :: max_num_profile_mass_points = 10
-
-   ! some Tioga colors for pgstar
-   integer :: clr_Black
-   integer :: clr_Blue
-   integer :: clr_BrightBlue
-   integer :: clr_Goldenrod
-   integer :: clr_Lilac
-   integer :: clr_Coral
-   integer :: clr_FireBrick
-   integer :: clr_RoyalPurple
-   integer :: clr_Gold
-   integer :: clr_Crimson
-   integer :: clr_SlateGray
-   integer :: clr_Teal
-   integer :: clr_LightSteelBlue
-   integer :: clr_MediumSlateBlue
-   integer :: clr_MediumSpringGreen
-   integer :: clr_MediumBlue
-   integer :: clr_RoyalBlue
-   integer :: clr_LightGray
-   integer :: clr_Silver
-   integer :: clr_DarkGray
-   integer :: clr_Gray
-   integer :: clr_LightSkyBlue
-   integer :: clr_LightSkyGreen
-   integer :: clr_SeaGreen
-   integer :: clr_Tan
-   integer :: clr_IndianRed
-   integer :: clr_LightOliveGreen
-   integer :: clr_CadetBlue
-   integer :: clr_Beige
-
    integer, parameter :: max_num_pgstar_trace_history_values = 20
 
    type pgstar_controls


### PR DESCRIPTION
This is refactor of the pgstar colors that partially originates from the build system branch.

The first two commits (those effectively come from the build system branch) are just a cleanup of the color setting code. I replaced some custom code to map color names to rgb values using a file provided by pgplot with an equivalent function in pgplot itself. There was 

The next two commits then get rid of the dynamic mapping of color indices, and just make the list static, since that is what ends up happening in practice anyway. I have also lifted the actual named colors from the pgplot provided rgb.txt.

I would consider the first set of changes more or less of a bug fix, so I would like to see those go in. The second set is a refactor I would do, but not something I would consider necessary.