### PR TITLE
Updating to save b% dt value during binary timestep

### DIFF
--- a/binary/private/binary_timestep.f90
+++ b/binary/private/binary_timestep.f90
@@ -66,6 +66,13 @@
          else
             dt_why_str(Tlim_binary) = binary_dt_why_str(b% dt_why_reason)
          end if
+         if (b% have_to_reduce_timestep_due_to_j) then
+            ! lower timesteps after retries due to large changes in angular momentum
+            dt_min = dt_min * b% dt_reduction_factor_for_j
+
+            b% have_to_reduce_timestep_due_to_j = .false.
+         end if
+
          do l = 1, num_stars
             if (l == 1 .and. b% point_mass_i == 1) then
                i = 2
@@ -83,16 +90,7 @@
             end if
          end do
 
-         if (b% have_to_reduce_timestep_due_to_j) then
-            ! lower timesteps after retries due to large changes in angular momentum
-            if (b% point_mass_i /= 1) then
-               b% s1% dt = b% s1% dt*b% dt_reduction_factor_for_j
-            end if
-            if (b% point_mass_i /= 2) then
-               b% s2% dt = b% s2% dt*b% dt_reduction_factor_for_j
-            end if
-            b% have_to_reduce_timestep_due_to_j = .false.
-         end if
+         b% dt = dt_min ! Set the binary dt to the minimum of the timesteps
 
       end subroutine set_star_timesteps
 


### PR DESCRIPTION
Attempting to resolve the behavior mentioned in #556 (b% dt not set in binary module). Previously, b% dt and b% dt_old remain set to 0, and are simply passed back and forth in private/binary_evolve.f90. Additionally, b% dt was not used to drive the dt's in the relevant star pointers (dt_min is used instead). 

This commit just casts that dt_min over into the binary pointer. It also simplifies the use of dt_reduction_factor_for_j, assuming the dt's for any star in the binary must be the same.