### PR TITLE
const: fix incorrect comments on real precision kinds

### DIFF
--- a/const/public/const_def.f90
+++ b/const/public/const_def.f90
@@ -30,9 +30,9 @@ module const_def
    public
 
    ! real number precision options: single, double, quad
-   integer, parameter :: sp = selected_real_kind(p=5)
-   integer, parameter :: dp = selected_real_kind(p=15)  ! real32
-   integer, parameter :: qp = selected_real_kind(p=30)  ! real64
+   integer, parameter :: sp = selected_real_kind(p=5)   ! real32
+   integer, parameter :: dp = selected_real_kind(p=15)  ! real64
+   integer, parameter :: qp = selected_real_kind(p=30)  ! real128
 
    ! integer precision options
    integer, parameter :: i1 = selected_int_kind(2)   ! int8


### PR DESCRIPTION
Test program to check

```fortran
program main
   use iso_fortran_env, only: real32, real64, real128
   implicit none
   integer, parameter :: my_real32 = selected_real_kind(p=5)
   integer, parameter :: my_real64 = selected_real_kind(p=15)
   integer, parameter :: my_real128 = selected_real_kind(p=30)

   write (*,*) "p = 5 ", real32, my_real32
   write (*,*) "p = 15", real64, my_real64
   write (*,*) "p = 30", real128, my_real128
end program main
```