### PR TITLE
fix uninitialized variable in atm t_tau

### DIFF
--- a/atm/private/atm_t_tau_varying.f90
+++ b/atm/private/atm_t_tau_varying.f90
@@ -551,8 +551,8 @@ contains
        return
     end if
 
-    if (dlntau <= 0._dp) then
-       write(*,*) 'Invalid dlntau in build_atm_uniform:', dlntau
+    if (dlogtau <= 0._dp) then
+       write(*,*) 'Invalid dlogtau in build_atm_uniform:', dlogtau
        call mesa_error(__FILE__,__LINE__)
     end if
 


### PR DESCRIPTION
The check should be on the value passed into the function, not the converted value which is only computed later.