### PR TITLE
utils: mark mesa_error with NORETURN (gcc only)

### DIFF
--- a/utils/public/utils_lib.f90
+++ b/utils/public/utils_lib.f90
@@ -1065,6 +1065,7 @@ contains
 
    subroutine mesa_error(file, line,msg)
       use iso_fortran_env, only: error_unit
+      !GCC$ ATTRIBUTES NORETURN :: mesa_error
       character(len=*), intent(in) :: file
       character(len=*), optional,intent(in) :: msg
       integer, intent(in) :: line


### PR DESCRIPTION
This means that the function will never return to its caller. This makes life easier for the optimizer and can prevent spurious maybe-uninitialized warnings.

This change was triggered by warnings in the mtx module about potentially uninitialized variables after allocation. mesa_error was used to terminate MESA if allocate would fail. Inspection of the intermediate representation of GCC showed that it considered execution to continue after mesa_error, which muddied the control flow blocks. To actually trigger a spurious warning, the variable needs to have rank > 1, be declared with pointer, and have unknown size at compile time. This is quite niche, but future changes to warnings & optimizations might change this. At least adding this attribute may make the generated assembly smaller (this was the case for a simple test function).

ifort does not seem to have a similar attribute.

*Note: this is a retake of #708, now that the latest SDK is required. The change removes ~40 maybe uninitialized variable warnings*