### PR TITLE
Update GYRE to 8.1

### DIFF
--- a/gyre/build_and_test
+++ b/gyre/build_and_test
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 rm -rf gyre
-tar xf gyre-8.0.tar.gz
-mv gyre-8.0 gyre
+tar xf gyre-8.1.tar.gz
+mv gyre-8.1 gyre
 
 ../utils/build_and_test

--- a/gyre/build_and_test_parallel
+++ b/gyre/build_and_test_parallel
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 rm -rf gyre
-tar xf gyre-8.0.tar.gz
-mv gyre-8.0 gyre
+tar xf gyre-8.1.tar.gz
+mv gyre-8.1 gyre
 
 ../utils/build_and_test_parallel

--- a/gyre/gyre-8.0.tar.gz
+++ b/gyre/gyre-8.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2396f42671476070767c00dce753ba0ac9998ca00688af51771fe2025e1424f
-size 4807426

--- a/gyre/gyre-8.1.tar.gz
+++ b/gyre/gyre-8.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82f440ed952401c9a308555cc950fb770abc4b62957895ba546964e732d54f5
+size 4807156


### PR DESCRIPTION
Updates GYRE to [v8.1](https://github.com/rhdtownsend/gyre/releases/tag/v8.1), released 11 Sep 2025.

Follows on from previous update to v8.0 in #807.

Tests are [passing](https://testhub.mesastar.org/gyre-8.1/commits/44b1b39), following fixes to `1.4_ms_op_mono` (in da57bc6fc50733418a3c6169677f527e861dec23) and `make_co_wd` (in 10fd9e9f1e6f2e3f5322eb36b65a72237e4d6a88) on `main`.