### PR TITLE
docs: fix indentation in TOC of module documentation

### DIFF
--- a/docs/source/atm/overview.rst
+++ b/docs/source/atm/overview.rst
@@ -13,6 +13,8 @@ Overview of Atmosphere Choices
    fixed-tsurf
    fixed-psurf
    fixed-psurf-tsurf
+   mapping
+   structure
 
 The ``atm_option`` control determines MESA's overall approach to
 evaluating :math:`T_{\rm surf}` and :math:`P_{\rm surf}`, as follows:

--- a/docs/source/auto_diff/example.rst
+++ b/docs/source/auto_diff/example.rst
@@ -3,9 +3,6 @@
 Example of ``auto_diff`` in ``run_star_extras``
 ===============================================
 
-.. toctree::
-   :maxdepth: 1
-
 The ``auto_diff`` module simplifies using ``run_star_extras`` hooks that
 need to provide partial derivatives.
 For example, the ``other_surface_PT`` hook can be used to specify an alternate

--- a/docs/source/auto_diff/overview.rst
+++ b/docs/source/auto_diff/overview.rst
@@ -2,7 +2,11 @@ Overview of ``auto_diff`` module
 ================================
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
+   :hidden:
+
+   example
+   more_detail
 
 The ``auto_diff`` module provides Fortran derived types that support automatic
 differentiation via operator overloading. Users will not generally

--- a/docs/source/colors/overview.rst
+++ b/docs/source/colors/overview.rst
@@ -1,6 +1,13 @@
 Overview of colors module
 =========================
 
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   defaults
+
 The ``colors`` module calculates synthetic photometry during stellar evolution.
 The module computes bolometric and synthetic magnitudes by interpolating stellar atmosphere model grids and convolving with photometric filter transmission curves.
 

--- a/docs/source/eos/overview.rst
+++ b/docs/source/eos/overview.rst
@@ -2,6 +2,13 @@
 Overview of ``eos`` module
 ==========================
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   defaults
+   interface
+
 The equation of state (EOS) is delivered by the ``eos`` module.  The
 MESA EOS combines different input sources in order to cover the wide
 range of conditions encountered during stellar evolution.  The most

--- a/docs/source/kap/overview.rst
+++ b/docs/source/kap/overview.rst
@@ -1,6 +1,13 @@
 Overview of kap module
 ======================
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   defaults
+   interface
+
 The opacity values returned by the ``kap`` module combine opacity
 data from many sources.  The most important opacity-related MESA
 options select which opacity sources to use and control the location

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -47,8 +47,6 @@ subsidiary controls.
 .. toctree::
 
    atm/overview
-   atm/mapping
-   atm/structure
 
 .. _auto_diff:
 
@@ -61,8 +59,6 @@ automatic calculation of analytic derivatives using the chain rule.
 .. toctree::
 
    auto_diff/overview
-   auto_diff/example
-   auto_diff/more_detail
 
 
 .. _chem:
@@ -86,7 +82,6 @@ The ``colors`` module calculates synthetic photometry during stellar evolution.
    :maxdepth: 1
 
    colors/overview
-   colors/defaults
 
 
 .. _const:
@@ -110,9 +105,6 @@ The ``eos`` module provides the equation of state.
    :maxdepth: 1
 
    eos/overview
-   eos/defaults
-   eos/interface
-
 
 .. _kap:
 
@@ -126,8 +118,6 @@ conductive opacities.
    :maxdepth: 1
 
    kap/overview
-   kap/defaults
-   kap/interface
 
 .. _net:
 
@@ -140,7 +130,6 @@ The ``net`` module implements nuclear reaction networks.
    :maxdepth: 1
 
    net/overview
-   net/nets
 
 .. _neu:
 

--- a/docs/source/net/overview.rst
+++ b/docs/source/net/overview.rst
@@ -2,6 +2,12 @@
 Overview of net module
 ======================
 
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   nets
+
 The ``net`` module implements nuclear reaction networks.
 
 

--- a/docs/source/turb/overview.rst
+++ b/docs/source/turb/overview.rst
@@ -2,9 +2,6 @@
 Overview of turb module
 =======================
 
-.. toctree::
-   :maxdepth: 1
-
 The ``turb`` module provides routines for computing properties of turbulence
 under local theories, including ``mlt`` (mixing-length theory), ``tdc`` (time-dependent convection),
 semiconvection, and thermohaline turbulence.


### PR DESCRIPTION
Before and after:

<img width="264" height="945" alt="image" src="https://github.com/user-attachments/assets/4127da06-8369-4a5b-90b1-3b57ba07e869" /> <img width="264" height="945" alt="Image" src="https://github.com/user-attachments/assets/5afeddbb-a2ab-4254-82b8-ef13925ff204" />
