### PR TITLE
rename pause to pause_flag since pause is a reserved fortran 77 keyword

### DIFF
--- a/astero/test_suite/astero_adipls/inlist_astero_adipls
+++ b/astero/test_suite/astero_adipls/inlist_astero_adipls
@@ -69,7 +69,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/astero_gyre/inlist_astero_gyre
+++ b/astero/test_suite/astero_gyre/inlist_astero_gyre
@@ -69,7 +69,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/example_astero/inlist_example_astero
+++ b/astero/test_suite/example_astero/inlist_example_astero
@@ -83,7 +83,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/fast_from_file/inlist_fast_from_file
+++ b/astero/test_suite/fast_from_file/inlist_fast_from_file
@@ -84,7 +84,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/fast_newuoa/inlist_fast_newuoa
+++ b/astero/test_suite/fast_newuoa/inlist_fast_newuoa
@@ -81,7 +81,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/fast_scan_grid/inlist_fast_scan_grid
+++ b/astero/test_suite/fast_scan_grid/inlist_fast_scan_grid
@@ -79,7 +79,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/fast_simplex/inlist_fast_simplex
+++ b/astero/test_suite/fast_simplex/inlist_fast_simplex
@@ -79,7 +79,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/astero/test_suite/surface_effects/inlist_surface_effects
+++ b/astero/test_suite/surface_effects/inlist_surface_effects
@@ -70,7 +70,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/binary/defaults/pgbinary.defaults
+++ b/binary/defaults/pgbinary.defaults
@@ -26,14 +26,14 @@
    pgbinary_interval = 1
 
 
-      ! pause
-      ! ~~~~~
+      ! pause_flag
+      ! ~~~~~~~~~~
 
       ! if true, then after refresh windows, wait for user to hit RETURN
 
       ! ::
 
-   pause = .false.
+   pause_flag = .false.
 
 
       ! pause_interval

--- a/binary/private/pgbinary_ctrls_io.f90
+++ b/binary/private/pgbinary_ctrls_io.f90
@@ -31,7 +31,7 @@ module pgbinary_ctrls_io
       file_device, &
       file_digits, &
       pgbinary_interval, &
-      pause, &
+      pause_flag, &
       pause_interval, &
       pgbinary_sleep, &
       clear_history, &
@@ -1449,7 +1449,7 @@ contains
       pg% file_device = file_device
       pg% file_digits = file_digits
       pg% pgbinary_interval = pgbinary_interval
-      pg% pause = pause
+      pg% pause = pause_flag
       pg% pause_interval = pause_interval
       pg% pgbinary_sleep = pgbinary_sleep
       pg% clear_history = clear_history

--- a/binary/private/pgbinary_ctrls_io.f90
+++ b/binary/private/pgbinary_ctrls_io.f90
@@ -1449,7 +1449,7 @@ contains
       pg% file_device = file_device
       pg% file_digits = file_digits
       pg% pgbinary_interval = pgbinary_interval
-      pg% pause = pause_flag
+      pg% pause_flag = pause_flag
       pg% pause_interval = pause_interval
       pg% pgbinary_sleep = pgbinary_sleep
       pg% clear_history = clear_history

--- a/binary/private/pgbinary_full.f90
+++ b/binary/private/pgbinary_full.f90
@@ -775,7 +775,7 @@ contains
       if (failed('onScreen_Plots')) return
       call update_pgbinary_history_file(b, ierr)
       if (failed('save_text_data')) return
-      do_pause = b% pg% pause
+      do_pause = b% pg% pause_flag
       if ((.not. do_pause) .and. b% pg% pause_interval > 0) &
       do_pause = (mod(b% model_number, b% pg% pause_interval) == 0)
       if (do_pause) then

--- a/binary/private/pgbinary_stub.f90
+++ b/binary/private/pgbinary_stub.f90
@@ -142,7 +142,7 @@ contains
 
       integer :: i
       integer(i8) :: time0, time1, clock_rate
-      logical :: pause
+      logical :: pause_flag
 
       include 'formats'
 

--- a/binary/public/pgbinary_controls.inc
+++ b/binary/public/pgbinary_controls.inc
@@ -55,7 +55,7 @@ real :: pgbinary_grid_title_scale, &
       pgbinary_right_yaxis_label_disp, &
       pgbinary_num_scale
 
-logical :: pause
+logical :: pause_flag
 integer :: pause_interval
 real :: pgbinary_sleep
 logical :: clear_history

--- a/binary/test_suite/double_bh/inlist_pgstar
+++ b/binary/test_suite/double_bh/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
    pgstar_interval = 10
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_age_disp = 2.5
    pgstar_model_disp = 2.5

--- a/binary/test_suite/evolve_both_stars/inlist_pgbinary
+++ b/binary/test_suite/evolve_both_stars/inlist_pgbinary
@@ -1,5 +1,5 @@
 &pgbinary
-!pause = .true.
+!pause_flag = .true.
 
 pgbinary_age_disp = 1.7
 pgbinary_age_fjust = -0.5

--- a/binary/test_suite/evolve_both_stars/inlist_pgstar
+++ b/binary/test_suite/evolve_both_stars/inlist_pgstar
@@ -1,6 +1,6 @@
 &pgstar
 pgstar_interval = 1
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_age_disp = 2.5
 pgstar_model_disp = 2.5

--- a/binary/test_suite/star_plus_point_mass/inlist_pgbinary
+++ b/binary/test_suite/star_plus_point_mass/inlist_pgbinary
@@ -1,5 +1,5 @@
 &pgbinary
