### PR TITLE
introduce switch_donor in adjust_mdots

### DIFF
--- a/binary/private/binary_mdot.f90
+++ b/binary/private/binary_mdot.f90
@@ -1004,6 +1004,7 @@
          q = min(max(q, 0.0667d0), 15d0)
          min_r = 0.0425d0 * b% separation * pow(q + q * q, 0.25d0)
 
+         !TODO: find an appropriate way to define an "equatorial radius" in a binary
          if (dbg) write(*, *) "radius, impact_radius, separation: ", &
              b% r(b% a_i), min_r/rsun, b% separation/rsun
          if (b% r(b% a_i) < min_r) then  ! accretion through disk; inner rim has j = sqrt(GMR)


### PR DESCRIPTION
When doing wind-mass transfer with accretion_j_dot, in the case when the direction of mass transfer changes, the accretor does not have its accreted_material_j set. This makes solve_omega_mix fail as j(k) == 0 for the added cells.

This introduces a check during adjust_mdots to prevent this from happening.
If the current donor ends up accreting while the current accretor ends up losing mass, a donor switch is warranted without adjusting anything related to the implicit MT solver. Likely that value is very low anyway (compared to the wind-mass loss rates).

The todo on the equatorial radius is valid, as a critically rotating star has its eq_radius about 17% larger than its volume equivalent radius, much larger than the inacurracy of the fit used for R_min. However, if the star is appreciably roche filling, the concept of an equatorial radius washes away. The point radius (largest extent on the x-axis connecting the stars) would likely be the best approximation here. I could supply those from my Roche integrations.