### PR TITLE
fix conv_vel mesh pruning for removing surface zones

### DIFF
--- a/star/private/mesh_adjust.f90
+++ b/star/private/mesh_adjust.f90
@@ -594,6 +594,7 @@
 
          call prune1(s% lnT, lnT_old, skip)
          call prune1(s% D_mix, D_mix_old, skip)
+         call prune1(s% mlt_vc, mlt_vc_old, skip)
 
          if (s% rotation_flag) then
             call prune1(s% j_rot, j_rot_old, skip)

--- a/star/private/remove_shells.f90
+++ b/star/private/remove_shells.f90
@@ -1108,7 +1108,7 @@
             s, nz, nz_old, prv% xh, prv% xa, &
             prv% j_rot, prv% i_rot, &
             prv% omega, prv% D_omega, prv% am_nu_rot, &
-            prv% conv_vel, prv% lnT, &
+            prv% mlt_vc, prv% lnT, &
             prv% dPdr_dRhodr_info, prv% nu_ST, prv% D_ST, prv% D_DSI, prv% D_SH, &
             prv% D_SSI, prv% D_ES, prv% D_GSF, prv% D_mix, &
             s% xh, s% xa, ierr)


### PR DESCRIPTION
Fixed a nasty little bug hiding in the mesh_pruning for `star_relax_to_cut` and `remove_surface_at_*`, which resulted in `nonzero ierr`'s and segfaults for some test_suite cases, and in preparation to fully resurrect `ppisn` with `TDC`.

This is related to https://github.com/MESAHub/mesa/issues/888, and https://github.com/MESAHub/mesa/issues/880 which still need addressed in the future. 