-!pause = .true.
+!pause_flag = .true.
 
 pgbinary_age_disp = 1.7
 pgbinary_age_fjust = -0.5

--- a/binary/test_suite/star_plus_point_mass/inlist_pgstar
+++ b/binary/test_suite/star_plus_point_mass/inlist_pgstar
@@ -1,6 +1,6 @@
 &pgstar
 pgstar_interval = 1
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_age_disp = 2.5
 pgstar_model_disp = 2.5

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,8 @@ Backwards-incompatible changes
 
 Removed `file_extension` option because it is redundant with `file_device`. Delete `file_extension` from your inlists.
 
+Renamed pgstar `pause` option to `pause_flag` because pause is a reserved Fortran 77 keyword.
+
 .. _New Features main:
 
 New Features

--- a/docs/source/developing/debugging.rst
+++ b/docs/source/developing/debugging.rst
@@ -26,7 +26,7 @@ The MESA SDK contains the GNU debugger `gdb <https://www.gnu.org/software/gdb/>`
 Using pgstar
 ~~~~~~~~~~~~
 
-The built in pgstar plotting is itself an invaluable a debugging tool.  Something may jump out from a plot as strange behavior before it shows up as a problem in the run.  You may notice that an issue begins when the model reaches certain conditions and that can provide a useful guide to the problem.  After you identify an issue and configure some useful plots, consider setting ``pgstar_interval = 1`` and ``pause = .true.`` so that you can step through the model timestep-by-timestep.
+The built in pgstar plotting is itself an invaluable a debugging tool.  Something may jump out from a plot as strange behavior before it shows up as a problem in the run.  You may notice that an issue begins when the model reaches certain conditions and that can provide a useful guide to the problem.  After you identify an issue and configure some useful plots, consider setting ``pgstar_interval = 1`` and ``pause_flag = .true.`` so that you can step through the model timestep-by-timestep.
 
 Using a profiler
 ~~~~~~~~~~~~~~~~

--- a/star/defaults/pgstar.README
+++ b/star/defaults/pgstar.README
@@ -39,7 +39,7 @@ General Controls
    Changing the win_flag from .true. to .false. removes the window, but because
    of quirks of pgplot and/or x-windows, it will pause and ask you to hit a return.
 
-   you can have the code pause at each step by setting pause = .true.
+   you can have the code pause at each step by setting pause_flag = .true.
    it will pause every nth step if you set pause_interval = n.
 
    you can slow it down by setting pgstar_sleep to the minimum number

--- a/star/defaults/pgstar.defaults
+++ b/star/defaults/pgstar.defaults
@@ -26,14 +26,14 @@
     pgstar_interval = 2
 
 
-      ! pause
-      ! ~~~~~
+      ! pause_flag
+      ! ~~~~~~~~~~
 
       ! if true, then after refresh windows, wait for user to hit RETURN
 
       ! ::
 
-    pause = .false.
+    pause_flag = .false.
 
 
       ! pause_interval

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_pgstar
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_rsp2_Cepheid
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_rsp2_Cepheid
@@ -118,7 +118,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 5
    pgstar_interval = 1
       

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_tdc_Cepheid
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP2_TDC/inlist_tdc_Cepheid
@@ -123,7 +123,7 @@
 
 &pgstar
 
-   pause = .true.
+   pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 1
       

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_pgstar
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp2_Cepheid
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp2_Cepheid
@@ -136,7 +136,7 @@ x_logical_ctrl(1) = .true. ! resynchronize at each step by star2 = star1
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 5
    pgstar_interval = 1
       

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp_Cepheid
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_RSP2/inlist_rsp_Cepheid
@@ -354,7 +354,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 1
 

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_pgstar
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_rsp_Cepheid
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_rsp_Cepheid
@@ -343,7 +343,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 25
 

--- a/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_tdc_Cepheid
+++ b/star/dev_cases_compare_pulses/dev_compare_Cepheid_RSP_TDC/inlist_tdc_Cepheid
@@ -113,7 +113,7 @@
 
 &pgstar
 
-   pause = .true.
+   pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_BLAP/inlist_BLAP
+++ b/star/dev_cases_star_to_RSP2/dev_BLAP/inlist_BLAP
@@ -49,7 +49,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 1 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_convert
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_convert
@@ -181,7 +181,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 5 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_initialize
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_initialize
@@ -164,7 +164,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_pulse
@@ -191,7 +191,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 5 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_near_pulses
@@ -128,7 +128,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_pulse
@@ -148,7 +148,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_zams
+++ b/star/dev_cases_star_to_RSP2/dev_BW_Vul/inlist_to_zams
@@ -54,7 +54,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_convert
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_convert
@@ -192,7 +192,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 5 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_initialize
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_initialize
@@ -168,7 +168,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_pulse
@@ -200,7 +200,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_near_pulses
@@ -129,7 +129,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_pulse
@@ -148,7 +148,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_zams
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid/inlist_to_zams
@@ -54,7 +54,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_initialize
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_initialize
@@ -22,7 +22,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_pulse
@@ -41,7 +41,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remesh
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remesh
@@ -29,7 +29,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1 ! 10
       

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_near_pulses
@@ -29,7 +29,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_6M/inlist_to_pulse
@@ -22,7 +22,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_initialize
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_initialize
@@ -22,7 +22,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1 ! 10
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_pulse
@@ -39,7 +39,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remesh
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remesh
@@ -29,7 +29,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1 ! 10
       

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_near_pulses
@@ -24,7 +24,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Cepheid_9M/inlist_to_pulse
@@ -22,7 +22,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_pulse
@@ -43,7 +43,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_near_pulses
@@ -31,7 +31,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_nearer_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_nearer_pulses
@@ -43,7 +43,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 1 ! 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_pulse
@@ -48,7 +48,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_zams
+++ b/star/dev_cases_star_to_RSP2/dev_Mira/inlist_to_zams
@@ -17,7 +17,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    HR_title = '2 M\d\(2281)\u  Z=0.02  Mira'
 

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_pulse
@@ -42,7 +42,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_near_pulses
@@ -33,7 +33,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_nearer_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_nearer_pulses
@@ -33,7 +33,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 1 ! 25
 

