### PR TITLE
Restore high_T timestep namelist options

### DIFF
--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -415,7 +415,8 @@
 
 
     ! timestep
-    time_delta_coeff, min_timestep_factor, max_timestep_factor, timestep_factor_for_retries, retry_hold, &
+    time_delta_coeff, min_timestep_factor, max_timestep_factor, max_timestep_factor_at_highT, min_logT_for_max_timestep_factor_at_high_T, &
+    timestep_factor_for_retries, retry_hold, &
     neg_mass_fraction_hold, timestep_dt_factor, use_dt_low_pass_controller, &
     force_timestep_min, force_timestep_min_years, force_timestep_min_factor, force_timestep, force_timestep_years, &
     varcontrol_target, min_allowed_varcontrol_target, varcontrol_dt_limit_ratio_hard_max, xa_scale, &


### PR DESCRIPTION
During #471, when cleaning up the control namelist for deprecated items, I mistakenly removed two timestep options from the namelist. Here I reintroduce them. 
