### PR TITLE
[ci skip] Remove URL

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -128,7 +128,7 @@ Past Developers
 
 * `Ed Brown <http://web.pa.msu.edu/people/ebrown/>`__
 * `Aaron Dotter <https://aarondotter.github.io/>`__
-* `Robert Farmer <http://rjfarmer.io/>`__
+* Robert Farmer
 * `Eoin Farrell <https://scholar.google.es/citations?user=Shv2DncAAAAJ&hl=es>`__
 * `Falk Herwig <http://www.astro.uvic.ca/~fherwig/>`__
 * `Adam Jermyn <http://adamjermyn.com/>`__


### PR DESCRIPTION
Domain name is no longer under my control and should not be linked to from the mesa docs.