--- a/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_RR_Lyrae/inlist_to_pulse
@@ -32,7 +32,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_pulse
@@ -43,7 +43,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_near_pulses
@@ -24,7 +24,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_RSG/inlist_to_pulse
@@ -22,7 +22,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_pulse
@@ -42,7 +42,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_near_pulses
@@ -38,7 +38,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_nearer_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_nearer_pulses
@@ -33,7 +33,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 1 ! 25
 

--- a/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_Type_II_Cepheid/inlist_to_pulse
@@ -32,7 +32,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_pulse
@@ -43,7 +43,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 50
 

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_remove_core
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_remove_core
@@ -27,7 +27,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 1
       

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_near_pulses
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_near_pulses
@@ -22,7 +22,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_pulse
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_pulse
@@ -36,7 +36,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_zams
+++ b/star/dev_cases_star_to_RSP2/dev_beta_Cepheid/inlist_to_zams
@@ -17,7 +17,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_star_to_RSP2/shared/inlist_to_zams
+++ b/star/dev_cases_star_to_RSP2/shared/inlist_to_zams
@@ -44,7 +44,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/dev_cases_test_RSP2/dev_rsp2_BEP/inlist_rsp2_BEP
+++ b/star/dev_cases_test_RSP2/dev_rsp2_BEP/inlist_rsp2_BEP
@@ -231,7 +231,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 25
 

--- a/star/dev_cases_test_RSP2/dev_rsp2_BLAP/inlist_rsp2_BLAP
+++ b/star/dev_cases_test_RSP2/dev_rsp2_BLAP/inlist_rsp2_BLAP
@@ -234,7 +234,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 25
 

--- a/star/dev_cases_test_RSP2/dev_rsp2_Cepheid/inlist_rsp2_Cepheid
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Cepheid/inlist_rsp2_Cepheid
@@ -246,7 +246,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 5  ! 25
 

--- a/star/dev_cases_test_RSP2/dev_rsp2_Cepheid_6M/inlist_rsp2_Cepheid
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Cepheid_6M/inlist_rsp2_Cepheid
@@ -245,7 +245,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 5  ! 25
 

--- a/star/dev_cases_test_RSP2/dev_rsp2_Delta_Scuti/inlist_rsp2_Delta_Scuti
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Delta_Scuti/inlist_rsp2_Delta_Scuti
@@ -231,7 +231,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 25
 

--- a/star/dev_cases_test_RSP2/dev_rsp2_RR_Lyrae/inlist_rsp2_RR_Lyrae
+++ b/star/dev_cases_test_RSP2/dev_rsp2_RR_Lyrae/inlist_rsp2_RR_Lyrae
@@ -230,7 +230,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 25
 

--- a/star/dev_cases_test_RSP2/dev_rsp2_Type_II_Cepheid/inlist_rsp2_Type_II_Cepheid
+++ b/star/dev_cases_test_RSP2/dev_rsp2_Type_II_Cepheid/inlist_rsp2_Type_II_Cepheid
@@ -240,7 +240,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 100
    pgstar_interval = 25
 

--- a/star/dev_cases_test_TDC/dev_TDC_he_core_flash/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_he_core_flash/inlist_pgstar
@@ -1,6 +1,6 @@
 
 &pgstar
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_test_TDC/dev_TDC_he_core_flash/inlist_to_end_core_he_burn_for_TDC
+++ b/star/dev_cases_test_TDC/dev_TDC_he_core_flash/inlist_to_end_core_he_burn_for_TDC
@@ -208,7 +208,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 10
    pgstar_interval = 1
    

--- a/star/dev_cases_test_TDC/dev_TDC_through_ppisn/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_through_ppisn/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
    pgstar_interval = 1
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_age_disp = 2.5
    pgstar_model_disp = 2.5

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_common
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_common
@@ -214,7 +214,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_pgstar
@@ -1,6 +1,6 @@
 
 &pgstar
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_to_cc
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_12/inlist_to_cc
@@ -182,7 +182,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 10
    pgstar_interval = 1
    

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_common
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_common
@@ -209,7 +209,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_pgstar
@@ -1,6 +1,6 @@
 
 &pgstar
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_to_cc
+++ b/star/dev_cases_test_TDC/dev_TDC_to_cc_80/inlist_to_cc
@@ -184,7 +184,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 10
    pgstar_interval = 1
    

--- a/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_common
+++ b/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_common
@@ -192,7 +192,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_common_converted
+++ b/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_common_converted
@@ -148,7 +148,7 @@
 / ! end of controls namelist
 
 &pgstar
-!pause = .true.
+!pause_flag = .true.
 TRho_logT_max = 10d0
 TRho_logRho_max = 10d0
 

--- a/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_finish
+++ b/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_finish
@@ -148,7 +148,7 @@
 &pgstar
 
 
-!pause = .true.
+!pause_flag = .true.
 
 !Grid1_file_flag = .true.
 Grid1_file_dir = 'png'

