### PR TITLE
remove module level safe qualifiers across MESA

### DIFF
--- a/astero/private/adipls_support.f90
+++ b/astero/private/adipls_support.f90
@@ -28,18 +28,18 @@
       implicit none
 
       ! args for adipls
-      integer, save :: i_paramset, ierr_param, i_inout, nn
-      real(dp), save, pointer :: x(:) => null()  ! (nn)
-      real(dp), save, pointer :: aa(:,:) => null()  ! (iaa_arg,nn)
-      real(dp), save :: data(8)
+      integer :: i_paramset, ierr_param, i_inout, nn
+      real(dp), pointer :: x(:) => null()  ! (nn)
+      real(dp), pointer :: aa(:,:) => null()  ! (iaa_arg,nn)
+      real(dp) :: data(8)
 
       integer, parameter :: ivarmd = 6, iaa_arg = 10
-      integer, save :: iounit_dev_null = -1
-      integer, save :: nn_redist  ! set from redistrb.c input file
+      integer :: iounit_dev_null = -1
+      integer :: nn_redist  ! set from redistrb.c input file
 
-      real(dp), save, pointer :: x_arg(:) => null(), aa_arg(:,:) => null()
-      integer, save :: nn_arg
-      real(dp), save :: data_arg(8)
+      real(dp), pointer :: x_arg(:) => null(), aa_arg(:,:) => null()
+      integer :: nn_arg
+      real(dp) :: data_arg(8)
 
       logical, parameter :: ADIPLS_IS_ENABLED = .true.
 

--- a/astero/public/astero_def.f90
+++ b/astero/public/astero_def.f90
@@ -67,7 +67,7 @@
 
       end type astero_info
 
-      type (astero_info), save :: astero_other_procs
+      type (astero_info) :: astero_other_procs
 
       logical :: use_other_after_get_chi2 = .false.
       logical :: use_other_adipls_mode_info = .false.
@@ -650,8 +650,7 @@
             data_for_extra_profile_columns
       end type astero_procs
 
-      type (astero_procs), target, save :: star_astero_procs
-         ! gfortran seems to require "save" here.  at least it did once upon a time.
+      type (astero_procs), target :: star_astero_procs
 
       contains
 

--- a/atm/private/atm_utils.f90
+++ b/atm/private/atm_utils.f90
@@ -26,11 +26,11 @@ module atm_utils
 
   integer, parameter :: E2_NPAIRS = 571
 
-  real(dp), target, save  :: E2_x(E2_NPAIRS)
-  real(dp), save          :: E2_pairs(2*E2_NPAIRS)
-  real(dp), target, save  :: E2_f_ary(4*E2_NPAIRS)
-  real(dp), pointer, save :: E2_f1(:), E2_f(:,:)
-  logical, save           :: have_E2_interpolant = .false.
+  real(dp), target  :: E2_x(E2_NPAIRS)
+  real(dp)          :: E2_pairs(2*E2_NPAIRS)
+  real(dp), target  :: E2_f_ary(4*E2_NPAIRS)
+  real(dp), pointer :: E2_f1(:), E2_f(:,:)
+  logical           :: have_E2_interpolant = .false.
 
   private
   public :: init

--- a/atm/public/atm_def.f90
+++ b/atm/public/atm_def.f90
@@ -91,7 +91,7 @@ module atm_def
 
   ! Atmosphere tables
 
-  type (Atm_Info), target, save :: &
+  type (Atm_Info), target :: &
        ai_two_thirds, ai_100, ai_10, ai_1, &
        ai_1m1, ai_wd_25, ai_db_wd_25
 

--- a/binary/public/binary_def.f90
+++ b/binary/public/binary_def.f90
@@ -252,9 +252,7 @@
 
       logical :: have_initialized_binary_handles = .false.
       integer, parameter :: max_binary_handles = 10  ! this can be increased as necessary
-      type (binary_info), target, save :: binary_handles(max_binary_handles)
-         ! gfortran seems to require "save" here.  at least it did once upon a time.
-
+      type (binary_info), target :: binary_handles(max_binary_handles)
 
       contains
 

--- a/kap/private/op_def.f90
+++ b/kap/private/op_def.f90
@@ -61,15 +61,15 @@ module op_def
                                               22.9898, 24.305, 26.9815, 28.086, 32.06, 39.948, &
                                               40.08, 51.996, 54.9380, 55.847, 58.71]
 
-   integer, save :: ite1, ite2, ite3, jne3, ntotp, nc, nf
-   integer, dimension(91), save :: jn1, jn2
-   integer, dimension(17), save :: int
-   real, save :: umin, umax
-   real, dimension(17, 91, 25), save :: epatom, oplnck
-   integer, dimension(17, 91, 25), save :: ne1p, ne2p, np, kp1, kp2, kp3, npp
-   real, dimension(-1:28, 28, 91, 25), save :: fionp
-   real, allocatable, dimension(:), save :: yy2, yx
-   integer, allocatable, dimension(:), save :: nx
+   integer :: ite1, ite2, ite3, jne3, ntotp, nc, nf
+   integer, dimension(91) :: jn1, jn2
+   integer, dimension(17) :: int
+   real :: umin, umax
+   real, dimension(17, 91, 25) :: epatom, oplnck
+   integer, dimension(17, 91, 25) :: ne1p, ne2p, np, kp1, kp2, kp3, npp
+   real, dimension(-1:28, 28, 91, 25) :: fionp
+   real, allocatable, dimension(:) :: yy2, yx
+   integer, allocatable, dimension(:) :: nx
 
    integer, parameter :: op_cache_version = 1
 

