### PR TITLE
lower overshoot_D_min

### DIFF
--- a/astero/test_suite/example_astero/inlist_astero_search_controls
+++ b/astero/test_suite/example_astero/inlist_astero_search_controls
@@ -228,28 +228,28 @@
 
       ! parameters
          param_name(1) = 'initial_mass'
-         first_param(1) = 1.2713303424d0
+         first_param(1) = 1.269515d0
          vary_param(1) = .true.
          min_param(1) = 1.24d0
          max_param(1) = 1.32d0
          delta_param(1) = 0.01d0
 
          param_name(2) = 'initial_Y'
-         first_param(2) = 0.2668448980d0
+         first_param(2) = 0.2658184d0
          vary_param(2) = .true.
          min_param(2) = 0.24d0
          max_param(2) = 0.30d0
          delta_param(2) = 0.01d0
 
          param_name(3) = 'initial_FeH'
-         first_param(3) = 0.0725374166d0
+         first_param(3) = 0.1005567d0
          vary_param(3) = .true.
          min_param(3) = 0.0d0
          max_param(3) = 0.17d0
          delta_param(3) = 0.03d0
 
          param_name(4) = 'alpha'
-         first_param(4) = 1.6534734832d0
+         first_param(4) = 1.6928250d0
          vary_param(4) = .true.
          min_param(4) = 1.5d0
          max_param(4) = 1.9d0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,6 +31,9 @@ Renamed pgstar `pause` option to `pause_flag` because pause is a reserved Fortra
 New Features
 ------------
 
+The default ``overshoot_D_min = 1d2`` has been changed to ``overshoot_D_min = 1d-2``. This change primarily affects
+exponential diffusive overshooting routines, improving their convergence properties. See `Buchele et al. (2025) <https://ui.adsabs.harvard.edu/abs/2025RNAAS...9..193B/abstract>`_.
+
 Changed the default for ``use_radiation_corrected_transfer_rate =
 .false.``.
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -2683,7 +2683,7 @@
 
       ! ::
 
-    overshoot_D_min = 1d2
+    overshoot_D_min = 1d-2
 
 
       ! overshoot_brunt_B_max

--- a/star/test_suite/20M_z2m2_high_rotation/inlist_to_end_core_he_burn
+++ b/star/test_suite/20M_z2m2_high_rotation/inlist_to_end_core_he_burn
@@ -129,7 +129,7 @@
       overshoot_f0(1) = 0.005
 
       min_overshoot_q = 0d0
-      overshoot_D_min = 100.0
+      overshoot_D_min = 1d-2
 
       use_other_alpha_mlt = .true. ! implemented in run_star_extras
       x_ctrl(21) = 3.0 ! alpha_H

--- a/star/test_suite/extended_convective_penetration/inlist_extended_convective_penetration
+++ b/star/test_suite/extended_convective_penetration/inlist_extended_convective_penetration
@@ -73,7 +73,7 @@
     overshoot_f(1)  = 0.055
     overshoot_f0(1) = 0.005
     x_ctrl(1) = 0.02
-    overshoot_D_min = 1d0
+    overshoot_D_min = 1d-2
 
 
 ! MESH & TIMESTEPS

--- a/star/test_suite/twin_studies/inlist_to_end_core_he_burn
+++ b/star/test_suite/twin_studies/inlist_to_end_core_he_burn
@@ -75,7 +75,7 @@
       overshoot_f0(3) = 0.005
 
       min_overshoot_q = 0d0
-      overshoot_D_min = 100.0
+      overshoot_D_min = 1d-2
 
 ! timesteps
 


### PR DESCRIPTION
See https://iopscience.iop.org/article/10.3847/2515-5172/adf06d. I am in favor of lowering the default overshoot_D_min if this pr passes testing with no issues.