--- a/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_to_pisn_200/inlist_pgstar
@@ -1,6 +1,6 @@
 
 &pgstar
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_common
+++ b/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_common
@@ -192,7 +192,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_common_converted
+++ b/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_common_converted
@@ -148,7 +148,7 @@
 / ! end of controls namelist
 
 &pgstar
-!pause = .true.
+!pause_flag = .true.
 TRho_logT_max = 10d0
 TRho_logRho_max = 10d0
 

--- a/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_part1
+++ b/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_part1
@@ -151,7 +151,7 @@
 &pgstar
 
 
-!pause = .true.
+!pause_flag = .true.
 
 !Grid1_file_flag = .true.
 Grid1_file_dir = 'png'

--- a/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_to_ppisn_100/inlist_pgstar
@@ -1,6 +1,6 @@
 
 &pgstar
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_test_TDC/dev_TDC_wd_nova_burst/inlist_pgstar
+++ b/star/dev_cases_test_TDC/dev_TDC_wd_nova_burst/inlist_pgstar
@@ -1,6 +1,6 @@
 
 &pgstar
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_xaxis_label_scale = 1.0
    pgstar_left_yaxis_label_scale = 0.9

--- a/star/dev_cases_test_TDC/dev_TDC_wd_nova_burst/inlist_wd_nova_burst
+++ b/star/dev_cases_test_TDC/dev_TDC_wd_nova_burst/inlist_wd_nova_burst
@@ -252,7 +252,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 10
    pgstar_interval = 1
    

--- a/star/private/pgstar_ctrls_io.f90
+++ b/star/private/pgstar_ctrls_io.f90
@@ -32,7 +32,7 @@
             file_device, &
             file_digits, &
             pgstar_interval, &
-            pause, &
+            pause_flag, &
             pause_interval, &
             pgstar_sleep, &
             clear_history, &
@@ -3145,7 +3145,7 @@
          s% pg% file_device = file_device
          s% pg% file_digits = file_digits
          s% pg% pgstar_interval = pgstar_interval
-         s% pg% pause = pause
+         s% pg% pause_flag = pause_flag
          s% pg% pause_interval = pause_interval
          s% pg% pgstar_sleep = pgstar_sleep
          s% pg% clear_history = clear_history

--- a/star/private/pgstar_full.f90
+++ b/star/private/pgstar_full.f90
@@ -1302,7 +1302,7 @@ contains
       if (s% pg% pause_interval > 0) then
          do_pause = (mod(s% model_number, s% pg% pause_interval) == 0)
       else
-         do_pause = s% pg% pause
+         do_pause = s% pg% pause_flag
       end if
 
       if (do_pause .and. s% pg% pgstar_interval > 0) &

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_common
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_common
@@ -384,7 +384,7 @@
 /
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_pgstar
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_cc
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_cc
@@ -108,7 +108,7 @@ ignore_too_large_correction = .true. ! for conv_vel's
 &pgstar
 !Grid1_file_flag = .true.
 
-!pause = .true.
+!pause_flag = .true.
 
 Profile_Panels3_xaxis_name = 'mass'
 Profile_Panels3_xmin = 0 ! -101d0

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn
@@ -67,7 +67,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0
 Profile_Panels3_xmax = -101d0

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_lgTmax
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_lgTmax
@@ -73,7 +73,7 @@ TRho_logRho_max = 10d0
 TRho_logT_max = 10d0
 
 
-!pause = .true.
+!pause_flag = .true.
 Profile_Panels3_xmin = 0 ! -101d0
 Profile_Panels3_xmax = 5 !
 Profile_Panels3_other_yaxis_name(4) = 'vel_km_per_s'

--- a/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_zams
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/inlist_to_zams
@@ -71,7 +71,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0

--- a/star/test_suite/1M_thermohaline/inlist_1M_thermohaline
+++ b/star/test_suite/1M_thermohaline/inlist_1M_thermohaline
@@ -194,7 +194,7 @@
 &pgstar
          
          
-!pause = .true.
+!pause_flag = .true.
          pgstar_grid_title_scale = 1.2
          pgstar_grid_title_disp = 2
 

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_common
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_common
@@ -390,7 +390,7 @@
 /
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_pgstar
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_cc
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_cc
@@ -109,7 +109,7 @@ ignore_too_large_correction = .true. ! for conv_vel's
 &pgstar
 !Grid1_file_flag = .true.
 
-!pause = .true.
+!pause_flag = .true.
 
 Profile_Panels3_xaxis_name = 'mass'
 Profile_Panels3_xmin = 0 ! -101d0

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_end_core_he_burn
@@ -66,7 +66,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0
 Profile_Panels3_xmax = -101d0

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_lgTmax
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_lgTmax
@@ -75,7 +75,7 @@ TRho_logRho_max = 10d0
 TRho_logT_max = 10d0
 
 
-!pause = .true.
+!pause_flag = .true.
 Profile_Panels3_xmin = 0 ! -101d0
 Profile_Panels3_xmax = 5 ! 
 Profile_Panels3_other_yaxis_name(4) = 'vel_km_per_s'

--- a/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_zams
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/inlist_to_zams
@@ -73,7 +73,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0

--- a/star/test_suite/20M_z2m2_high_rotation/inlist_pgstar
+++ b/star/test_suite/20M_z2m2_high_rotation/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/20M_z2m2_high_rotation/inlist_to_end_core_he_burn
+++ b/star/test_suite/20M_z2m2_high_rotation/inlist_to_end_core_he_burn
@@ -321,7 +321,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/test_suite/adjust_net/inlist_adjust_net
+++ b/star/test_suite/adjust_net/inlist_adjust_net
@@ -91,7 +91,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
          
 Profile_Panels1_xmax = 2.1 ! -101d0 ! only used if /= -101d0
 Abundance_xmax = 2.1 ! -101 ! only used if /= -101d0

