### PR TITLE
math: remove ieee_arithmetic import

### DIFF
--- a/math/public/math_lib_crmath.f90
+++ b/math/public/math_lib_crmath.f90
@@ -27,7 +27,6 @@ module math_lib
   use math_def
 
   use crmath
-  use IEEE_ARITHMETIC
 
   implicit none
 
@@ -130,7 +129,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log_x
 
-    if (.NOT. IEEE_IS_FINITE(x)) then
+    if (is_nan(x) .or. is_inf(x)) then
 
        log_x = -99._dp
 
@@ -148,7 +147,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log10_x
 
-    if (.NOT. IEEE_IS_FINITE(x)) then
+    if (is_nan(x) .or. is_inf(x)) then
 
        log10_x = -99._dp
 

--- a/math/public/math_lib_intrinsic.f90
+++ b/math/public/math_lib_intrinsic.f90
@@ -25,8 +25,6 @@ module math_lib
   use math_pown
   use math_def
 
-  use IEEE_ARITHMETIC
-
   implicit none
 
   character(LEN=16), parameter :: MATH_BACKEND = 'INTRINSIC'
@@ -147,7 +145,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log_x
 
-    if (.NOT. IEEE_IS_FINITE(x)) then
+    if (is_nan(x) .or. is_inf(x)) then
 
        log_x = -99._dp
 
@@ -165,7 +163,7 @@ contains
     real(dp), intent(in) :: x
     real(dp)             :: log10_x
 
-    if (.NOT. IEEE_IS_FINITE(x)) then
+    if (is_nan(x) .or. is_inf(x)) then
 
        log10_x = -99._dp
 


### PR DESCRIPTION
Importing any of the ieee modules has a somewhat unexpected effect. Each procedure that has an ieee module in scope will (1) save the FPU state at the start and (2) restore it at the end, adding any flags that were raised by the procedure. Since the `use ieee_arithmetic` is included in the main math module directly, everything that imports math will be effectively be importing an ieee module. This has a large impact on performance (for example, the `low_z` test case runs in 2/3 the time with this patch).