--- a/kap/public/kap_lib.f90
+++ b/kap/public/kap_lib.f90
@@ -28,16 +28,16 @@
 
       implicit none
 
-      integer , pointer, public, save :: izz(:),ite(:),jne(:)
-      real(dp), pointer, public, save :: sig(:,:,:)
-      real(dp), pointer, public, save :: epatom(:,:),amamu(:),eumesh(:,:,:)
-      real(dp), pointer, public, save :: lkap_ross_pcg(:)
+      integer , pointer, public :: izz(:),ite(:),jne(:)
+      real(dp), pointer, public :: sig(:,:,:)
+      real(dp), pointer, public :: epatom(:,:),amamu(:),eumesh(:,:,:)
+      real(dp), pointer, public :: lkap_ross_pcg(:)
       integer, public, parameter :: ngp = 2
-      real(dp), public, save :: lgamm_pcg(ngp,17,1648), lkap_face_pcg(ngp,1648), logT_pcg(ngp,1648), logRho_pcg(ngp,1648)
+      real(dp), public :: lgamm_pcg(ngp,17,1648), lkap_face_pcg(ngp,1648), logT_pcg(ngp,1648), logRho_pcg(ngp,1648)
       integer, parameter :: nzm = 3000
-      real(dp), public, save :: fk_old(nzm,17), fk_old_grad(nzm,17)
-      real(dp), public, save ::logT_grid_old(nzm,4,4), logRho_grid_old(nzm,4,4), fk_pcg(17), fk_grad_pcg(ngp,17)
-      real(dp), public, save :: lkap_grid_old(nzm,4,4), logT_cntr_old(nzm), logRho_cntr_old(nzm)
+      real(dp), public :: fk_old(nzm,17), fk_old_grad(nzm,17)
+      real(dp), public ::logT_grid_old(nzm,4,4), logRho_grid_old(nzm,4,4), fk_pcg(17), fk_grad_pcg(ngp,17)
+      real(dp), public :: lkap_grid_old(nzm,4,4), logT_cntr_old(nzm), logRho_cntr_old(nzm)
       logical :: initialize_fk_old = .true.
       contains  ! the procedure interface for the library
       ! client programs should only call these routines.

--- a/math/public/math_lib_crmath.f90
+++ b/math/public/math_lib_crmath.f90
@@ -32,7 +32,7 @@ module math_lib
 
   character(LEN=16), parameter :: MATH_BACKEND = 'CRMATH'
 
-  real(dp), save :: ln10_m
+  real(dp) :: ln10_m
 
   interface safe_sqrt
      module procedure safe_sqrt_

--- a/math/public/math_lib_intrinsic.f90
+++ b/math/public/math_lib_intrinsic.f90
@@ -86,7 +86,7 @@ module math_lib
      module procedure atanpi_
   end interface atanpi
 
-  real(dp), save :: ln10_m
+  real(dp) :: ln10_m
 
   private
 

--- a/star/private/create_initial_model.f90
+++ b/star/private/create_initial_model.f90
@@ -47,7 +47,7 @@
       end type create_star_info
 
       integer, parameter :: max_create_star_handles = 3
-      type (create_star_info), target, save :: &
+      type (create_star_info), target :: &
          create_star_handles(max_create_star_handles)
 
       contains

--- a/star/private/diffusion_procs.f90
+++ b/star/private/diffusion_procs.f90
@@ -34,7 +34,7 @@
       public :: setup_struct_info
 
       integer, parameter :: ngp = 2
-      real(dp), public, save :: fk_gam_old(ngp,17)
+      real(dp), public :: fk_gam_old(ngp,17)
       logical :: initialize_gamma_grid = .true.
 
       contains

--- a/star/private/micro.f90
+++ b/star/private/micro.f90
@@ -36,7 +36,7 @@ module micro
 
   logical, parameter :: dbg = .false.
   logical :: initialize_kap_grid = .true.
-  real(dp), public, save :: fk_pcg_old(17)
+  real(dp), public :: fk_pcg_old(17)
 
 contains
 

--- a/star/test_suite/simplex_solar_calibration/src/simplex_search_data.f90
+++ b/star/test_suite/simplex_solar_calibration/src/simplex_search_data.f90
@@ -461,9 +461,7 @@
          procedure(extras_after_evolve_interface), pointer, nopass :: extras_after_evolve
       end type simplex_procs
 
-      type (simplex_procs), target, save :: star_simplex_procs
-         ! gfortran seems to require "save" here.  at least it did once upon a time.
-
+      type (simplex_procs), target :: star_simplex_procs
 
       contains
 

--- a/star_data/public/star_data_def.f90
+++ b/star_data/public/star_data_def.f90
@@ -107,8 +107,7 @@ module star_data_def
 
    logical :: have_initialized_star_handles = .false.
    integer, parameter :: max_star_handles = 10  ! this can be increased as necessary
-   type(star_info), target, save :: star_handles(max_star_handles)
-   ! gfortran seems to require "save" here.  at least it did once upon a time.
+   type(star_info), target :: star_handles(max_star_handles)
 
 contains
 


### PR DESCRIPTION
See https://github.com/MESAHub/mesa/issues/942, this pr provides the module level variable declarations the "save" attribute across MESA.