--- a/star/test_suite/adjust_net/inlist_massive_defaults
+++ b/star/test_suite/adjust_net/inlist_massive_defaults
@@ -147,7 +147,7 @@
 &pgstar
 
          
-!pause = .true.
+!pause_flag = .true.
       
 
 pgstar_age_disp = 2.5

--- a/star/test_suite/c13_pocket/inlist_pgstar
+++ b/star/test_suite/c13_pocket/inlist_pgstar
@@ -1,6 +1,6 @@
 &pgstar
 
-  pause = .false.
+  pause_flag = .false.
 
   pgstar_interval = 1
 

--- a/star/test_suite/cburn_inward/inlist_cburn_inward
+++ b/star/test_suite/cburn_inward/inlist_cburn_inward
@@ -120,7 +120,7 @@
 
 
 &pgstar      
-   !pause = .true.
+   !pause_flag = .true.
          
    Grid2_win_flag = .true.
 

--- a/star/test_suite/cburn_inward/inlist_initial
+++ b/star/test_suite/cburn_inward/inlist_initial
@@ -114,7 +114,7 @@
 &pgstar
 
          
-!pause = .true.
+!pause_flag = .true.
          
     Grid2_win_flag = .true.
     

--- a/star/test_suite/ccsn_IIp/inlist_common
+++ b/star/test_suite/ccsn_IIp/inlist_common
@@ -122,7 +122,7 @@
 &pgstar
 
          
-!pause = .true.
+!pause_flag = .true.
       
 
 pgstar_age_disp = 2.5

--- a/star/test_suite/ccsn_IIp/inlist_edep
+++ b/star/test_suite/ccsn_IIp/inlist_edep
@@ -123,7 +123,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/ccsn_IIp/inlist_end_infall
+++ b/star/test_suite/ccsn_IIp/inlist_end_infall
@@ -149,7 +149,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/ccsn_IIp/inlist_infall
+++ b/star/test_suite/ccsn_IIp/inlist_infall
@@ -124,7 +124,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/ccsn_IIp/inlist_shock_part1
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part1
@@ -119,7 +119,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/ccsn_IIp/inlist_shock_part2
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part2
@@ -45,7 +45,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 5

--- a/star/test_suite/ccsn_IIp/inlist_shock_part3
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part3
@@ -47,7 +47,7 @@
 
 &pgstar        
          
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 5

--- a/star/test_suite/ccsn_IIp/inlist_shock_part4
+++ b/star/test_suite/ccsn_IIp/inlist_shock_part4
@@ -116,7 +116,7 @@
 
 &pgstar
          
-!pause = .true.
+!pause_flag = .true.
 Grid2_win_flag = .true.
 
 Profile_Panels1_xmin = -101 ! 1.9

--- a/star/test_suite/conductive_flame/inlist_pgstar
+++ b/star/test_suite/conductive_flame/inlist_pgstar
@@ -5,7 +5,7 @@
    file_device = 'png'      ! png
 
    pgstar_interval = 1
-   pause = .false.
+   pause_flag = .false.
 
    Grid1_win_flag = .false.
    Grid1_title = 'TW92 Flame'

--- a/star/test_suite/diffusion_smoothness/inlist_zams
+++ b/star/test_suite/diffusion_smoothness/inlist_zams
@@ -69,7 +69,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_gyre_in_mesa_rsg
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_gyre_in_mesa_rsg
@@ -72,7 +72,7 @@
 &pgstar
 
 
-!pause = .true.
+!pause_flag = .true.
 
       Grid1_win_flag = .true.
          Grid1_win_width = 9

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_near_pulses
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_near_pulses
@@ -43,7 +43,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 25
 

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_pulse
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_pulse
@@ -50,7 +50,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_interval = 1
 

--- a/star/test_suite/gyre_in_mesa_rsg/inlist_to_zams
+++ b/star/test_suite/gyre_in_mesa_rsg/inlist_to_zams
@@ -45,7 +45,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    ! HR window -- lg_L vs. lg_Teff
    

--- a/star/test_suite/high_rot_darkening/inlist_high_rot_darkening
+++ b/star/test_suite/high_rot_darkening/inlist_high_rot_darkening
@@ -149,7 +149,7 @@
 
 &pgstar
    pgstar_interval = 1
-   !pause = .true.
+   !pause_flag = .true.
    
    pgstar_age_disp = 2.5
    pgstar_model_disp = 2.5

--- a/star/test_suite/hse_riemann/inlist_finish
+++ b/star/test_suite/hse_riemann/inlist_finish
@@ -117,7 +117,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
          
          !show_HR_Mira_instability_region = .true.
          HR_logT_min = 4.3
@@ -133,7 +133,7 @@
          HR_target_logT_sigma = 0.01  
 
 
-!pause = .true.
+!pause_flag = .true.
 
       Grid1_win_flag = .true.
          Grid1_win_width = 9

--- a/star/test_suite/irradiated_planet/inlist_create
+++ b/star/test_suite/irradiated_planet/inlist_create
@@ -78,7 +78,7 @@
          
       ! top level controls
 
-         !pause = .true. 
+         !pause_flag = .true. 
             ! if true, the code waits for user to enter a RETURN on the command line
       
 

--- a/star/test_suite/irradiated_planet/inlist_evolve
+++ b/star/test_suite/irradiated_planet/inlist_evolve
@@ -91,7 +91,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/star/test_suite/magnetic_braking/inlist_braking_pgstar
+++ b/star/test_suite/magnetic_braking/inlist_braking_pgstar
@@ -1,5 +1,5 @@
 &pgstar
-      !pause = .true.
+      !pause_flag = .true.
       !pgstar_show_log_age_in_years = .true.
       pgstar_show_age_in_years = .true.
       pgstar_interval = 1

--- a/star/test_suite/magnetic_braking/inlist_zams_pgstar
+++ b/star/test_suite/magnetic_braking/inlist_zams_pgstar
@@ -1,7 +1,7 @@
 &pgstar
 
 
-!pause = .true.
+!pause_flag = .true.
 
 
 pgstar_age_disp = 2.5

--- a/star/test_suite/make_co_wd/inlist_remove_env
+++ b/star/test_suite/make_co_wd/inlist_remove_env
@@ -145,7 +145,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
          show_TRho_Profile_eos_regions = .true.
 

--- a/star/test_suite/make_co_wd/inlist_settle
+++ b/star/test_suite/make_co_wd/inlist_settle
@@ -64,7 +64,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
          show_TRho_Profile_eos_regions = .true.
 

--- a/star/test_suite/make_env/inlist_env
+++ b/star/test_suite/make_env/inlist_env
@@ -82,7 +82,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/star/test_suite/make_env/inlist_env_neutron_star
+++ b/star/test_suite/make_env/inlist_env_neutron_star
@@ -82,7 +82,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_he_wd/inlist_evolve
+++ b/star/test_suite/make_he_wd/inlist_evolve
@@ -74,7 +74,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/star/test_suite/make_he_wd/inlist_remove_envelope
+++ b/star/test_suite/make_he_wd/inlist_remove_envelope
@@ -83,7 +83,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
    !Grid3_win_flag = .true.

--- a/star/test_suite/make_he_wd/inlist_to_he_core
+++ b/star/test_suite/make_he_wd/inlist_to_he_core
@@ -79,7 +79,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_metals/inlist_make_metals
+++ b/star/test_suite/make_metals/inlist_make_metals
@@ -82,7 +82,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_c_burn
+++ b/star/test_suite/make_o_ne_wd/inlist_c_burn
@@ -168,7 +168,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !Profile_Panels3_xmax = 3 !  -101d0 ! only used if /= -101d0
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_o_ne_wd
+++ b/star/test_suite/make_o_ne_wd/inlist_o_ne_wd
@@ -107,7 +107,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
    !Profile_Panels3_xmax = 3 !  -101d0 ! only used if /= -101d0
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_o_ne_wd/inlist_pgstar
+++ b/star/test_suite/make_o_ne_wd/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/make_o_ne_wd/inlist_to_agb
+++ b/star/test_suite/make_o_ne_wd/inlist_to_agb
@@ -76,7 +76,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0
 Profile_Panels3_xmax = -101d0

--- a/star/test_suite/make_planets/inlist_core
+++ b/star/test_suite/make_planets/inlist_core
@@ -83,7 +83,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_planets/inlist_create
+++ b/star/test_suite/make_planets/inlist_create
@@ -81,7 +81,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/make_planets/inlist_evolve
+++ b/star/test_suite/make_planets/inlist_evolve
@@ -77,7 +77,7 @@
 
       ! top level controls
 
-         !pause = .true.
+         !pause_flag = .true.
             ! if true, the code waits for user to enter a RETURN on the command line
 
 

--- a/star/test_suite/make_sdb/inlist_make_sdb
+++ b/star/test_suite/make_sdb/inlist_make_sdb
@@ -88,7 +88,7 @@
 
 &pgstar
 
-         !pause = .true.
+         !pause_flag = .true.
          !Profile_Panels4_win_flag = .true. ! Abundance, Power, Mixing_Ds, and Dynamo
          Profile_Panels4_num_panels = 3
          Profile_Panels4_title = 'Abundance-Power-Mixing'

--- a/star/test_suite/ns_c/inlist_pgstar
+++ b/star/test_suite/ns_c/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/ns_h/inlist_add_he_layer
+++ b/star/test_suite/ns_h/inlist_add_he_layer
@@ -132,7 +132,7 @@ report_solver_progress = .false.
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/ns_h/inlist_to_steady_h_burn
+++ b/star/test_suite/ns_h/inlist_to_steady_h_burn
@@ -124,7 +124,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 Grid2_win_flag = .true.
 pgstar_interval = 1

--- a/star/test_suite/pisn/inlist_common
+++ b/star/test_suite/pisn/inlist_common
@@ -211,7 +211,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/test_suite/pisn/inlist_common_converted
+++ b/star/test_suite/pisn/inlist_common_converted
@@ -141,7 +141,7 @@
 / ! end of controls namelist
 
 &pgstar
-!pause = .true.
+!pause_flag = .true.
 TRho_logT_max = 10d0
 TRho_logRho_max = 10d0
 

--- a/star/test_suite/pisn/inlist_convert
+++ b/star/test_suite/pisn/inlist_convert
@@ -128,7 +128,7 @@
 &pgstar
 
 
-!pause = .true.
+!pause_flag = .true.
 Profile_Panels3_xmin = 0 ! -101d0
 Profile_Panels3_xmax = -101d0
 Profile_Panels3_yaxis_name(5) = 'logR_cm'

--- a/star/test_suite/pisn/inlist_finish
+++ b/star/test_suite/pisn/inlist_finish
@@ -142,7 +142,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       Grid1_file_flag = .true.
       Grid1_file_dir = 'png'

--- a/star/test_suite/pisn/inlist_pgstar
+++ b/star/test_suite/pisn/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 2
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/pisn/inlist_to_end_core_c_burn
+++ b/star/test_suite/pisn/inlist_to_end_core_c_burn
@@ -138,7 +138,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 !pgstar_interval = 1
 
 Profile_Panels3_xmin = 0 ! 2.5 ! -101d0

--- a/star/test_suite/pisn/inlist_to_end_core_he_burn
+++ b/star/test_suite/pisn/inlist_to_end_core_he_burn
@@ -141,7 +141,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0
 Profile_Panels3_xmax = -101d0

--- a/star/test_suite/pisn/inlist_to_zams
+++ b/star/test_suite/pisn/inlist_to_zams
@@ -144,7 +144,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 Grid1_plot_name(3) = 'HR'
 Profile_Panels3_xmin = -101d0

--- a/star/test_suite/ppisn/inlist_pgstar
+++ b/star/test_suite/ppisn/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
    pgstar_interval = 1
-   !pause = .true.
+   !pause_flag = .true.
 
    pgstar_age_disp = 2.5
    pgstar_model_disp = 2.5

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP
@@ -98,7 +98,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP_make_cycle0
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP_make_cycle0
@@ -97,7 +97,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP_std
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP_std
@@ -98,7 +98,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_BEP/inlist_rsp_BEP_test_cycle0
+++ b/star/test_suite/rsp_BEP/inlist_rsp_BEP_test_cycle0
@@ -97,7 +97,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP
@@ -104,7 +104,7 @@ use_Skye = .false.
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 10
          

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_make_cycle0
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_make_cycle0
@@ -101,7 +101,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 10
 

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_std
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_std
@@ -102,7 +102,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 10
 

--- a/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_test_cycle0
+++ b/star/test_suite/rsp_BLAP/inlist_rsp_BLAP_test_cycle0
@@ -100,7 +100,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid
@@ -102,7 +102,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       !pgstar_interval = 20
 

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_make_cycle0
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_make_cycle0
@@ -99,7 +99,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       !pgstar_interval = 20
 

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_std
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_std
@@ -102,7 +102,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       !pgstar_interval = 20
 

--- a/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_test_cycle0
+++ b/star/test_suite/rsp_Cepheid/inlist_rsp_Cepheid_test_cycle0
@@ -98,7 +98,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid
@@ -92,7 +92,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       !pgstar_interval = 20
 

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_make_cycle0
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_make_cycle0
@@ -91,7 +91,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       !pgstar_interval = 20
 

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_std
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_std
@@ -92,7 +92,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       !pgstar_interval = 20
 

--- a/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_test_cycle0
+++ b/star/test_suite/rsp_Cepheid_6M/inlist_rsp_Cepheid_test_cycle0
@@ -90,7 +90,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti
@@ -118,7 +118,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_make_cycle0
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_make_cycle0
@@ -117,7 +117,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_std
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_std
@@ -118,7 +118,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_test_cycle0
+++ b/star/test_suite/rsp_Delta_Scuti/inlist_rsp_Delta_Scuti_test_cycle0
@@ -116,7 +116,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae
@@ -89,7 +89,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_make_cycle0
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_make_cycle0
@@ -88,7 +88,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_std
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_std
@@ -89,7 +89,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_test_cycle0
+++ b/star/test_suite/rsp_RR_Lyrae/inlist_rsp_RR_Lyrae_test_cycle0
@@ -87,7 +87,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid
@@ -115,7 +115,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_make_cycle0
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_make_cycle0
@@ -114,7 +114,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_std
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_std
@@ -115,7 +115,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_test_cycle0
+++ b/star/test_suite/rsp_Type_II_Cepheid/inlist_rsp_Type_II_Cepheid_test_cycle0
@@ -101,7 +101,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 25
 

--- a/star/test_suite/rsp_check_2nd_crossing/inlist_rsp_check_2nd_crossing
+++ b/star/test_suite/rsp_check_2nd_crossing/inlist_rsp_check_2nd_crossing
@@ -132,7 +132,7 @@
 
 
   pgstar_interval = 5
-  pause = .false.
+  pause_flag = .false.
 
   Grid1_win_flag = .true.
 

--- a/star/test_suite/rsp_gyre/inlist_rsp_gyre
+++ b/star/test_suite/rsp_gyre/inlist_rsp_gyre
@@ -102,7 +102,7 @@
 
 &pgstar
 
-    !pause = .true.
+    !pause_flag = .true.
     !pause_interval = 100
     pgstar_interval = 5 ! 10
 

--- a/star/test_suite/rsp_save_and_load_file/inlist_rsp_load_file
+++ b/star/test_suite/rsp_save_and_load_file/inlist_rsp_load_file
@@ -62,7 +62,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
       pause_interval = 10
       pgstar_interval = 6
 

--- a/star/test_suite/rsp_save_and_load_file/inlist_rsp_save_file
+++ b/star/test_suite/rsp_save_and_load_file/inlist_rsp_save_file
@@ -52,7 +52,7 @@
 
 &pgstar
 
-      !pause = .true.
+      !pause_flag = .true.
 
       pgstar_interval = 6
 

--- a/star/test_suite/split_burn_big_net/inlist_big_net
+++ b/star/test_suite/split_burn_big_net/inlist_big_net
@@ -81,7 +81,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 Profile_Panels3_xmin = 0 ! -101d0
 Profile_Panels3_xmax = 2.6 ! -101d0
 

--- a/star/test_suite/split_burn_big_net/inlist_common
+++ b/star/test_suite/split_burn_big_net/inlist_common
@@ -198,7 +198,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/test_suite/split_burn_big_net/inlist_pgstar
+++ b/star/test_suite/split_burn_big_net/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/twin_studies/inlist_pgstar
+++ b/star/test_suite/twin_studies/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/twin_studies/inlist_star1
+++ b/star/test_suite/twin_studies/inlist_star1
@@ -26,7 +26,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 10
    pgstar_interval = 1
 

--- a/star/test_suite/twin_studies/inlist_star2
+++ b/star/test_suite/twin_studies/inlist_star2
@@ -32,7 +32,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    !pause_interval = 10
    pgstar_interval = 1
 

--- a/star/test_suite/twin_studies/inlist_to_end_core_he_burn
+++ b/star/test_suite/twin_studies/inlist_to_end_core_he_burn
@@ -101,7 +101,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    Grid1_plot_name(3) = 'HR'
    Profile_Panels3_xmin = -101d0
    Profile_Panels3_xmax = -101d0

--- a/star/test_suite/wd_acc_small_dm/inlist_wd_acc_small_dm
+++ b/star/test_suite/wd_acc_small_dm/inlist_wd_acc_small_dm
@@ -92,7 +92,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/wd_c_core_ignition/inlist_relax_mass
+++ b/star/test_suite/wd_c_core_ignition/inlist_relax_mass
@@ -108,7 +108,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
          TRho_Profile_win_flag = .true.
          TRho_Profile_xmin = -5.0

--- a/star/test_suite/wd_c_core_ignition/inlist_wd_c_core_ignition
+++ b/star/test_suite/wd_c_core_ignition/inlist_wd_c_core_ignition
@@ -101,7 +101,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
          TRho_Profile_win_flag = .true.
          TRho_Profile_xmin = -5.0

--- a/star/test_suite/wd_he_shell_ignition/inlist_he_shell_ignition
+++ b/star/test_suite/wd_he_shell_ignition/inlist_he_shell_ignition
@@ -141,7 +141,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
    Grid8_win_flag = .true.

--- a/star/test_suite/wd_stable_h_burn/inlist_wd_stable_h_burn
+++ b/star/test_suite/wd_stable_h_burn/inlist_wd_stable_h_burn
@@ -147,7 +147,7 @@
 
    ! top level controls
 
-   !pause = .true.
+   !pause_flag = .true.
    ! if true, the code waits for user to enter a RETURN on the command line
 
 / ! end of pgstar namelist

--- a/star/test_suite/zams_to_cc_80/inlist_common
+++ b/star/test_suite/zams_to_cc_80/inlist_common
@@ -385,7 +385,7 @@
 /
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 !pgstar_interval = 1
 

--- a/star/test_suite/zams_to_cc_80/inlist_pgstar
+++ b/star/test_suite/zams_to_cc_80/inlist_pgstar
@@ -1,7 +1,7 @@
 
 &pgstar
 
-!pause = .true.
+!pause_flag = .true.
 
 pgstar_interval = 1
 pgstar_show_age_in_years = .true.

--- a/star/test_suite/zams_to_cc_80/inlist_to_cc
+++ b/star/test_suite/zams_to_cc_80/inlist_to_cc
@@ -108,7 +108,7 @@ ignore_too_large_correction = .true. ! for conv_vel's
 &pgstar
 !Grid1_file_flag = .true.
 
-!pause = .true.
+!pause_flag = .true.
 
 Profile_Panels3_xaxis_name = 'mass'
 Profile_Panels3_xmin = 0 ! -101d0

--- a/star/test_suite/zams_to_cc_80/inlist_to_end_core_he_burn
+++ b/star/test_suite/zams_to_cc_80/inlist_to_end_core_he_burn
@@ -65,7 +65,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
    Grid1_plot_name(3) = 'HR'
    Profile_Panels3_xmin = -101d0
    Profile_Panels3_xmax = -101d0

--- a/star/test_suite/zams_to_cc_80/inlist_to_lgTmax
+++ b/star/test_suite/zams_to_cc_80/inlist_to_lgTmax
@@ -72,7 +72,7 @@
    TRho_logRho_max = 10d0
    TRho_logT_max = 10d0
 
-   !pause = .true.
+   !pause_flag = .true.
    Profile_Panels3_xmin = 0 ! -101d0
    Profile_Panels3_xmax =-101d0 !
    Profile_Panels3_other_yaxis_name(4) = 'vel_km_per_s'

--- a/star/test_suite/zams_to_cc_80/inlist_to_zams
+++ b/star/test_suite/zams_to_cc_80/inlist_to_zams
@@ -90,7 +90,7 @@
 
 &pgstar
 
-   !pause = .true.
+   !pause_flag = .true.
 
    Grid1_plot_name(3) = 'HR'
    Profile_Panels3_xmin = -101d0

--- a/star_data/private/pgstar_controls.inc
+++ b/star_data/private/pgstar_controls.inc
@@ -63,7 +63,7 @@
          pgstar_right_yaxis_label_disp, &
          pgstar_num_scale
 
-      logical :: pause
+      logical :: pause_flag
       integer :: pause_interval
       real :: pgstar_sleep
       logical :: clear_history


### PR DESCRIPTION
It is best practice to avoid using Fortran reserved keywords for variable names. In best case, it causes poor syntax highlighting in the editor and can confuse some linters. In worst case, it may cause unexpected behavior depending on the compiler and language standard down the road (although things work for us)

So I am renaming `pause` to `pause_flag`. I know it can be a pain when inlist variable names are changed, but I think it is worth it.