### PR TITLE
R25.12.1 colors updated interp optimization

### DIFF
--- a/colors/defaults/colors.defaults
+++ b/colors/defaults/colors.defaults
@@ -1,43 +1,72 @@
 ! ``colors`` module controls
 ! ==========================
 
-   ! The MESA/colors parameters are given default values here.
-
 
 ! Colors User Parameters
 ! ----------------------
 
    ! ``use_colors``
    ! ~~~~~~~~~~~~~~
+   ! Set to .true. to enable bolometric and synthetic photometry output.
+
    ! ``instrument``
    ! ~~~~~~~~~~~~~~
-   ! ``vega_sed``
-   ! ~~~~~~~~~~~~
+   ! Path to the filter instrument directory (structured as facility/instrument).
+   ! The directory must contain an index file named after the instrument and
+   ! one .dat transmission curve per filter. Each filter becomes a history column.
+
    ! ``stellar_atm``
    ! ~~~~~~~~~~~~~~~
+   ! Path to the stellar atmosphere model grid directory.
+   ! Must contain: lookup_table.csv, SED files, and optionally flux_cube.bin.
+
+   ! ``vega_sed``
+   ! ~~~~~~~~~~~~
+   ! Path to the Vega reference SED file. Required when mag_system = 'Vega'.
+   ! Used to compute photometric zero-points for all filters.
+
    ! ``distance``
    ! ~~~~~~~~~~~~
+   ! Distance to the star in cm. Determines whether output magnitudes are
+   ! absolute (default: 10 pc = 3.0857e19 cm) or apparent (set to source distance).
+
    ! ``make_csv``
    ! ~~~~~~~~~~~~
+   ! If .true., exports the full SED as a CSV file at every profile interval.
+   ! Files are written to colors_results_directory.
+
    ! ``colors_results_directory``
    ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ! Directory where CSV outputs (make_csv, sed_per_model) are saved.
+
    ! ``mag_system``
    ! ~~~~~~~~~~~~~~
+   ! Photometric zero-point system. Options: 'Vega', 'AB', 'ST'.
+   !   Vega : zero-point set so Vega has magnitude 0 in all bands.
+   !   AB   : zero-point based on flat f_nu = 3631 Jy.
+   !   ST   : zero-point based on flat f_lambda per unit wavelength.
 
-   ! If ``use_colors`` is true, the colors module is turned on, which will calculate
-   ! bolometric and synthetic magnitudes by interpolating stellar atmosphere model grids and convolving with photometric filter transmission curves.
-   ! Vega SED for Vega photometric system is used for photometric zero points.
-   ! Stellar distance is given in cm.
+   ! ``sed_per_model``
+   ! ~~~~~~~~~~~~~~~~~
+   ! Requires make_csv = .true. If .true., each SED output file is suffixed with
+   ! the model number, preserving the full SED history rather than overwriting.
+   ! WARNING: can produce very large numbers of files. Ensure adequate storage.
+
+
+   ! If ``use_colors`` is true, the colors module computes bolometric and synthetic
+   ! magnitudes by interpolating stellar atmosphere model grids and convolving with
+   ! photometric filter transmission curves. Output is appended to history.data.
    ! ::
 
       use_colors = .false.
-      instrument = '/data/colors_data/filters/Generic/Johnson'
-      stellar_atm = '/data/colors_data/stellar_models/Kurucz2003all/'
-      distance = 3.0857d19
+      instrument = 'data/colors_data/filters/Generic/Johnson'
+      stellar_atm = 'data/colors_data/stellar_models/Kurucz2003all/'
+      vega_sed = 'data/colors_data/stellar_models/vega_flam.csv'
+      distance = 3.0857d19     ! 10 parsecs in cm -> Absolute Magnitudes
       make_csv = .false.
       colors_results_directory = 'SED'
       mag_system = 'Vega'
-      vega_sed = '/data/colors_data/stellar_models/vega_flam.csv'
+      sed_per_model = .false.
 
 
 ! Extra inlist controls
@@ -45,7 +74,6 @@
 
    ! One can split a colors inlist into pieces using the following parameters.
    ! It works recursively, so the extras can read extras too.
-
 
          ! ``read_extra_colors_inlist(1..5)``
          ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/colors/private/bolometric.f90
+++ b/colors/private/bolometric.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2025  Niall Miller & The MESA Team
+!   Copyright (C) 2026  Niall Miller & The MESA Team
 !
 !   This program is free software: you can redistribute it and/or modify
 !   it under the terms of the GNU Lesser General Public License
@@ -19,7 +19,9 @@
 
 module bolometric
 
-   use const_def, only: dp, boltz_sigma
+   use const_def, only: dp
+   use colors_def, only: Colors_General_Info
+   use colors_utils, only: simpson_integration
    use hermite_interp, only: construct_sed_hermite
    use linear_interp, only: construct_sed_linear
    use knn_interp, only: construct_sed_knn
@@ -31,64 +33,81 @@ module bolometric
 
 contains
 
-subroutine calculate_bolometric(teff, log_g, metallicity, R, d, bolometric_magnitude, &
-                                   bolometric_flux, wavelengths, fluxes, sed_filepath, interpolation_radius, &
-                                   lu_file_names, lu_teff, lu_logg, lu_meta)
+   ! rq carries cached lookup table data and the preloaded flux cube (if available)
+   subroutine calculate_bolometric(rq, teff, log_g, metallicity, R, d, bolometric_magnitude, &
+                                   bolometric_flux, wavelengths, fluxes, sed_filepath, interpolation_radius)
+      type(Colors_General_Info), intent(inout) :: rq
       real(dp), intent(in) :: teff, log_g, metallicity, R, d
       character(len=*), intent(in) :: sed_filepath
       real(dp), intent(out) :: bolometric_magnitude, bolometric_flux, interpolation_radius
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
-      character(len=100), intent(in) :: lu_file_names(:)
-      real(dp), intent(in) :: lu_teff(:), lu_logg(:), lu_meta(:)
+
       character(len=32) :: interpolation_method
 
-      interpolation_method = 'Hermite'
+      interpolation_method = 'Hermite'   ! or 'Linear' / 'KNN' later
 
+      ! how far (teff, log_g, metallicity) is from the nearest grid point
       interpolation_radius = compute_interp_radius(teff, log_g, metallicity, &
-                                                   lu_teff, lu_logg, lu_meta)
+                                                   rq%lu_teff, rq%lu_logg, rq%lu_meta)
 
       select case (interpolation_method)
       case ('Hermite', 'hermite', 'HERMITE')
-         call construct_sed_hermite(teff, log_g, metallicity, R, d, lu_file_names, &
-                                    lu_teff, lu_logg, lu_meta, sed_filepath, &
-                                    wavelengths, fluxes)
+         call construct_sed_hermite(rq, teff, log_g, metallicity, R, d, &
+                                    sed_filepath, wavelengths, fluxes)
+
       case ('Linear', 'linear', 'LINEAR')
-         call construct_sed_linear(teff, log_g, metallicity, R, d, lu_file_names, &
-                                   lu_teff, lu_logg, lu_meta, sed_filepath, &
-                                   wavelengths, fluxes)
+         call construct_sed_linear(rq, teff, log_g, metallicity, R, d, &
+                                   sed_filepath, wavelengths, fluxes)
+
       case ('KNN', 'knn', 'Knn')
-         call construct_sed_knn(teff, log_g, metallicity, R, d, lu_file_names, &
-                                lu_teff, lu_logg, lu_meta, sed_filepath, &
-                                wavelengths, fluxes)
+         call construct_sed_knn(rq, teff, log_g, metallicity, R, d, &
+                                sed_filepath, wavelengths, fluxes)
+
       case default
-         call construct_sed_hermite(teff, log_g, metallicity, R, d, lu_file_names, &
-                                    lu_teff, lu_logg, lu_meta, sed_filepath, &
-                                    wavelengths, fluxes)
+         ! fallback: hermite
+         call construct_sed_hermite(rq, teff, log_g, metallicity, R, d, &
+                                    sed_filepath, wavelengths, fluxes)
       end select
 
-      ! bolometric flux is sigma*Teff^4 by definition, diluted by (R/d)^2
-      bolometric_flux = boltz_sigma * teff**4 * (R/d)**2
-      bolometric_magnitude = flux_to_magnitude(bolometric_flux)
-
+      call calculate_bolometric_phot(wavelengths, fluxes, bolometric_magnitude, bolometric_flux)
    end subroutine calculate_bolometric
 
+   subroutine calculate_bolometric_phot(wavelengths, fluxes, bolometric_magnitude, bolometric_flux)
+      real(dp), dimension(:), intent(inout) :: wavelengths, fluxes
+      real(dp), intent(out) :: bolometric_magnitude, bolometric_flux
+      integer :: i
 
-   !****************************
-   ! Convert Flux to Magnitude
-   !****************************
+      ! zero out any invalid flux/wavelength values
+      do i = 1, size(wavelengths) - 1
+         if (wavelengths(i) <= 0.0d0 .or. fluxes(i) < 0.0d0) then
+            fluxes(i) = 0.0d0
+         end if
+      end do
+
+      call simpson_integration(wavelengths, fluxes, bolometric_flux)
+
+      if (bolometric_flux <= 0.0d0) then
+         print *, "Error: Flux integration resulted in non-positive value."
+         bolometric_magnitude = 99.0d0
+         return
+      else if (bolometric_flux < 1.0d-10) then
+         print *, "Warning: Flux value is very small, precision might be affected."
+      end if
+
+      bolometric_magnitude = flux_to_magnitude(bolometric_flux)
+   end subroutine calculate_bolometric_phot
+
    real(dp) function flux_to_magnitude(flux)
       real(dp), intent(in) :: flux
       if (flux <= 0.0d0) then
          print *, "Error: Flux must be positive to calculate magnitude."
          flux_to_magnitude = 99.0d0
       else
-         flux_to_magnitude = -2.5d0 * log10(flux)
+         flux_to_magnitude = -2.5d0*log10(flux)
       end if
    end function flux_to_magnitude
 
-   !--------------------------------------------------------------------
-   ! Scalar metric: distance to nearest grid point in normalized space
-   !--------------------------------------------------------------------
+   ! scalar metric: distance to nearest grid point in normalized space
    real(dp) function compute_interp_radius(teff, log_g, metallicity, &
                                            lu_teff, lu_logg, lu_meta)
 
@@ -105,7 +124,7 @@ subroutine calculate_bolometric(teff, log_g, metallicity, R, d, bolometric_magni
       logical :: use_teff, use_logg, use_meta
       real(dp), parameter :: eps = 1.0d-12
 
-      ! Detect dummy columns (entire axis is 0 or ±999)
+      ! detect dummy columns (entire axis is 0 or ±999)
       use_teff = .not. (all(lu_teff == 0.0d0) .or. &
                         all(lu_teff == 999.0d0) .or. &
                         all(lu_teff == -999.0d0))
@@ -118,29 +137,28 @@ subroutine calculate_bolometric(teff, log_g, metallicity, R, d, bolometric_magni
                         all(lu_meta == 999.0d0) .or. &
                         all(lu_meta == -999.0d0))
 
-      ! Compute min/max for valid axes
       if (use_teff) then
          teff_min = minval(lu_teff)
          teff_max = maxval(lu_teff)
          teff_range = max(teff_max - teff_min, eps)
-         norm_teff = (teff - teff_min) / teff_range
+         norm_teff = (teff - teff_min)/teff_range
       end if
 
       if (use_logg) then
          logg_min = minval(lu_logg)
          logg_max = maxval(lu_logg)
          logg_range = max(logg_max - logg_min, eps)
-         norm_logg = (log_g - logg_min) / logg_range
+         norm_logg = (log_g - logg_min)/logg_range
       end if
 
       if (use_meta) then
          meta_min = minval(lu_meta)
          meta_max = maxval(lu_meta)
          meta_range = max(meta_max - meta_min, eps)
-         norm_meta = (metallicity - meta_min) / meta_range
+         norm_meta = (metallicity - meta_min)/meta_range
       end if
 
-      ! Find minimum distance to any grid point
+      ! find minimum distance to any grid point
       d_min = huge(1.0d0)
       n = size(lu_teff)
 
@@ -148,17 +166,17 @@ subroutine calculate_bolometric(teff, log_g, metallicity, R, d, bolometric_magni
          d = 0.0d0
 
          if (use_teff) then
-            grid_teff = (lu_teff(i) - teff_min) / teff_range
+            grid_teff = (lu_teff(i) - teff_min)/teff_range
             d = d + (norm_teff - grid_teff)**2
          end if
 
          if (use_logg) then
-            grid_logg = (lu_logg(i) - logg_min) / logg_range
+            grid_logg = (lu_logg(i) - logg_min)/logg_range
             d = d + (norm_logg - grid_logg)**2
          end if
 
          if (use_meta) then
-            grid_meta = (lu_meta(i) - meta_min) / meta_range
+            grid_meta = (lu_meta(i) - meta_min)/meta_range
             d = d + (norm_meta - grid_meta)**2
          end if
 

--- a/colors/private/colors_ctrls_io.f90
+++ b/colors/private/colors_ctrls_io.f90
@@ -35,10 +35,11 @@ module colors_ctrls_io
    character(len=256) :: vega_sed
    character(len=256) :: stellar_atm
    character(len=256) :: colors_results_directory
-   character(len=32) :: mag_system
+   character(len=256) :: mag_system
 
    real(dp) :: distance
    logical :: make_csv
+   logical :: sed_per_model
    logical :: use_colors
 
    namelist /colors/ &
@@ -47,6 +48,7 @@ module colors_ctrls_io
       stellar_atm, &
       distance, &
       make_csv, &
+      sed_per_model, &
       mag_system, &
       colors_results_directory, &
       use_colors, &
@@ -55,7 +57,6 @@ module colors_ctrls_io
 
 contains
 
-! read a "namelist" file and set parameters
    subroutine read_namelist(handle, inlist, ierr)
       integer, intent(in) :: handle
       character(len=*), intent(in) :: inlist
@@ -148,7 +149,6 @@ contains
    subroutine store_controls(rq, ierr)
       type(Colors_General_Info), pointer, intent(inout) :: rq
 
-      integer :: i
       integer, intent(out) :: ierr
 
       rq%instrument = instrument
@@ -156,6 +156,7 @@ contains
       rq%stellar_atm = stellar_atm
       rq%distance = distance
       rq%make_csv = make_csv
+      rq%sed_per_model = sed_per_model
       rq%colors_results_directory = colors_results_directory
       rq%use_colors = use_colors
       rq%mag_system = mag_system
@@ -192,6 +193,7 @@ contains
       stellar_atm = rq%stellar_atm
       distance = rq%distance
       make_csv = rq%make_csv
+      sed_per_model = rq%sed_per_model
       colors_results_directory = rq%colors_results_directory
       use_colors = rq%use_colors
       mag_system = rq%mag_system
@@ -211,18 +213,17 @@ contains
 
       ierr = 0
 
-      ! First save current controls
+      ! save current controls
       call set_controls_for_writing(rq)
 
-      ! Write namelist to temporary file
+      ! write namelist to temporary file
       open (newunit=iounit, status='scratch')
       write (iounit, nml=colors)
       rewind (iounit)
 
-      ! Namelists get written in capitals
+      ! namelists get written in capitals
       upper_name = trim(StrUpCase(name))//'='
       val = ''
-      ! Search for name inside namelist
       do
          read (iounit, '(A)', iostat=iostat) str
          ind = index(trim(str), trim(upper_name))
@@ -250,16 +251,14 @@ contains
 
       ierr = 0
 
-      ! First save current colors_controls
+      ! save current controls
       call set_controls_for_writing(rq)
 
       tmp = ''
       tmp = '&colors '//trim(name)//'='//trim(val)//' /'
 
-      ! Load into namelist
       read (tmp, nml=colors)
 
-      ! Add to colors
       call store_controls(rq, ierr)
       if (ierr /= 0) return
 

--- a/colors/private/colors_history.f90
+++ b/colors/private/colors_history.f90
@@ -19,10 +19,10 @@
 
 module colors_history
 
-   use const_def, only: dp, mesa_dir
+   use const_def, only: dp
    use utils_lib, only: mesa_error
    use colors_def, only: Colors_General_Info, get_colors_ptr, num_color_filters, color_filter_names
-   use colors_utils, only: remove_dat
+   use colors_utils, only: remove_dat, resolve_path
    use bolometric, only: calculate_bolometric
    use synthetic, only: calculate_synthetic
 
@@ -39,7 +39,7 @@ contains
       call get_colors_ptr(colors_handle, colors_settings, ierr)
       if (ierr /= 0) then
          write (*, *) 'failed in colors_ptr'
-         num_cols = 0
+         how_many_colors_history_columns = 0
          return
       end if
 
@@ -53,19 +53,21 @@ contains
    end function how_many_colors_history_columns
 
    subroutine data_for_colors_history_columns( &
-      t_eff, log_g, R, metallicity, &
+      t_eff, log_g, R, metallicity, model_number, &
       colors_handle, n, names, vals, ierr)
       real(dp), intent(in) :: t_eff, log_g, R, metallicity
       integer, intent(in) :: colors_handle, n
       character(len=80) :: names(n)
       real(dp) :: vals(n)
       integer, intent(out) :: ierr
+      integer, intent(in) :: model_number
 
       type(Colors_General_Info), pointer :: cs  ! colors_settings
       integer :: i, filter_offset
       real(dp) :: d, bolometric_magnitude, bolometric_flux, interpolation_radius
       real(dp) :: zero_point
-      character(len=256) :: sed_filepath, filter_name
+      character(len=256) :: sed_filepath
+      character(len=80) :: filter_name
       logical :: make_sed
 
       real(dp), dimension(:), allocatable :: wavelengths, fluxes
@@ -90,14 +92,12 @@ contains
       end if
 
       d = cs%distance
-      sed_filepath = trim(mesa_dir)//cs%stellar_atm
+      sed_filepath = trim(resolve_path(cs%stellar_atm))
       make_sed = cs%make_csv
 
-      ! Calculate bolometric magnitude using cached lookup table
-      call calculate_bolometric(t_eff, log_g, metallicity, R, d, &
+      call calculate_bolometric(cs, t_eff, log_g, metallicity, R, d, &
                                 bolometric_magnitude, bolometric_flux, wavelengths, fluxes, &
-                                sed_filepath, interpolation_radius, &
-                                cs%lu_file_names, cs%lu_teff, cs%lu_logg, cs%lu_meta)
+                                sed_filepath, interpolation_radius)
 
       names(1) = "Mag_bol"
       vals(1) = bolometric_magnitude
@@ -113,7 +113,7 @@ contains
             names(i + filter_offset) = filter_name
 
             if (t_eff >= 0 .and. metallicity >= 0) then
-               ! Select precomputed zero-point based on magnitude system
+               ! pick the precomputed zero-point for the requested mag system
                select case (trim(cs%mag_system))
                case ('VEGA', 'Vega', 'vega')
                   zero_point = cs%filters(i)%vega_zero_point
@@ -126,14 +126,15 @@ contains
                   zero_point = -1.0_dp
                end select
 
-               ! Calculate synthetic magnitude using cached filter data and precomputed zero-point
                vals(i + filter_offset) = calculate_synthetic(t_eff, log_g, metallicity, ierr, &
                                                              wavelengths, fluxes, &
                                                              cs%filters(i)%wavelengths, &
                                                              cs%filters(i)%transmission, &
                                                              zero_point, &
                                                              color_filter_names(i), &
-                                                             make_sed, cs%colors_results_directory)
+                                                             make_sed, cs%sed_per_model, &
+                                                             cs%colors_results_directory, model_number)
+
                if (ierr /= 0) vals(i + filter_offset) = -1.0_dp
             else
                vals(i + filter_offset) = -1.0_dp
@@ -145,9 +146,9 @@ contains
          call mesa_error(__FILE__, __LINE__, 'colors: data_for_colors_history_columns array size mismatch')
       end if
 
-      ! Clean up allocated arrays from calculate_bolometric
-      if (allocated(wavelengths)) deallocate(wavelengths)
-      if (allocated(fluxes)) deallocate(fluxes)
+      ! clean up
+      if (allocated(wavelengths)) deallocate (wavelengths)
+      if (allocated(fluxes)) deallocate (fluxes)
 
    end subroutine data_for_colors_history_columns
 

--- a/colors/private/colors_utils.f90
+++ b/colors/private/colors_utils.f90
@@ -19,41 +19,32 @@
 
 module colors_utils
    use const_def, only: dp, strlen, mesa_dir
-   use colors_def, only: Colors_General_Info
+   use colors_def, only: Colors_General_Info, sed_mem_cache_cap
    use utils_lib, only: mesa_error
 
    implicit none
 
-   public :: dilute_flux, trapezoidal_integration, simpson_integration, &
-             load_sed, load_filter, load_vega_sed, &
-             load_lookup_table, remove_dat
+   public :: dilute_flux, trapezoidal_integration, &
+             simpson_integration, load_sed, load_filter, load_vega_sed, &
+             load_lookup_table, remove_dat, load_flux_cube, build_unique_grids, &
+             build_grid_to_lu_map, &
+             find_containing_cell, find_interval, find_nearest_point, &
+             find_bracket_index, load_sed_cached, load_stencil
 contains
 
-   !---------------------------------------------------------------------------
-   ! Apply dilution factor to convert surface flux to observed flux
-   !---------------------------------------------------------------------------
+   ! apply dilution factor (R/d)^2 to convert surface flux to observed flux
    subroutine dilute_flux(surface_flux, R, d, calibrated_flux)
       real(dp), intent(in)  :: surface_flux(:)
       real(dp), intent(in)  :: R, d  ! R = stellar radius, d = distance (both in the same units, e.g., cm)
       real(dp), intent(out) :: calibrated_flux(:)
 
-      ! Check that the output array has the same size as the input
       if (size(calibrated_flux) /= size(surface_flux)) then
          print *, "Error in dilute_flux: Output array must have the same size as input array."
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Apply the dilution factor (R/d)^2 to each element
       calibrated_flux = surface_flux*((R/d)**2)
    end subroutine dilute_flux
-
-   !###########################################################
-   !## MATHS
-   !###########################################################
-
-   !****************************
-   !Trapezoidal and Simpson Integration For Flux Calculation
-   !****************************
 
    subroutine trapezoidal_integration(x, y, result)
       real(dp), dimension(:), intent(in) :: x, y
@@ -65,7 +56,6 @@ contains
       n = size(x)
       sum = 0.0_dp
 
-      ! Validate input sizes
       if (size(x) /= size(y)) then
          print *, "Error: x and y arrays must have the same size."
          call mesa_error(__FILE__, __LINE__)
@@ -76,7 +66,6 @@ contains
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Perform trapezoidal integration
       do i = 1, n - 1
          sum = sum + 0.5_dp*(x(i + 1) - x(i))*(y(i + 1) + y(i))
       end do
@@ -94,7 +83,6 @@ contains
       n = size(x)
       sum = 0.0_dp
 
-      ! Validate input sizes
       if (size(x) /= size(y)) then
          print *, "Error: x and y arrays must have the same size."
          call mesa_error(__FILE__, __LINE__)
@@ -105,24 +93,24 @@ contains
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Perform adaptive Simpson's rule
+      ! adaptive Simpson's rule
       do i = 1, n - 2, 2
-         h1 = x(i + 1) - x(i)       ! Step size for first interval
-         h2 = x(i + 2) - x(i + 1)     ! Step size for second interval
+         h1 = x(i + 1) - x(i)
+         h2 = x(i + 2) - x(i + 1)
 
          f0 = y(i)
          f1 = y(i + 1)
          f2 = y(i + 2)
 
          ! Simpson's rule: (h/3) * (f0 + 4f1 + f2)
-         ! non-uniform Simpson's rule (quadratic fit over three points)
          sum = sum + (h1 + h2)/6.0_dp * ( &
             f0*(2.0_dp*h1 - h2)/h1 + &
             f1*(h1 + h2)**2/(h1*h2) + &
             f2*(2.0_dp*h2 - h1)/h2)
+
       end do
 
-      ! Handle the case where n is odd (last interval)
+      ! handle the last interval if n is even (odd number of points)
       if (MOD(n, 2) == 0) then
          sum = sum + 0.5_dp*(x(n) - x(n - 1))*(y(n) + y(n - 1))
       end if
@@ -130,13 +118,6 @@ contains
       result = sum
    end subroutine simpson_integration
 
-   !-----------------------------------------------------------------------
-   ! File I/O functions
-   !-----------------------------------------------------------------------
-
-   !****************************
-   ! Load Vega SED for Zero Point Calculation
-   !****************************
    subroutine load_vega_sed(filepath, wavelengths, flux)
       character(len=*), intent(in) :: filepath
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, flux
@@ -144,21 +125,18 @@ contains
       integer :: unit, n_rows, status, i
       real(dp) :: temp_wave, temp_flux
 
-      unit = 20
-      open (unit, file=trim(filepath), status='OLD', action='READ', iostat=status)
+      open (newunit=unit, file=trim(filepath), status='OLD', action='READ', iostat=status)
       if (status /= 0) then
          print *, "Error: Could not open Vega SED file ", trim(filepath)
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Skip header line
       read (unit, '(A)', iostat=status) line
       if (status /= 0) then
          print *, "Error: Could not read header from Vega SED file ", trim(filepath)
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Count the number of data lines
       n_rows = 0
       do
          read (unit, '(A)', iostat=status) line
@@ -167,14 +145,14 @@ contains
       end do
 
       rewind (unit)
-      read (unit, '(A)', iostat=status) line  ! Skip header again
+      read (unit, '(A)', iostat=status) line  ! skip header again
 
       allocate (wavelengths(n_rows))
       allocate (flux(n_rows))
 
       i = 0
       do
-         read (unit, *, iostat=status) temp_wave, temp_flux  ! Ignore any extra columns
+         read (unit, *, iostat=status) temp_wave, temp_flux  ! ignore any extra columns
          if (status /= 0) exit
          i = i + 1
          wavelengths(i) = temp_wave
@@ -184,9 +162,6 @@ contains
       close (unit)
    end subroutine load_vega_sed
 
-   !****************************
-   ! Load Filter File
-   !****************************
    subroutine load_filter(directory, filter_wavelengths, filter_trans)
       character(len=*), intent(in) :: directory
       real(dp), dimension(:), allocatable, intent(out) :: filter_wavelengths, filter_trans
@@ -195,22 +170,18 @@ contains
       integer :: unit, n_rows, status, i
       real(dp) :: temp_wavelength, temp_trans
 
-      ! Open the file
-      unit = 20
-      open (unit, file=trim(directory), status='OLD', action='READ', iostat=status)
+      open (newunit=unit, file=trim(directory), status='OLD', action='READ', iostat=status)
       if (status /= 0) then
          print *, "Error: Could not open file ", trim(directory)
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Skip header line
       read (unit, '(A)', iostat=status) line
       if (status /= 0) then
          print *, "Error: Could not read the file", trim(directory)
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Count rows in the file
       n_rows = 0
       do
          read (unit, '(A)', iostat=status) line
@@ -218,11 +189,10 @@ contains
          n_rows = n_rows + 1
       end do
 
-      ! Allocate arrays
       allocate (filter_wavelengths(n_rows))
       allocate (filter_trans(n_rows))
 
-      ! Rewind to the first non-comment line
+      ! rewind to the first non-comment line
       rewind (unit)
       do
          read (unit, '(A)', iostat=status) line
@@ -233,7 +203,6 @@ contains
          if (line(1:1) /= "#") exit
       end do
 
-      ! Read and parse data
       i = 0
       do
          read (unit, *, iostat=status) temp_wavelength, temp_trans
@@ -247,9 +216,7 @@ contains
       close (unit)
    end subroutine load_filter
 
-   !****************************
-   ! Load Lookup Table For Identifying Stellar Atmosphere Models
-   !****************************
+   ! parses a csv lookup table mapping atmosphere grid parameters to SED filenames
    subroutine load_lookup_table(lookup_file, lookup_table, out_file_names, &
                                 out_logg, out_meta, out_teff)
 
@@ -258,21 +225,19 @@ contains
       character(len=100), allocatable, intent(inout) :: out_file_names(:)
       real(dp), allocatable, intent(inout) :: out_logg(:), out_meta(:), out_teff(:)
 
-      integer :: i, n_rows, status, unit
+      integer :: i, n_rows, status, unit, ios
       character(len=512) :: line
       character(len=*), parameter :: delimiter = ","
       character(len=100), allocatable :: columns(:), headers(:)
+      character(len=256) :: token
       integer :: logg_col, meta_col, teff_col
 
-      ! Open the file
-      unit = 10
-      open (unit, file=lookup_file, status='old', action='read', iostat=status)
+      open (newunit=unit, file=lookup_file, status='old', action='read', iostat=status)
       if (status /= 0) then
          print *, "Error: Could not open file", lookup_file
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Read header line
       read (unit, '(A)', iostat=status) line
       if (status /= 0) then
          print *, "Error: Could not read header line"
@@ -281,14 +246,30 @@ contains
 
       call split_line(line, delimiter, headers)
 
-      ! Determine column indices for logg, meta, and teff
+      ! determine column indices -- try all plausible header name variants
       logg_col = get_column_index(headers, "logg")
+      if (logg_col < 0) logg_col = get_column_index(headers, "log_g")
+      if (logg_col < 0) logg_col = get_column_index(headers, "log(g)")
+      if (logg_col < 0) logg_col = get_column_index(headers, "log10g")
+      if (logg_col < 0) logg_col = get_column_index(headers, "log10_g")
+
       teff_col = get_column_index(headers, "teff")
+      if (teff_col < 0) teff_col = get_column_index(headers, "t_eff")
+      if (teff_col < 0) teff_col = get_column_index(headers, "t(eff)")
+      if (teff_col < 0) teff_col = get_column_index(headers, "temperature")
+      if (teff_col < 0) teff_col = get_column_index(headers, "temp")
 
       meta_col = get_column_index(headers, "meta")
-      if (meta_col < 0) then
-         meta_col = get_column_index(headers, "feh")
-      end if
+      if (meta_col < 0) meta_col = get_column_index(headers, "feh")
+      if (meta_col < 0) meta_col = get_column_index(headers, "fe_h")
+      if (meta_col < 0) meta_col = get_column_index(headers, "[fe/h]")
+      if (meta_col < 0) meta_col = get_column_index(headers, "mh")
+      if (meta_col < 0) meta_col = get_column_index(headers, "[m/h]")
+      if (meta_col < 0) meta_col = get_column_index(headers, "m_h")
+      if (meta_col < 0) meta_col = get_column_index(headers, "z")
+      if (meta_col < 0) meta_col = get_column_index(headers, "logz")
+      if (meta_col < 0) meta_col = get_column_index(headers, "metallicity")
+      if (meta_col < 0) meta_col = get_column_index(headers, "metals")
 
       n_rows = 0
       do
@@ -298,14 +279,11 @@ contains
       end do
       rewind (unit)
 
-      ! Skip header
-      read (unit, '(A)', iostat=status) line
+      read (unit, '(A)', iostat=status) line  ! skip header
 
-      ! Allocate output arrays
       allocate (out_file_names(n_rows))
       allocate (out_logg(n_rows), out_meta(n_rows), out_teff(n_rows))
 
-      ! Read and parse the file
       i = 0
       do
          read (unit, '(A)', iostat=status) line
@@ -314,34 +292,40 @@ contains
 
          call split_line(line, delimiter, columns)
 
-         ! Populate arrays
          out_file_names(i) = columns(1)
 
+         ! robust numeric parsing: never crash on bad/missing values
          if (logg_col > 0) then
-            if (columns(logg_col) /= "") then
-               read (columns(logg_col), *) out_logg(i)
+            token = trim(adjustl(columns(logg_col)))
+            if (len_trim(token) == 0 .or. token == '""') then
+               out_logg(i) = -999.0_dp
             else
-               out_logg(i) = -999.0
+               read(token, *, iostat=ios) out_logg(i)
+               if (ios /= 0) out_logg(i) = -999.0_dp
             end if
          else
             out_logg(i) = -999.0
          end if
 
          if (meta_col > 0) then
-            if (columns(meta_col) /= "") then
-               read (columns(meta_col), *) out_meta(i)
+            token = trim(adjustl(columns(meta_col)))
+            if (len_trim(token) == 0 .or. token == '""') then
+               out_meta(i) = 0.0_dp
             else
-               out_meta(i) = 0.0
+               read(token, *, iostat=ios) out_meta(i)
+               if (ios /= 0) out_meta(i) = 0.0_dp
             end if
          else
             out_meta(i) = 0.0
          end if
 
          if (teff_col > 0) then
-            if (columns(teff_col) /= "") then
-               read (columns(teff_col), *) out_teff(i)
+            token = trim(adjustl(columns(teff_col)))
+            if (len_trim(token) == 0 .or. token == '""') then
+               out_teff(i) = 0.0_dp
             else
-               out_teff(i) = 0.0
+               read(token, *, iostat=ios) out_teff(i)
+               if (ios /= 0) out_teff(i) = 0.0_dp
             end if
          else
             out_teff(i) = 0.0
@@ -359,10 +343,10 @@ contains
          character(len=100) :: clean_header, clean_target
 
          index = -1
-         clean_target = trim(adjustl(target))  ! Clean the target string
+         clean_target = trim(adjustl(target))
 
          do i = 1, size(headers)
-            clean_header = trim(adjustl(headers(i)))  ! Clean each header
+            clean_header = trim(adjustl(headers(i)))
             if (clean_header == clean_target) then
                index = i
                exit
@@ -405,16 +389,19 @@ contains
          else
             n = size(tokens)
             allocate (temp(n))
-            temp = tokens  ! Backup the current tokens
-            deallocate (tokens)  ! Deallocate the old array
-            allocate (tokens(n + 1))  ! Allocate with one extra space
-            tokens(1:n) = temp  ! Restore old tokens
-            tokens(n + 1) = token  ! Add the new token
+            temp = tokens
+            deallocate (tokens)
+            allocate (tokens(n + 1))
+            tokens(1:n) = temp
+            tokens(n + 1) = token
             deallocate (temp)  ! unsure if this is till needed.
          end if
       end subroutine append_token
 
    end subroutine load_lookup_table
+
+
+
 
    subroutine load_sed(directory, index, wavelengths, flux)
       character(len=*), intent(in) :: directory
@@ -422,57 +409,46 @@ contains
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, flux
 
       character(len=512) :: line
-      integer :: unit, n_rows, status, i
+      integer :: unit, n_rows, status, i, header_lines
       real(dp) :: temp_wavelength, temp_flux
 
-      ! Open the file
-      unit = 20
-      open (unit, file=trim(directory), status='OLD', action='READ', iostat=status)
+
+      header_lines = 0
+      open (newunit=unit, file=trim(directory), status='OLD', action='READ', iostat=status)
       if (status /= 0) then
          print *, "Error: Could not open file ", trim(directory)
          call mesa_error(__FILE__, __LINE__)
       end if
 
-      ! Skip header lines
       do
          read (unit, '(A)', iostat=status) line
-         if (status /= 0) then
-            print *, "Error: Could not read the file", trim(directory)
-            call mesa_error(__FILE__, __LINE__)
-         end if
+         if (status /= 0) exit
          if (line(1:1) /= "#") exit
+         header_lines = header_lines + 1
       end do
 
-      ! Count rows in the file
-      n_rows = 0
+      ! count data rows (we've already read one; count it)
+      n_rows = 1
       do
          read (unit, '(A)', iostat=status) line
          if (status /= 0) exit
          n_rows = n_rows + 1
       end do
 
-      ! Allocate arrays
       allocate (wavelengths(n_rows))
       allocate (flux(n_rows))
 
-      ! Rewind to the first non-comment line
       rewind (unit)
-      do
+      ! skip exactly header_lines lines
+      do i = 1, header_lines
          read (unit, '(A)', iostat=status) line
-         if (status /= 0) then
-            print *, "Error: Could not rewind file", trim(directory)
-            call mesa_error(__FILE__, __LINE__)
-         end if
-         if (line(1:1) /= "#") exit
       end do
 
-      ! Read and parse data
       i = 0
       do
          read (unit, *, iostat=status) temp_wavelength, temp_flux
          if (status /= 0) exit
          i = i + 1
-         ! Convert f_lambda to f_nu
          wavelengths(i) = temp_wavelength
          flux(i) = temp_flux
       end do
@@ -481,28 +457,20 @@ contains
 
    end subroutine load_sed
 
-   !-----------------------------------------------------------------------
-   ! Helper function for file names
-   !-----------------------------------------------------------------------
-
    function remove_dat(path) result(base)
-      ! Extracts the portion of the string before the first dot
+      ! returns the portion of the string before the first dot
       character(len=*), intent(in) :: path
       character(len=strlen) :: base
       integer :: first_dot
 
-      ! Find the position of the first dot
       first_dot = 0
       do while (first_dot < len_trim(path) .and. path(first_dot + 1:first_dot + 1) /= '.')
          first_dot = first_dot + 1
       end do
 
-      ! Check if a dot was found
       if (first_dot < len_trim(path)) then
-         ! Extract the part before the dot
          base = path(:first_dot)
       else
-         ! No dot found, return the input string
          base = path
       end if
    end function remove_dat
@@ -519,6 +487,42 @@ contains
       name = path(i + 1:)
    end function basename
 
+   function resolve_path(path) result(full_path)
+      use const_def, only: mesa_dir
+      character(len=*), intent(in) :: path
+      character(len=512) :: full_path
+      character(len=:), allocatable :: p
+      logical :: exists
+      integer :: n
+
+      exists = .false.
+      p = trim(adjustl(path))
+      n = len_trim(p)
+
+      if (n >= 2 .and. p(1:2) == './') then
+         full_path = p
+      else if (n >= 3 .and. p(1:3) == '../') then
+         full_path = p
+
+      else if (n >= 1 .and. p(1:1) == '/') then
+         inquire (file=p, exist=exists)
+         if (.not. exists) inquire (file=p//'/.', exist=exists)
+
+         if (exists) then
+            full_path = p
+         else
+            !it might be nice to warn the user that their filepath implies absolute
+            !silently correcting this WILL lead to confusion
+            !warning every step seems a smidge over the top though
+            !write (*, *) trim(p), " not found. Trying ", trim(mesa_dir)//trim(p)
+            full_path = trim(mesa_dir)//trim(p)
+         end if
+
+      else
+         full_path = trim(mesa_dir)//'/'//trim(p)
+      end if
+   end function resolve_path
+
    subroutine read_strings_from_file(colors_settings, strings, n, ierr)
       character(len=512) :: filename
       character(len=100), allocatable, intent(out) :: strings(:)
@@ -529,14 +533,11 @@ contains
 
       ierr = 0
 
-      filename = trim(mesa_dir)//trim(colors_settings%instrument)//"/"// &
+      filename = trim(resolve_path(colors_settings%instrument))//"/"// &
                  trim(basename(colors_settings%instrument))
 
-      !filename = trim(mesa_dir)//trim(colors_settings%instrument)//"/"
-
       n = 0
-      unit = 10
-      open (unit, file=filename, status='old', action='read', iostat=status)
+      open (newunit=unit, file=filename, status='old', action='read', iostat=status)
       if (status /= 0) then
          ierr = -1
          print *, "Error: Could not open file", filename
@@ -557,4 +558,527 @@ contains
       close (unit)
    end subroutine read_strings_from_file
 
+   ! load flux cube from binary file into handle at initialization.
+   ! if the file cannot be opened or the large flux_cube array cannot be
+   ! allocated, sets cube_loaded = .false. so the runtime will fall back to
+   ! loading individual SED files via the lookup table.
+   ! grids and wavelengths are always loaded (small); only the 4-D cube
+   ! allocation is treated as the fallback trigger.
+   subroutine load_flux_cube(rq, stellar_model_dir)
+      type(Colors_General_Info), intent(inout) :: rq
+      character(len=*), intent(in) :: stellar_model_dir
+
+      character(len=512) :: bin_filename
+      integer :: unit, status, n_teff, n_logg, n_meta, n_lambda
+      real(dp) :: cube_mb
+
+      rq%cube_loaded = .false.
+
+      bin_filename = trim(resolve_path(stellar_model_dir))//'/flux_cube.bin'
+
+      open (newunit=unit, file=trim(bin_filename), status='OLD', &
+            access='STREAM', form='UNFORMATTED', iostat=status)
+      if (status /= 0) then
+         ! no binary cube available -- will use individual SED files
+         write (*, '(a)') 'colors: no flux_cube.bin found; using per-file SED loading'
+         return
+      end if
+
+      read (unit, iostat=status) n_teff, n_logg, n_meta, n_lambda
+      if (status /= 0) then
+         close (unit)
+         return
+      end if
+
+      ! attempt the large allocation first -- this is the one that may fail.
+      ! doing it before the small grid allocations avoids partial cleanup.
+      allocate (rq%cube_flux(n_teff, n_logg, n_meta, n_lambda), stat=status)
+      if (status /= 0) then
+         if (allocated(rq%cube_flux)) deallocate (rq%cube_flux)
+         cube_mb = real(n_teff, dp)*n_logg*n_meta*n_lambda*8.0_dp/(1024.0_dp**2)
+         write (*, '(a,f0.1,a)') &
+            'colors: flux cube allocation failed (', cube_mb, &
+            ' MB); falling back to per-file SED loading'
+         close (unit)
+         return
+      end if
+
+      ! grid arrays are small -- always expected to succeed
+      allocate (rq%cube_teff_grid(n_teff), stat=status)
+      if (status /= 0) goto 900
+
+      allocate (rq%cube_logg_grid(n_logg), stat=status)
+      if (status /= 0) goto 900
+
+      allocate (rq%cube_meta_grid(n_meta), stat=status)
+      if (status /= 0) goto 900
+
+      allocate (rq%cube_wavelengths(n_lambda), stat=status)
+      if (status /= 0) goto 900
+
+      read (unit, iostat=status) rq%cube_teff_grid
+      if (status /= 0) goto 900
+
+      read (unit, iostat=status) rq%cube_logg_grid
+      if (status /= 0) goto 900
+
+      read (unit, iostat=status) rq%cube_meta_grid
+      if (status /= 0) goto 900
+
+      read (unit, iostat=status) rq%cube_wavelengths
+      if (status /= 0) goto 900
+
+      read (unit, iostat=status) rq%cube_flux
+      if (status /= 0) goto 900
+
+      close (unit)
+      rq%cube_loaded = .true.
+
+      cube_mb = real(n_teff, dp)*n_logg*n_meta*n_lambda*8.0_dp/(1024.0_dp**2)
+      write (*, '(a,i0,a,i0,a,i0,a,i0,a,f0.1,a)') &
+         'colors: flux cube loaded (', &
+         n_teff, ' x ', n_logg, ' x ', n_meta, ' x ', n_lambda, &
+         ', ', cube_mb, ' MB)'
+      return
+
+      ! error cleanup -- deallocate everything that may have been allocated
+900   continue
+      write (*, '(a)') 'colors: error reading flux_cube.bin; falling back to per-file SED loading'
+      if (allocated(rq%cube_flux)) deallocate (rq%cube_flux)
+      if (allocated(rq%cube_teff_grid)) deallocate (rq%cube_teff_grid)
+      if (allocated(rq%cube_logg_grid)) deallocate (rq%cube_logg_grid)
+      if (allocated(rq%cube_meta_grid)) deallocate (rq%cube_meta_grid)
+      if (allocated(rq%cube_wavelengths)) deallocate (rq%cube_wavelengths)
+      close (unit)
+
+   end subroutine load_flux_cube
+
+   ! build unique sorted grids from lookup table and store on handle.
+   ! called once at init so the fallback interpolation path never rebuilds these.
+   subroutine build_unique_grids(rq)
+      type(Colors_General_Info), intent(inout) :: rq
+      logical :: found
+
+      if (rq%unique_grids_built) return
+      if (.not. rq%lookup_loaded) return
+
+      call extract_unique_sorted(rq%lu_teff, rq%u_teff)
+      call extract_unique_sorted(rq%lu_logg, rq%u_logg)
+      call extract_unique_sorted(rq%lu_meta, rq%u_meta)
+
+      rq%unique_grids_built = .true.
+
+   contains
+
+      subroutine extract_unique_sorted(arr, unique)
+         real(dp), intent(in) :: arr(:)
+         real(dp), allocatable, intent(out) :: unique(:)
+         real(dp), allocatable :: buf(:)
+         integer :: ii, jj, nn, nnu
+         real(dp) :: sw
+
+         nn = size(arr)
+         allocate (buf(nn))
+         nnu = 0
+
+         do ii = 1, nn
+            found = .false.
+            do jj = 1, nnu
+               if (abs(arr(ii) - buf(jj)) < 1.0e-10_dp) then
+                  found = .true.
+                  exit
+               end if
+            end do
+            if (.not. found) then
+               nnu = nnu + 1
+               buf(nnu) = arr(ii)
+            end if
+         end do
+
+         ! insertion sort (grids are small)
+         do ii = 2, nnu
+            sw = buf(ii)
+            jj = ii - 1
+            do while (jj >= 1 .and. buf(jj) > sw)
+               buf(jj + 1) = buf(jj)
+               jj = jj - 1
+            end do
+            buf(jj + 1) = sw
+         end do
+
+         allocate (unique(nnu))
+         unique = buf(1:nnu)
+         deallocate (buf)
+      end subroutine extract_unique_sorted
+
+   end subroutine build_unique_grids
+
+   ! build a 3-D mapping from unique-grid indices to lookup-table rows.
+   ! grid_to_lu(i_t, i_g, i_m) = row in lu_* whose parameters match
+   ! (u_teff(i_t), u_logg(i_g), u_meta(i_m)).
+   ! called once at init; replaces the O(n_lu) nearest-neighbour scan
+   ! that previously ran per corner at runtime.
+   subroutine build_grid_to_lu_map(rq)
+      type(Colors_General_Info), intent(inout) :: rq
+
+      integer :: nt, ng, nm, n_lu
+      integer :: it, ig, im, idx
+      integer :: best_idx
+      real(dp) :: best_dist, dist
+      real(dp), parameter :: tol = 1.0e-10_dp
+
+      if (rq%grid_map_built) return
+      if (.not. rq%unique_grids_built) return
+      if (.not. rq%lookup_loaded) return
+
+      nt = size(rq%u_teff)
+      ng = size(rq%u_logg)
+      nm = size(rq%u_meta)
+      n_lu = size(rq%lu_teff)
+
+      allocate (rq%grid_to_lu(nt, ng, nm))
+      rq%grid_to_lu = 0
+
+      do it = 1, nt
+         do ig = 1, ng
+            do im = 1, nm
+               best_idx = 1
+               best_dist = huge(1.0_dp)
+               do idx = 1, n_lu
+                  dist = abs(rq%lu_teff(idx) - rq%u_teff(it)) + &
+                         abs(rq%lu_logg(idx) - rq%u_logg(ig)) + &
+                         abs(rq%lu_meta(idx) - rq%u_meta(im))
+                  if (dist < best_dist) then
+                     best_dist = dist
+                     best_idx = idx
+                  end if
+                  if (best_dist < tol) exit  ! exact match found
+               end do
+               rq%grid_to_lu(it, ig, im) = best_idx
+            end do
+         end do
+      end do
+
+      rq%grid_map_built = .true.
+
+   end subroutine build_grid_to_lu_map
+
+   subroutine find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                   i_x, i_y, i_z, t_x, t_y, t_z)
+      real(dp), intent(in) :: x_val, y_val, z_val
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
+      integer, intent(out) :: i_x, i_y, i_z
+      real(dp), intent(out) :: t_x, t_y, t_z
+
+      call find_interval(x_grid, x_val, i_x, t_x)
+      call find_interval(y_grid, y_val, i_y, t_y)
+      call find_interval(z_grid, z_val, i_z, t_z)
+   end subroutine find_containing_cell
+
+   ! find the interval in a sorted array containing a value.
+   ! returns index i such that x(i) <= val <= x(i+1) and fractional position t in [0,1].
+   ! detects dummy axes (all zeros / 999 / -999) and collapses them to i=1, t=0.
+   subroutine find_interval(x, val, i, t)
+      real(dp), intent(in) :: x(:), val
+      integer, intent(out) :: i
+      real(dp), intent(out) :: t
+
+      integer :: n, lo, hi, mid
+      logical :: dummy_axis
+
+      n = size(x)
+
+      ! detect dummy axis: all values == 0, 999, or -999
+      dummy_axis = all(x == 0.0_dp) .or. all(x == 999.0_dp) .or. all(x == -999.0_dp)
+
+      if (dummy_axis) then
+         i = 1
+         t = 0.0_dp
+         return
+      end if
+
+      if (val <= x(1)) then
+         i = 1
+         t = 0.0_dp
+         return
+      else if (val >= x(n)) then
+         i = n - 1
+         t = 1.0_dp
+         return
+      end if
+
+      lo = 1
+      hi = n
+      do while (hi - lo > 1)
+         mid = (lo + hi)/2
+         if (val >= x(mid)) then
+            lo = mid
+         else
+            hi = mid
+         end if
+      end do
+
+      i = lo
+      if (abs(x(i + 1) - x(i)) < 1.0e-30_dp) then
+         t = 0.0_dp  ! degenerate interval -- no interpolation needed
+      else
+         t = (val - x(i))/(x(i + 1) - x(i))
+      end if
+   end subroutine find_interval
+
+   subroutine find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                 i_x, i_y, i_z)
+      real(dp), intent(in) :: x_val, y_val, z_val
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
+      integer, intent(out) :: i_x, i_y, i_z
+
+      i_x = minloc(abs(x_val - x_grid), 1)
+      i_y = minloc(abs(y_val - y_grid), 1)
+      i_z = minloc(abs(z_val - z_grid), 1)
+   end subroutine find_nearest_point
+
+   ! returns idx such that grid(idx) <= val < grid(idx+1), clamped to bounds
+   subroutine find_bracket_index(grid, val, idx)
+      real(dp), intent(in) :: grid(:), val
+      integer, intent(out) :: idx
+
+      integer :: n, lo, hi, mid
+
+      n = size(grid)
+      if (n < 2) then
+         idx = 1
+         return
+      end if
+
+      if (val <= grid(1)) then
+         idx = 1
+         return
+      else if (val >= grid(n)) then
+         idx = n - 1
+         return
+      end if
+
+      lo = 1
+      hi = n
+      do while (hi - lo > 1)
+         mid = (lo + hi)/2
+         if (val >= grid(mid)) then
+            lo = mid
+         else
+            hi = mid
+         end if
+      end do
+      idx = lo
+   end subroutine find_bracket_index
+
+   ! fallback SED cache and stencil loader
+
+   ! load a stencil sub-cube of SED fluxes for the given index ranges.
+   ! uses load_sed_cached so repeated visits to the same grid point are
+   ! served from memory rather than disk.
+   subroutine load_stencil(rq, resolved_dir, lo_t, hi_t, lo_g, hi_g, lo_m, hi_m)
+      type(Colors_General_Info), intent(inout) :: rq
+      character(len=*), intent(in) :: resolved_dir
+      integer, intent(in) :: lo_t, hi_t, lo_g, hi_g, lo_m, hi_m
+
+      integer :: st, sg, sm, n_lambda, lu_idx
+      integer :: it, ig, im
+      real(dp), dimension(:), allocatable :: sed_flux
+
+      st = hi_t - lo_t + 1
+      sg = hi_g - lo_g + 1
+      sm = hi_m - lo_m + 1
+
+      ! free previous stencil flux data
+      if (allocated(rq%stencil_fluxes)) deallocate (rq%stencil_fluxes)
+
+      n_lambda = 0
+
+      do it = lo_t, hi_t
+         do ig = lo_g, hi_g
+            do im = lo_m, hi_m
+               lu_idx = rq%grid_to_lu(it, ig, im)
+               call load_sed_cached(rq, resolved_dir, lu_idx, sed_flux)
+
+               if (n_lambda == 0) then
+                  n_lambda = size(sed_flux)
+                  allocate (rq%stencil_fluxes(st, sg, sm, n_lambda))
+               else if (size(sed_flux) /= n_lambda) then
+                  ! SED files have inconsistent wavelength counts — this is a
+                  ! fatal grid inconsistency; crash with a clear message.
+                  write (*, '(a,i0,a,i0,a,i0)') &
+                     'colors ERROR: SED at lu_idx=', lu_idx, &
+                     ' has ', size(sed_flux), ' wavelength points; expected ', n_lambda
+                  write (*, '(a)') &
+                     'colors: bt-settl (or other) grid files have non-uniform wavelength grids.'
+                  call mesa_error(__FILE__, __LINE__)
+               end if
+
+               rq%stencil_fluxes(it - lo_t + 1, ig - lo_g + 1, im - lo_m + 1, :) = &
+                  sed_flux(1:n_lambda)
+               if (allocated(sed_flux)) deallocate (sed_flux)
+            end do
+         end do
+      end do
+
+      ! set stencil wavelengths from the canonical copy on the handle
+      if (allocated(rq%stencil_wavelengths)) deallocate (rq%stencil_wavelengths)
+      allocate (rq%stencil_wavelengths(n_lambda))
+      rq%stencil_wavelengths = rq%fallback_wavelengths(1:n_lambda)
+
+   end subroutine load_stencil
+
+   ! retrieve an SED flux from the memory cache, or load from disk on miss.
+   ! uses a bounded circular buffer (sed_mem_cache_cap slots).
+   ! on the first disk read, the wavelength array is stored once on the handle
+   ! as rq%fallback_wavelengths -- all SEDs in a given atmosphere grid share
+   ! the same wavelengths, so only flux is cached and returned.
+   subroutine load_sed_cached(rq, resolved_dir, lu_idx, flux)
+      type(Colors_General_Info), intent(inout) :: rq
+      character(len=*), intent(in) :: resolved_dir
+      integer, intent(in) :: lu_idx
+      real(dp), dimension(:), allocatable, intent(out) :: flux
+
+      integer :: slot, n_lam, status
+      character(len=512) :: filepath
+      real(dp), dimension(:), allocatable :: sed_wave
+      real(dp), dimension(:), allocatable :: flux_interp
+
+      ! initialise the cache on first call
+      if (.not. rq%sed_mcache_init) then
+         allocate (rq%sed_mcache_keys(sed_mem_cache_cap))
+         rq%sed_mcache_keys = 0   ! 0 means empty slot
+         rq%sed_mcache_count = 0
+         rq%sed_mcache_next = 1
+         rq%sed_mcache_nlam = 0
+         rq%sed_mcache_init = .true.
+      end if
+
+      ! search for a cache hit (linear scan over a small array)
+      do slot = 1, rq%sed_mcache_count
+         if (rq%sed_mcache_keys(slot) == lu_idx) then
+            ! hit -- return cached flux
+            n_lam = rq%sed_mcache_nlam
+            allocate (flux(n_lam))
+            flux = rq%sed_mcache_data(:, slot)
+            return
+         end if
+      end do
+
+      ! miss -- load from disk
+      filepath = trim(resolved_dir)//'/'//trim(rq%lu_file_names(lu_idx))
+      call load_sed(filepath, lu_idx, sed_wave, flux)
+
+      ! store the canonical wavelength array on the handle (once only)
+      if (.not. rq%fallback_wavelengths_set) then
+         n_lam = size(sed_wave)
+         allocate (rq%fallback_wavelengths(n_lam))
+         rq%fallback_wavelengths = sed_wave
+         rq%fallback_wavelengths_set = .true.
+      end if
+
+
+
+      ! store flux in the cache
+      n_lam = size(flux)
+      if (rq%sed_mcache_nlam == 0) then
+         rq%sed_mcache_nlam = n_lam
+         allocate (rq%sed_mcache_data(n_lam, sed_mem_cache_cap), stat=status)
+         if (status /= 0) then
+            write (*, '(a,f0.1,a)') 'colors: SED memory cache allocation failed (', &
+               real(n_lam, dp)*sed_mem_cache_cap*8.0_dp/1024.0_dp**2, ' MB); cache disabled'
+            rq%sed_mcache_init = .false.   ! fall through to disk-only path
+            if (allocated(sed_wave)) deallocate (sed_wave)
+            return
+         end if
+      else if (n_lam /= rq%sed_mcache_nlam) then
+         ! non-uniform wavelength grids across SED files: interpolate onto the canonical grid
+         if (.not. rq%fallback_wavelengths_set) then
+            allocate (rq%fallback_wavelengths(n_lam))
+            rq%fallback_wavelengths = sed_wave
+            rq%fallback_wavelengths_set = .true.
+         end if
+
+         allocate (flux_interp(rq%sed_mcache_nlam), stat=status)
+         if (status /= 0) then
+            write (*, '(a)') 'colors: WARNING: could not allocate interpolation buffer; SED cache disabled'
+            rq%sed_mcache_init = .false.
+            if (allocated(sed_wave)) deallocate (sed_wave)
+            return
+         end if
+
+         call interp_linear_internal(rq%fallback_wavelengths, sed_wave, flux, flux_interp)
+
+         deallocate (flux)
+         allocate (flux(rq%sed_mcache_nlam))
+         flux = flux_interp
+         deallocate (flux_interp)
+
+         n_lam = rq%sed_mcache_nlam
+      end if
+
+      ! write to the next slot (circular)
+      slot = rq%sed_mcache_next
+      rq%sed_mcache_keys(slot) = lu_idx
+      rq%sed_mcache_data(:, slot) = flux(1:n_lam)
+
+      ! advance the circular pointer
+      if (rq%sed_mcache_count < sed_mem_cache_cap) &
+         rq%sed_mcache_count = rq%sed_mcache_count + 1
+      rq%sed_mcache_next = mod(slot, sed_mem_cache_cap) + 1
+
+      if (allocated(sed_wave)) deallocate (sed_wave)
+   end subroutine load_sed_cached
+
+
+   ! simple 1D linear interpolation (np.interp-like): clamps to endpoints
+   subroutine interp_linear_internal(x_out, x_in, y_in, y_out)
+      real(dp), intent(in) :: x_out(:), x_in(:), y_in(:)
+      real(dp), intent(out) :: y_out(:)
+      integer :: i, n_in, n_out, lo, hi, mid
+      real(dp) :: t, denom
+
+      n_in = size(x_in)
+      n_out = size(x_out)
+
+      if (n_out <= 0) return
+
+      if (n_in <= 0) then
+         y_out = 0.0_dp
+         return
+      end if
+
+      if (n_in == 1) then
+         y_out = y_in(1)
+         return
+      end if
+
+      do i = 1, n_out
+         if (x_out(i) <= x_in(1)) then
+            y_out(i) = y_in(1)
+         else if (x_out(i) >= x_in(n_in)) then
+            y_out(i) = y_in(n_in)
+         else
+            lo = 1
+            hi = n_in
+            do while (hi - lo > 1)
+               mid = (lo + hi)/2
+               if (x_out(i) >= x_in(mid)) then
+                  lo = mid
+               else
+                  hi = mid
+               end if
+            end do
+
+            denom = x_in(lo + 1) - x_in(lo)
+            if (abs(denom) <= 0.0_dp) then
+               y_out(i) = y_in(lo)
+            else
+               t = (x_out(i) - x_in(lo))/denom
+               y_out(i) = y_in(lo) + t*(y_in(lo + 1) - y_in(lo))
+            end if
+         end if
+      end do
+
+   end subroutine interp_linear_internal
 end module colors_utils

--- a/colors/private/hermite_interp.f90
+++ b/colors/private/hermite_interp.f90
@@ -1,20 +1,5 @@
 ! ***********************************************************************
-!
-!   Copyright (C) 2025  Niall Miller & The MESA Team
-!
-!   This program is free software: you can redistribute it and/or modify
-!   it under the terms of the GNU Lesser General Public License
-!   as published by the Free Software Foundation,
-!   either version 3 of the License, or (at your option) any later version.
-!
-!   This program is distributed in the hope that it will be useful,
-!   but WITHOUT ANY WARRANTY; without even the implied warranty of
-!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-!   See the GNU Lesser General Public License for more details.
-!
-!   You should have received a copy of the GNU Lesser General Public License
-!   along with this program. If not, see <https://www.gnu.org/licenses/>.
-!
+!   Copyright (C) 2026  Niall Miller & The MESA Team
 ! ***********************************************************************
 
 ! ***********************************************************************
@@ -23,51 +8,54 @@
 
 module hermite_interp
    use const_def, only: dp
-   use colors_utils, only: dilute_flux
+   use colors_def, only: Colors_General_Info
+   use colors_utils, only: dilute_flux, find_containing_cell, find_interval, &
+                          find_nearest_point, find_bracket_index, load_stencil
    implicit none
 
    private
-   public :: construct_sed_hermite, hermite_tensor_interp3d, hermite_interp_vector
+   public :: construct_sed_hermite, hermite_tensor_interp3d
 
 contains
 
    !---------------------------------------------------------------------------
-   ! Main entry point: Construct a SED using Hermite tensor interpolation
+   ! Main entry point: Construct a SED using Hermite tensor interpolation.
+   ! Data loading strategy is determined by rq%cube_loaded (set at init):
+   !   cube_loaded = .true.  -> use the preloaded 4-D cube on the handle
+   !   cube_loaded = .false. -> load individual SED files via the lookup table
    !---------------------------------------------------------------------------
-   subroutine construct_sed_hermite(teff, log_g, metallicity, R, d, file_names, &
-                                    lu_teff, lu_logg, lu_meta, stellar_model_dir, &
-                                    wavelengths, fluxes)
+   subroutine construct_sed_hermite(rq, teff, log_g, metallicity, R, d, &
+                                    stellar_model_dir, wavelengths, fluxes)
+      type(Colors_General_Info), intent(inout) :: rq
       real(dp), intent(in) :: teff, log_g, metallicity, R, d
-      real(dp), intent(in) :: lu_teff(:), lu_logg(:), lu_meta(:)
       character(len=*), intent(in) :: stellar_model_dir
-      character(len=100), intent(in) :: file_names(:)
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
 
-      integer :: n_lambda, status
+      integer :: n_lambda
       real(dp), dimension(:), allocatable :: interp_flux, diluted_flux
-      real(dp), dimension(:, :, :, :), allocatable :: precomputed_flux_cube
 
-      ! Parameter grids
-      real(dp), allocatable :: teff_grid(:), logg_grid(:), meta_grid(:)
-      character(len=256) :: bin_filename
+      if (rq%cube_loaded) then
+         ! ---- Fast path: use preloaded cube from handle ----
+         n_lambda = size(rq%cube_wavelengths)
 
-      ! Construct the binary filename
-      bin_filename = trim(stellar_model_dir)//'/flux_cube.bin'
+         ! Copy wavelengths to output
+         allocate (wavelengths(n_lambda))
+         wavelengths = rq%cube_wavelengths
 
-      ! Load the data from binary file
-      call load_binary_data(bin_filename, teff_grid, logg_grid, meta_grid, &
-                            wavelengths, precomputed_flux_cube, status)
-
-      n_lambda = size(wavelengths)
-
-      ! Allocate space for interpolated flux
-      allocate (interp_flux(n_lambda))
-
-      ! Interpolate all wavelengths in one call — cell search and basis functions
-      ! are computed once and reused across the wavelength loop inside the subroutine
-      call hermite_interp_vector(teff, log_g, metallicity, &
-                                 teff_grid, logg_grid, meta_grid, &
-                                 precomputed_flux_cube, n_lambda, interp_flux)
+         ! Vectorised interpolation over all wavelengths in one pass —
+         ! cell location is computed once and reused, no per-wavelength
+         ! allocation or 3-D slice extraction needed.
+         allocate (interp_flux(n_lambda))
+         call hermite_interp_vector(teff, log_g, metallicity, &
+                                     rq%cube_teff_grid, rq%cube_logg_grid, &
+                                     rq%cube_meta_grid, &
+                                     rq%cube_flux, n_lambda, interp_flux)
+      else
+         ! ---- Fallback path: load individual SED files from lookup table ----
+         call construct_sed_from_files(rq, teff, log_g, metallicity, &
+                                       stellar_model_dir, interp_flux, wavelengths)
+         n_lambda = size(wavelengths)
+      end if
 
       ! Apply distance dilution to get observed flux
       allocate (diluted_flux(n_lambda))
@@ -76,113 +64,247 @@ contains
 
    end subroutine construct_sed_hermite
 
-!---------------------------------------------------------------------------
-! Load data from binary file
-!---------------------------------------------------------------------------
-   subroutine load_binary_data(filename, teff_grid, logg_grid, meta_grid, &
-                               wavelengths, flux_cube, status)
-      character(len=*), intent(in) :: filename
-      real(dp), allocatable, intent(out) :: teff_grid(:), logg_grid(:), meta_grid(:)
-      real(dp), allocatable, intent(out) :: wavelengths(:)
-      real(dp), allocatable, intent(out) :: flux_cube(:, :, :, :)
-      integer, intent(out) :: status
+   !---------------------------------------------------------------------------
+   ! Fallback: Build a local sub-cube from individual SED files with enough
+   ! context for Hermite derivative computation, then interpolate all
+   ! wavelengths in a single pass.
+   !---------------------------------------------------------------------------
+   subroutine construct_sed_from_files(rq, teff, log_g, metallicity, &
+                                        stellar_model_dir, interp_flux, wavelengths)
+      use colors_utils, only: resolve_path, build_grid_to_lu_map
+      type(Colors_General_Info), intent(inout) :: rq
+      real(dp), intent(in) :: teff, log_g, metallicity
+      character(len=*), intent(in) :: stellar_model_dir
+      real(dp), dimension(:), allocatable, intent(out) :: interp_flux, wavelengths
 
-      integer :: unit, n_teff, n_logg, n_meta, n_lambda
+      integer :: i_t, i_g, i_m   ! bracketing indices in unique grids
+      integer :: lo_t, hi_t, lo_g, hi_g, lo_m, hi_m   ! stencil bounds
+      integer :: nt, ng, nm, n_lambda
+      integer :: it, ig, im, lu_idx, i
+      character(len=512) :: resolved_dir
+      logical :: need_reload
 
-      unit = 99
-      status = 0
+      resolved_dir = trim(resolve_path(stellar_model_dir))
 
-      ! Open the binary file
-      open (unit=unit, file=filename, status='OLD', ACCESS='STREAM', FORM='UNFORMATTED', iostat=status)
-      if (status /= 0) then
-         print *, 'Error opening binary file:', trim(filename)
+      ! Ensure the grid-to-lu mapping exists (built once, then reused)
+      if (.not. rq%grid_map_built) call build_grid_to_lu_map(rq)
+
+      ! Find bracketing cell in the unique grids
+      call find_bracket_index(rq%u_teff, teff, i_t)
+      call find_bracket_index(rq%u_logg, log_g, i_g)
+      call find_bracket_index(rq%u_meta, metallicity, i_m)
+
+      ! Check if the stencil cache is still valid for this cell
+      need_reload = .true.
+      if (rq%stencil_valid .and. &
+          i_t == rq%stencil_i_t .and. &
+          i_g == rq%stencil_i_g .and. &
+          i_m == rq%stencil_i_m) then
+         need_reload = .false.
+      end if
+
+      if (need_reload) then
+         ! Determine the extended stencil bounds:
+         ! For each axis, include one point before and after the cell
+         ! when available, so that centred differences match the cube.
+         nt = size(rq%u_teff)
+         ng = size(rq%u_logg)
+         nm = size(rq%u_meta)
+
+         if (nt < 2) then
+            lo_t = 1; hi_t = 1
+         else
+            lo_t = max(1,  i_t - 1)
+            hi_t = min(nt, i_t + 2)
+         end if
+
+         if (ng < 2) then
+            lo_g = 1; hi_g = 1
+         else
+            lo_g = max(1,  i_g - 1)
+            hi_g = min(ng, i_g + 2)
+         end if
+
+         if (nm < 2) then
+            lo_m = 1; hi_m = 1
+         else
+            lo_m = max(1,  i_m - 1)
+            hi_m = min(nm, i_m + 2)
+         end if
+
+         ! Load SEDs for every stencil point (using memory cache)
+         call load_stencil(rq, resolved_dir, lo_t, hi_t, lo_g, hi_g, lo_m, hi_m)
+
+         ! Store subgrid arrays on the handle
+         if (allocated(rq%stencil_teff)) deallocate(rq%stencil_teff)
+         if (allocated(rq%stencil_logg)) deallocate(rq%stencil_logg)
+         if (allocated(rq%stencil_meta)) deallocate(rq%stencil_meta)
+
+         allocate (rq%stencil_teff(hi_t - lo_t + 1))
+         allocate (rq%stencil_logg(hi_g - lo_g + 1))
+         allocate (rq%stencil_meta(hi_m - lo_m + 1))
+         rq%stencil_teff = rq%u_teff(lo_t:hi_t)
+         rq%stencil_logg = rq%u_logg(lo_g:hi_g)
+         rq%stencil_meta = rq%u_meta(lo_m:hi_m)
+
+         rq%stencil_i_t = i_t
+         rq%stencil_i_g = i_g
+         rq%stencil_i_m = i_m
+         rq%stencil_valid = .true.
+      end if
+
+      ! Copy wavelengths to output
+      n_lambda = size(rq%stencil_wavelengths)
+      allocate (wavelengths(n_lambda))
+      wavelengths = rq%stencil_wavelengths
+
+      ! Interpolate all wavelengths using precomputed stencil
+      allocate (interp_flux(n_lambda))
+      call hermite_interp_vector(teff, log_g, metallicity, &
+                                  rq%stencil_teff, rq%stencil_logg, rq%stencil_meta, &
+                                  rq%stencil_fluxes, n_lambda, interp_flux)
+
+   end subroutine construct_sed_from_files
+
+   !---------------------------------------------------------------------------
+   ! Vectorised Hermite interpolation over all wavelengths.
+   !
+   ! The cell location (i_x, i_y, i_z, t_x, t_y, t_z) depends only on
+   ! (teff, logg, meta) and the sub-grids — not on wavelength.  Computing
+   ! it once and reusing across all n_lambda samples eliminates redundant
+   ! binary searches and basis-function evaluations.
+   !---------------------------------------------------------------------------
+   subroutine hermite_interp_vector(x_val, y_val, z_val, &
+                                     x_grid, y_grid, z_grid, &
+                                     f_values_4d, n_lambda, result_flux)
+      real(dp), intent(in) :: x_val, y_val, z_val
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
+      real(dp), intent(in) :: f_values_4d(:,:,:,:)   ! (nx, ny, nz, n_lambda)
+      integer, intent(in) :: n_lambda
+      real(dp), intent(out) :: result_flux(n_lambda)
+
+      integer :: i_x, i_y, i_z
+      real(dp) :: t_x, t_y, t_z
+      real(dp) :: dx, dy, dz
+      integer :: nx, ny, nz
+      integer :: ix, iy, iz, lam
+      real(dp) :: h_x(2), h_y(2), h_z(2)
+      real(dp) :: hx_d(2), hy_d(2), hz_d(2)
+      real(dp) :: val, df_dx, df_dy, df_dz, s
+      real(dp) :: wx, wy, wz, wxd, wyd, wzd
+
+      nx = size(x_grid)
+      ny = size(y_grid)
+      nz = size(z_grid)
+
+      ! Find containing cell (done once for all wavelengths)
+      call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                i_x, i_y, i_z, t_x, t_y, t_z)
+
+      ! If outside grid, use nearest point for all wavelengths
+      if (i_x < 1 .or. i_x >= nx .or. &
+          i_y < 1 .or. i_y >= ny .or. &
+          i_z < 1 .or. i_z >= nz) then
+
+         call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                 i_x, i_y, i_z)
+         do lam = 1, n_lambda
+            result_flux(lam) = f_values_4d(i_x, i_y, i_z, lam)
+         end do
          return
       end if
 
-      ! Read dimensions
-      read (unit, iostat=status) n_teff, n_logg, n_meta, n_lambda
-      if (status /= 0) then
-         print *, 'Error reading dimensions from binary file'
-         close (unit)
-         return
+      ! Grid cell spacing
+      dx = x_grid(i_x + 1) - x_grid(i_x)
+      dy = y_grid(i_y + 1) - y_grid(i_y)
+      dz = z_grid(i_z + 1) - z_grid(i_z)
+
+      ! Precompute Hermite basis functions (same for all wavelengths)
+      h_x  = [h00(t_x), h01(t_x)]
+      hx_d = [h10(t_x), h11(t_x)]
+      h_y  = [h00(t_y), h01(t_y)]
+      hy_d = [h10(t_y), h11(t_y)]
+      h_z  = [h00(t_z), h01(t_z)]
+      hz_d = [h10(t_z), h11(t_z)]
+
+      ! Loop over wavelengths — the hot loop
+      do lam = 1, n_lambda
+         s = 0.0_dp
+         do iz = 0, 1
+            wz  = h_z(iz + 1)
+            wzd = hz_d(iz + 1)
+            do iy = 0, 1
+               wy  = h_y(iy + 1)
+               wyd = hy_d(iy + 1)
+               do ix = 0, 1
+                  wx  = h_x(ix + 1)
+                  wxd = hx_d(ix + 1)
+
+                  val = f_values_4d(i_x + ix, i_y + iy, i_z + iz, lam)
+
+                  call compute_derivatives_at_point_4d( &
+                     f_values_4d, i_x + ix, i_y + iy, i_z + iz, lam, &
+                     nx, ny, nz, dx, dy, dz, df_dx, df_dy, df_dz)
+
+                  s = s + wx*wy*wz     * val &
+                        + wxd*wy*wz    * dx * df_dx &
+                        + wx*wyd*wz    * dy * df_dy &
+                        + wx*wy*wzd    * dz * df_dz
+               end do
+            end do
+         end do
+         result_flux(lam) = s
+      end do
+
+   end subroutine hermite_interp_vector
+
+   !---------------------------------------------------------------------------
+   ! Compute derivatives directly from the 4-D array at a given wavelength,
+   ! avoiding the need to extract a 3-D slice first.
+   !---------------------------------------------------------------------------
+   subroutine compute_derivatives_at_point_4d(f4d, i, j, k, lam, nx, ny, nz, &
+                                               dx, dy, dz, df_dx, df_dy, df_dz)
+      real(dp), intent(in) :: f4d(:,:,:,:)
+      integer, intent(in) :: i, j, k, lam, nx, ny, nz
+      real(dp), intent(in) :: dx, dy, dz
+      real(dp), intent(out) :: df_dx, df_dy, df_dz
+
+      ! x derivative
+      if (dx < 1.0e-30_dp) then
+         df_dx = 0.0_dp
+      else if (i > 1 .and. i < nx) then
+         df_dx = (f4d(i + 1, j, k, lam) - f4d(i - 1, j, k, lam)) / (2.0_dp * dx)
+      else if (i == 1) then
+         df_dx = (f4d(i + 1, j, k, lam) - f4d(i, j, k, lam)) / dx
+      else
+         df_dx = (f4d(i, j, k, lam) - f4d(i - 1, j, k, lam)) / dx
       end if
 
-      ! Allocate arrays based on dimensions
-      allocate (teff_grid(n_teff), STAT=status)
-      if (status /= 0) then
-         print *, 'Error allocating teff_grid array'
-         close (unit)
-         return
+      ! y derivative
+      if (dy < 1.0e-30_dp) then
+         df_dy = 0.0_dp
+      else if (j > 1 .and. j < ny) then
+         df_dy = (f4d(i, j + 1, k, lam) - f4d(i, j - 1, k, lam)) / (2.0_dp * dy)
+      else if (j == 1) then
+         df_dy = (f4d(i, j + 1, k, lam) - f4d(i, j, k, lam)) / dy
+      else
+         df_dy = (f4d(i, j, k, lam) - f4d(i, j - 1, k, lam)) / dy
       end if
 
-      allocate (logg_grid(n_logg), STAT=status)
-      if (status /= 0) then
-         print *, 'Error allocating logg_grid array'
-         close (unit)
-         return
+      ! z derivative
+      if (dz < 1.0e-30_dp) then
+         df_dz = 0.0_dp
+      else if (k > 1 .and. k < nz) then
+         df_dz = (f4d(i, j, k + 1, lam) - f4d(i, j, k - 1, lam)) / (2.0_dp * dz)
+      else if (k == 1) then
+         df_dz = (f4d(i, j, k + 1, lam) - f4d(i, j, k, lam)) / dz
+      else
+         df_dz = (f4d(i, j, k, lam) - f4d(i, j, k - 1, lam)) / dz
       end if
 
-      allocate (meta_grid(n_meta), STAT=status)
-      if (status /= 0) then
-         print *, 'Error allocating meta_grid array'
-         close (unit)
-         return
-      end if
+   end subroutine compute_derivatives_at_point_4d
 
-      allocate (wavelengths(n_lambda), STAT=status)
-      if (status /= 0) then
-         print *, 'Error allocating wavelengths array'
-         close (unit)
-         return
-      end if
 
-      allocate (flux_cube(n_teff, n_logg, n_meta, n_lambda), STAT=status)
-      if (status /= 0) then
-         print *, 'Error allocating flux_cube array'
-         close (unit)
-         return
-      end if
-
-      ! Read grid arrays
-      read (unit, iostat=status) teff_grid
-      if (status /= 0) then
-         print *, 'Error reading teff_grid'
-         close (unit)
-         return
-      end if
-
-      read (unit, iostat=status) logg_grid
-      if (status /= 0) then
-         print *, 'Error reading logg_grid'
-         close (unit)
-         return
-      end if
-
-      read (unit, iostat=status) meta_grid
-      if (status /= 0) then
-         print *, 'Error reading meta_grid'
-         close (unit)
-         return
-      end if
-
-      read (unit, iostat=status) wavelengths
-      if (status /= 0) then
-         print *, 'Error reading wavelengths'
-         close (unit)
-         return
-      end if
-
-      ! Read flux cube
-      read (unit, iostat=status) flux_cube
-      if (status /= 0) then
-         print *, 'Error reading flux_cube'
-         close (unit)
-         return
-      end if
-
-      ! Close file and return success
-      close (unit)
-   end subroutine load_binary_data
 
    function hermite_tensor_interp3d(x_val, y_val, z_val, x_grid, y_grid, &
                                     z_grid, f_values) result(f_interp)
@@ -237,82 +359,6 @@ contains
       end do
 
       ! Precompute Hermite basis functions and derivatives
-      h_x = [h00(t_x), h01(t_x)]
-      hx_d = [h10(t_x), h11(t_x)]
-      h_y = [h00(t_y), h01(t_y)]
-      hy_d = [h10(t_y), h11(t_y)]
-      h_z = [h00(t_z), h01(t_z)]
-      hz_d = [h10(t_z), h11(t_z)]
-
-      ! Final interpolation sum
-      sum = 0.0_dp
-      do iz = 1, 2
-         do iy = 1, 2
-            do ix = 1, 2
-               sum = sum + h_x(ix)*h_y(iy)*h_z(iz)*values(ix, iy, iz)
-               sum = sum + hx_d(ix)*h_y(iy)*h_z(iz)*dx*dx_values(ix, iy, iz)
-               sum = sum + h_x(ix)*hy_d(iy)*h_z(iz)*dy*dy_values(ix, iy, iz)
-               sum = sum + h_x(ix)*h_y(iy)*hz_d(iz)*dz*dz_values(ix, iy, iz)
-            end do
-         end do
-      end do
-
-      f_interp = sum
-   end function hermite_tensor_interp3d
-
-   !---------------------------------------------------------------------------
-   ! Vectorized Hermite interpolation over all wavelengths.
-   ! The cell search and basis function evaluation depend only on
-   ! (teff, logg, meta) and the sub-grids — not on wavelength. Computing
-   ! them once and reusing across all n_lambda samples eliminates redundant
-   ! binary searches and basis-function evaluations.
-   !---------------------------------------------------------------------------
-   subroutine hermite_interp_vector(x_val, y_val, z_val, &
-                                     x_grid, y_grid, z_grid, &
-                                     f_values_4d, n_lambda, result_flux)
-      real(dp), intent(in) :: x_val, y_val, z_val
-      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
-      real(dp), intent(in) :: f_values_4d(:,:,:,:)   ! (nx, ny, nz, n_lambda)
-      integer, intent(in) :: n_lambda
-      real(dp), intent(out) :: result_flux(n_lambda)
-
-      integer :: i_x, i_y, i_z
-      real(dp) :: t_x, t_y, t_z
-      real(dp) :: dx, dy, dz
-      integer :: nx, ny, nz
-      integer :: ix, iy, iz, lam
-      real(dp) :: h_x(2), h_y(2), h_z(2)
-      real(dp) :: hx_d(2), hy_d(2), hz_d(2)
-      real(dp) :: val, df_dx, df_dy, df_dz, s
-      real(dp) :: wx, wy, wz, wxd, wyd, wzd
-
-      nx = size(x_grid)
-      ny = size(y_grid)
-      nz = size(z_grid)
-
-      ! find containing cell (done once for all wavelengths)
-      call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
-                                i_x, i_y, i_z, t_x, t_y, t_z)
-
-      ! if outside grid, use nearest point for all wavelengths
-      if (i_x < 1 .or. i_x >= nx .or. &
-          i_y < 1 .or. i_y >= ny .or. &
-          i_z < 1 .or. i_z >= nz) then
-
-         call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
-                                 i_x, i_y, i_z)
-         do lam = 1, n_lambda
-            result_flux(lam) = f_values_4d(i_x, i_y, i_z, lam)
-         end do
-         return
-      end if
-
-      ! grid cell spacing
-      dx = x_grid(i_x + 1) - x_grid(i_x)
-      dy = y_grid(i_y + 1) - y_grid(i_y)
-      dz = z_grid(i_z + 1) - z_grid(i_z)
-
-      ! precompute Hermite basis functions (same for all wavelengths)
       h_x  = [h00(t_x), h01(t_x)]
       hx_d = [h10(t_x), h11(t_x)]
       h_y  = [h00(t_y), h01(t_y)]
@@ -320,126 +366,25 @@ contains
       h_z  = [h00(t_z), h01(t_z)]
       hz_d = [h10(t_z), h11(t_z)]
 
-      ! loop over wavelengths — the hot loop
-      do lam = 1, n_lambda
-         s = 0.0_dp
-         do iz = 0, 1
-            wz  = h_z(iz + 1)
-            wzd = hz_d(iz + 1)
-            do iy = 0, 1
-               wy  = h_y(iy + 1)
-               wyd = hy_d(iy + 1)
-               do ix = 0, 1
-                  wx  = h_x(ix + 1)
-                  wxd = hx_d(ix + 1)
-
-                  val = f_values_4d(i_x + ix, i_y + iy, i_z + iz, lam)
-
-                  call compute_derivatives_at_point(f_values_4d(:, :, :, lam), &
-                       i_x + ix, i_y + iy, i_z + iz, &
-                       nx, ny, nz, dx, dy, dz, &
-                       df_dx, df_dy, df_dz)
-
-                  s = s + wx*wy*wz*val &
-                        + wxd*wy*wz*dx*df_dx &
-                        + wx*wyd*wz*dy*df_dy &
-                        + wx*wy*wzd*dz*df_dz
-               end do
+      ! Final interpolation sum
+      sum = 0.0_dp
+      do iz = 1, 2
+         do iy = 1, 2
+            do ix = 1, 2
+               sum = sum + h_x(ix)*h_y(iy)*h_z(iz)     * values(ix, iy, iz)
+               sum = sum + hx_d(ix)*h_y(iy)*h_z(iz)    * dx * dx_values(ix, iy, iz)
+               sum = sum + h_x(ix)*hy_d(iy)*h_z(iz)    * dy * dy_values(ix, iy, iz)
+               sum = sum + h_x(ix)*h_y(iy)*hz_d(iz)    * dz * dz_values(ix, iy, iz)
             end do
          end do
-         result_flux(lam) = s
       end do
 
-   end subroutine hermite_interp_vector
+      f_interp = sum
+   end function hermite_tensor_interp3d
+
 
    !---------------------------------------------------------------------------
-   ! Find the cell containing the interpolation point
-   !---------------------------------------------------------------------------
-   subroutine find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
-                                   i_x, i_y, i_z, t_x, t_y, t_z)
-      real(dp), intent(in) :: x_val, y_val, z_val
-      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
-      integer, intent(out) :: i_x, i_y, i_z
-      real(dp), intent(out) :: t_x, t_y, t_z
-
-      ! Find x interval
-      call find_interval(x_grid, x_val, i_x, t_x)
-
-      ! Find y interval
-      call find_interval(y_grid, y_val, i_y, t_y)
-
-      ! Find z interval
-      call find_interval(z_grid, z_val, i_z, t_z)
-   end subroutine find_containing_cell
-
-   !---------------------------------------------------------------------------
-   ! Find the interval in a sorted array containing a value
-   !---------------------------------------------------------------------------
-
-   subroutine find_interval(x, val, i, t)
-      real(dp), intent(in) :: x(:), val
-      integer, intent(out) :: i
-      real(dp), intent(out) :: t
-
-      integer :: n, lo, hi, mid
-      logical :: dummy_axis
-
-      n = size(x)
-
-      ! Detect dummy axis: all values == 0, 999, or -999
-      dummy_axis = all(x == 0.0_dp) .or. all(x == 999.0_dp) .or. all(x == -999.0_dp)
-
-      if (dummy_axis) then
-         ! Collapse axis: always use first point, no interpolation
-         i = 1
-         t = 0.0_dp
-         return
-      end if
-
-      ! ---------- ORIGINAL CODE BELOW ----------------
-
-      if (val <= x(1)) then
-         i = 1
-         t = 0.0_dp
-         return
-      else if (val >= x(n)) then
-         i = n - 1
-         t = 1.0_dp
-         return
-      end if
-
-      lo = 1
-      hi = n
-      do while (hi - lo > 1)
-         mid = (lo + hi)/2
-         if (val >= x(mid)) then
-            lo = mid
-         else
-            hi = mid
-         end if
-      end do
-
-      i = lo
-      t = (val - x(i))/(x(i + 1) - x(i))
-   end subroutine find_interval
-
-   !---------------------------------------------------------------------------
-   ! Find the nearest grid point
-   !---------------------------------------------------------------------------
-   subroutine find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
-                                 i_x, i_y, i_z)
-      real(dp), intent(in) :: x_val, y_val, z_val
-      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
-      integer, intent(out) :: i_x, i_y, i_z
-
-      ! Find nearest grid points using intrinsic minloc
-      i_x = minloc(abs(x_val - x_grid), 1)
-      i_y = minloc(abs(y_val - y_grid), 1)
-      i_z = minloc(abs(z_val - z_grid), 1)
-   end subroutine find_nearest_point
-
-   !---------------------------------------------------------------------------
-   ! Compute derivatives at a grid point
+   ! Compute derivatives at a grid point (3-D version, used by scalar path)
    !---------------------------------------------------------------------------
    subroutine compute_derivatives_at_point(f, i, j, k, nx, ny, nz, dx, dy, dz, &
                                            df_dx, df_dy, df_dz)
@@ -449,7 +394,9 @@ contains
       real(dp), intent(out) :: df_dx, df_dy, df_dz
 
       ! Compute x derivative using centered differences where possible
-      if (i > 1 .and. i < nx) then
+      if (dx < 1.0e-30_dp) then
+         df_dx = 0.0_dp  ! degenerate axis
+      else if (i > 1 .and. i < nx) then
          df_dx = (f(i + 1, j, k) - f(i - 1, j, k))/(2.0_dp*dx)
       else if (i == 1) then
          df_dx = (f(i + 1, j, k) - f(i, j, k))/dx
@@ -458,7 +405,9 @@ contains
       end if
 
       ! Compute y derivative using centered differences where possible
-      if (j > 1 .and. j < ny) then
+      if (dy < 1.0e-30_dp) then
+         df_dy = 0.0_dp  ! degenerate axis
+      else if (j > 1 .and. j < ny) then
          df_dy = (f(i, j + 1, k) - f(i, j - 1, k))/(2.0_dp*dy)
       else if (j == 1) then
          df_dy = (f(i, j + 1, k) - f(i, j, k))/dy
@@ -467,7 +416,9 @@ contains
       end if
 
       ! Compute z derivative using centered differences where possible
-      if (k > 1 .and. k < nz) then
+      if (dz < 1.0e-30_dp) then
+         df_dz = 0.0_dp  ! degenerate axis
+      else if (k > 1 .and. k < nz) then
          df_dz = (f(i, j, k + 1) - f(i, j, k - 1))/(2.0_dp*dz)
       else if (k == 1) then
          df_dz = (f(i, j, k + 1) - f(i, j, k))/dz

--- a/colors/private/hermite_interp.f90
+++ b/colors/private/hermite_interp.f90
@@ -27,7 +27,7 @@ module hermite_interp
    implicit none
 
    private
-   public :: construct_sed_hermite, hermite_tensor_interp3d
+   public :: construct_sed_hermite, hermite_tensor_interp3d, hermite_interp_vector
 
 contains
 
@@ -43,10 +43,9 @@ contains
       character(len=100), intent(in) :: file_names(:)
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
 
-      integer :: i, n_lambda, status, n_teff, n_logg, n_meta
+      integer :: n_lambda, status
       real(dp), dimension(:), allocatable :: interp_flux, diluted_flux
       real(dp), dimension(:, :, :, :), allocatable :: precomputed_flux_cube
-      real(dp), dimension(:, :, :), allocatable :: flux_cube_lambda
 
       ! Parameter grids
       real(dp), allocatable :: teff_grid(:), logg_grid(:), meta_grid(:)
@@ -59,24 +58,16 @@ contains
       call load_binary_data(bin_filename, teff_grid, logg_grid, meta_grid, &
                             wavelengths, precomputed_flux_cube, status)
 
-      n_teff = size(teff_grid)
-      n_logg = size(logg_grid)
-      n_meta = size(meta_grid)
       n_lambda = size(wavelengths)
 
       ! Allocate space for interpolated flux
       allocate (interp_flux(n_lambda))
 
-      ! Process each wavelength point
-      do i = 1, n_lambda
-         allocate (flux_cube_lambda(n_teff, n_logg, n_meta))
-         flux_cube_lambda = precomputed_flux_cube(:, :, :, i)
-
-         interp_flux(i) = hermite_tensor_interp3d(teff, log_g, metallicity, &
-                                                  teff_grid, logg_grid, meta_grid, flux_cube_lambda)
-
-         deallocate (flux_cube_lambda)
-      end do
+      ! Interpolate all wavelengths in one call — cell search and basis functions
+      ! are computed once and reused across the wavelength loop inside the subroutine
+      call hermite_interp_vector(teff, log_g, metallicity, &
+                                 teff_grid, logg_grid, meta_grid, &
+                                 precomputed_flux_cube, n_lambda, interp_flux)
 
       ! Apply distance dilution to get observed flux
       allocate (diluted_flux(n_lambda))
@@ -268,6 +259,98 @@ contains
 
       f_interp = sum
    end function hermite_tensor_interp3d
+
+   !---------------------------------------------------------------------------
+   ! Vectorized Hermite interpolation over all wavelengths.
+   ! The cell search and basis function evaluation depend only on
+   ! (teff, logg, meta) and the sub-grids — not on wavelength. Computing
+   ! them once and reusing across all n_lambda samples eliminates redundant
+   ! binary searches and basis-function evaluations.
+   !---------------------------------------------------------------------------
+   subroutine hermite_interp_vector(x_val, y_val, z_val, &
+                                     x_grid, y_grid, z_grid, &
+                                     f_values_4d, n_lambda, result_flux)
+      real(dp), intent(in) :: x_val, y_val, z_val
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
+      real(dp), intent(in) :: f_values_4d(:,:,:,:)   ! (nx, ny, nz, n_lambda)
+      integer, intent(in) :: n_lambda
+      real(dp), intent(out) :: result_flux(n_lambda)
+
+      integer :: i_x, i_y, i_z
+      real(dp) :: t_x, t_y, t_z
+      real(dp) :: dx, dy, dz
+      integer :: nx, ny, nz
+      integer :: ix, iy, iz, lam
+      real(dp) :: h_x(2), h_y(2), h_z(2)
+      real(dp) :: hx_d(2), hy_d(2), hz_d(2)
+      real(dp) :: val, df_dx, df_dy, df_dz, s
+      real(dp) :: wx, wy, wz, wxd, wyd, wzd
+
+      nx = size(x_grid)
+      ny = size(y_grid)
+      nz = size(z_grid)
+
+      ! find containing cell (done once for all wavelengths)
+      call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                i_x, i_y, i_z, t_x, t_y, t_z)
+
+      ! if outside grid, use nearest point for all wavelengths
+      if (i_x < 1 .or. i_x >= nx .or. &
+          i_y < 1 .or. i_y >= ny .or. &
+          i_z < 1 .or. i_z >= nz) then
+
+         call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                 i_x, i_y, i_z)
+         do lam = 1, n_lambda
+            result_flux(lam) = f_values_4d(i_x, i_y, i_z, lam)
+         end do
+         return
+      end if
+
+      ! grid cell spacing
+      dx = x_grid(i_x + 1) - x_grid(i_x)
+      dy = y_grid(i_y + 1) - y_grid(i_y)
+      dz = z_grid(i_z + 1) - z_grid(i_z)
+
+      ! precompute Hermite basis functions (same for all wavelengths)
+      h_x  = [h00(t_x), h01(t_x)]
+      hx_d = [h10(t_x), h11(t_x)]
+      h_y  = [h00(t_y), h01(t_y)]
+      hy_d = [h10(t_y), h11(t_y)]
+      h_z  = [h00(t_z), h01(t_z)]
+      hz_d = [h10(t_z), h11(t_z)]
+
+      ! loop over wavelengths — the hot loop
+      do lam = 1, n_lambda
+         s = 0.0_dp
+         do iz = 0, 1
+            wz  = h_z(iz + 1)
+            wzd = hz_d(iz + 1)
+            do iy = 0, 1
+               wy  = h_y(iy + 1)
+               wyd = hy_d(iy + 1)
+               do ix = 0, 1
+                  wx  = h_x(ix + 1)
+                  wxd = hx_d(ix + 1)
+
+                  val = f_values_4d(i_x + ix, i_y + iy, i_z + iz, lam)
+
+                  call compute_derivatives_at_point(f_values_4d(:, :, :, lam), &
+                       i_x + ix, i_y + iy, i_z + iz, &
+                       nx, ny, nz, dx, dy, dz, &
+                       df_dx, df_dy, df_dz)
+
+                  s = s + wx*wy*wz*val &
+                        + wxd*wy*wz*dx*df_dx &
+                        + wx*wyd*wz*dy*df_dy &
+                        + wx*wy*wzd*dz*df_dz
+               end do
+            end do
+         end do
+         result_flux(lam) = s
+      end do
+
+   end subroutine hermite_interp_vector
 
    !---------------------------------------------------------------------------
    ! Find the cell containing the interpolation point

--- a/colors/private/hermite_interp.f90
+++ b/colors/private/hermite_interp.f90
@@ -9,7 +9,7 @@
 module hermite_interp
    use const_def, only: dp
    use colors_def, only: Colors_General_Info
-   use colors_utils, only: dilute_flux, find_containing_cell, find_interval, &
+   use colors_utils, only: dilute_flux, find_containing_cell, &
                           find_nearest_point, find_bracket_index, load_stencil
    implicit none
 
@@ -32,7 +32,7 @@ contains
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
 
       integer :: n_lambda
-      real(dp), dimension(:), allocatable :: interp_flux, diluted_flux
+      real(dp), dimension(:), allocatable :: interp_flux
 
       if (rq%cube_loaded) then
          ! ---- Fast path: use preloaded cube from handle ----
@@ -58,9 +58,8 @@ contains
       end if
 
       ! Apply distance dilution to get observed flux
-      allocate (diluted_flux(n_lambda))
-      call dilute_flux(interp_flux, R, d, diluted_flux)
-      fluxes = diluted_flux
+      allocate(fluxes(n_lambda))
+      call dilute_flux(interp_flux, R, d, fluxes)
 
    end subroutine construct_sed_hermite
 
@@ -80,7 +79,6 @@ contains
       integer :: i_t, i_g, i_m   ! bracketing indices in unique grids
       integer :: lo_t, hi_t, lo_g, hi_g, lo_m, hi_m   ! stencil bounds
       integer :: nt, ng, nm, n_lambda
-      integer :: it, ig, im, lu_idx, i
       character(len=512) :: resolved_dir
       logical :: need_reload
 
@@ -186,11 +184,11 @@ contains
       integer :: i_x, i_y, i_z
       real(dp) :: t_x, t_y, t_z
       real(dp) :: dx, dy, dz
+      real(dp) :: val, df_dx, df_dy, df_dz
       integer :: nx, ny, nz
       integer :: ix, iy, iz, lam
       real(dp) :: h_x(2), h_y(2), h_z(2)
       real(dp) :: hx_d(2), hy_d(2), hz_d(2)
-      real(dp) :: val, df_dx, df_dy, df_dz, s
       real(dp) :: wx, wy, wz, wxd, wyd, wzd
 
       nx = size(x_grid)
@@ -227,33 +225,33 @@ contains
       h_z  = [h00(t_z), h01(t_z)]
       hz_d = [h10(t_z), h11(t_z)]
 
-      ! Loop over wavelengths — the hot loop
-      do lam = 1, n_lambda
-         s = 0.0_dp
-         do iz = 0, 1
-            wz  = h_z(iz + 1)
-            wzd = hz_d(iz + 1)
-            do iy = 0, 1
-               wy  = h_y(iy + 1)
-               wyd = hy_d(iy + 1)
-               do ix = 0, 1
-                  wx  = h_x(ix + 1)
-                  wxd = hx_d(ix + 1)
 
+      ! stencil loop — weights are invariant over lambda, so lambda is innermost
+      result_flux = 0.0_dp
+      do iz = 0, 1
+         wz  = h_z(iz + 1)
+         wzd = hz_d(iz + 1)
+         do iy = 0, 1
+            wy  = h_y(iy + 1)
+            wyd = hy_d(iy + 1)
+            do ix = 0, 1
+               wx  = h_x(ix + 1)
+               wxd = hx_d(ix + 1)
+               do lam = 1, n_lambda
                   val = f_values_4d(i_x + ix, i_y + iy, i_z + iz, lam)
 
                   call compute_derivatives_at_point_4d( &
                      f_values_4d, i_x + ix, i_y + iy, i_z + iz, lam, &
-                     nx, ny, nz, dx, dy, dz, df_dx, df_dy, df_dz)
+                     nx, ny, nz, x_grid, y_grid, z_grid, df_dx, df_dy, df_dz)
 
-                  s = s + wx*wy*wz     * val &
+                  result_flux(lam) = result_flux(lam) &
+                        + wx*wy*wz     * val &
                         + wxd*wy*wz    * dx * df_dx &
                         + wx*wyd*wz    * dy * df_dy &
                         + wx*wy*wzd    * dz * df_dz
                end do
             end do
          end do
-         result_flux(lam) = s
       end do
 
    end subroutine hermite_interp_vector
@@ -263,47 +261,46 @@ contains
    ! avoiding the need to extract a 3-D slice first.
    !---------------------------------------------------------------------------
    subroutine compute_derivatives_at_point_4d(f4d, i, j, k, lam, nx, ny, nz, &
-                                               dx, dy, dz, df_dx, df_dy, df_dz)
+                                               x_grid, y_grid, z_grid, df_dx, df_dy, df_dz)
       real(dp), intent(in) :: f4d(:,:,:,:)
       integer, intent(in) :: i, j, k, lam, nx, ny, nz
-      real(dp), intent(in) :: dx, dy, dz
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
       real(dp), intent(out) :: df_dx, df_dy, df_dz
 
       ! x derivative
-      if (dx < 1.0e-30_dp) then
+      if (nx == 1) then
          df_dx = 0.0_dp
       else if (i > 1 .and. i < nx) then
-         df_dx = (f4d(i + 1, j, k, lam) - f4d(i - 1, j, k, lam)) / (2.0_dp * dx)
+         df_dx = (f4d(i+1,j,k,lam) - f4d(i-1,j,k,lam)) / (x_grid(i+1) - x_grid(i-1))
       else if (i == 1) then
-         df_dx = (f4d(i + 1, j, k, lam) - f4d(i, j, k, lam)) / dx
+         df_dx = (f4d(i+1,j,k,lam) - f4d(i,j,k,lam)) / (x_grid(i+1) - x_grid(i))
       else
-         df_dx = (f4d(i, j, k, lam) - f4d(i - 1, j, k, lam)) / dx
+         df_dx = (f4d(i,j,k,lam) - f4d(i-1,j,k,lam)) / (x_grid(i) - x_grid(i-1))
       end if
 
       ! y derivative
-      if (dy < 1.0e-30_dp) then
+      if (ny == 1) then
          df_dy = 0.0_dp
       else if (j > 1 .and. j < ny) then
-         df_dy = (f4d(i, j + 1, k, lam) - f4d(i, j - 1, k, lam)) / (2.0_dp * dy)
+         df_dy = (f4d(i,j+1,k,lam) - f4d(i,j-1,k,lam)) / (y_grid(j+1) - y_grid(j-1))
       else if (j == 1) then
-         df_dy = (f4d(i, j + 1, k, lam) - f4d(i, j, k, lam)) / dy
+         df_dy = (f4d(i,j+1,k,lam) - f4d(i,j,k,lam)) / (y_grid(j+1) - y_grid(j))
       else
-         df_dy = (f4d(i, j, k, lam) - f4d(i, j - 1, k, lam)) / dy
+         df_dy = (f4d(i,j,k,lam) - f4d(i,j-1,k,lam)) / (y_grid(j) - y_grid(j-1))
       end if
 
       ! z derivative
-      if (dz < 1.0e-30_dp) then
+      if (nz == 1) then
          df_dz = 0.0_dp
       else if (k > 1 .and. k < nz) then
-         df_dz = (f4d(i, j, k + 1, lam) - f4d(i, j, k - 1, lam)) / (2.0_dp * dz)
+         df_dz = (f4d(i,j,k+1,lam) - f4d(i,j,k-1,lam)) / (z_grid(k+1) - z_grid(k-1))
       else if (k == 1) then
-         df_dz = (f4d(i, j, k + 1, lam) - f4d(i, j, k, lam)) / dz
+         df_dz = (f4d(i,j,k+1,lam) - f4d(i,j,k,lam)) / (z_grid(k+1) - z_grid(k))
       else
-         df_dz = (f4d(i, j, k, lam) - f4d(i, j, k - 1, lam)) / dz
+         df_dz = (f4d(i,j,k,lam) - f4d(i,j,k-1,lam)) / (z_grid(k) - z_grid(k-1))
       end if
 
    end subroutine compute_derivatives_at_point_4d
-
 
 
    function hermite_tensor_interp3d(x_val, y_val, z_val, x_grid, y_grid, &
@@ -313,52 +310,47 @@ contains
       real(dp), intent(in) :: f_values(:, :, :)
       real(dp) :: f_interp
 
-      integer :: i_x, i_y, i_z
-      real(dp) :: t_x, t_y, t_z
-      real(dp) :: dx, dy, dz
+      integer :: i_x, i_y, i_z, ix, iy, iz
+      integer :: nx, ny, nz
+      real(dp) :: t_x, t_y, t_z, dx, dy, dz, f_sum
       real(dp) :: dx_values(2, 2, 2), dy_values(2, 2, 2), dz_values(2, 2, 2)
       real(dp) :: values(2, 2, 2)
-      real(dp) :: sum
-      integer :: ix, iy, iz
       real(dp) :: h_x(2), h_y(2), h_z(2)
       real(dp) :: hx_d(2), hy_d(2), hz_d(2)
 
-      ! Find containing cell and parameter values
+      nx = size(x_grid)
+      ny = size(y_grid)
+      nz = size(z_grid)
+
       call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
                                 i_x, i_y, i_z, t_x, t_y, t_z)
 
-      ! If outside grid, use nearest point
-      if (i_x < 1 .or. i_x >= size(x_grid) .or. &
-          i_y < 1 .or. i_y >= size(y_grid) .or. &
-          i_z < 1 .or. i_z >= size(z_grid)) then
-
+      if (i_x < 1 .or. i_x >= nx .or. &
+          i_y < 1 .or. i_y >= ny .or. &
+          i_z < 1 .or. i_z >= nz) then
          call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
                                  i_x, i_y, i_z)
          f_interp = f_values(i_x, i_y, i_z)
          return
       end if
 
-      ! Grid cell spacing
       dx = x_grid(i_x + 1) - x_grid(i_x)
       dy = y_grid(i_y + 1) - y_grid(i_y)
       dz = z_grid(i_z + 1) - z_grid(i_z)
 
-      ! Extract the local 2x2x2 grid cell and compute derivatives
       do iz = 0, 1
          do iy = 0, 1
             do ix = 0, 1
-               values(ix + 1, iy + 1, iz + 1) = f_values(i_x + ix, i_y + iy, i_z + iz)
-               call compute_derivatives_at_point(f_values, i_x + ix, i_y + iy, i_z + iz, &
-                                                 size(x_grid), size(y_grid), size(z_grid), &
-                                                 dx, dy, dz, &
-                                                 dx_values(ix + 1, iy + 1, iz + 1), &
-                                                 dy_values(ix + 1, iy + 1, iz + 1), &
-                                                 dz_values(ix + 1, iy + 1, iz + 1))
+               values(ix+1, iy+1, iz+1) = f_values(i_x+ix, i_y+iy, i_z+iz)
+               call compute_derivatives_at_point(f_values, i_x+ix, i_y+iy, i_z+iz, &
+                                                 nx, ny, nz, x_grid, y_grid, z_grid, &
+                                                 dx_values(ix+1, iy+1, iz+1), &
+                                                 dy_values(ix+1, iy+1, iz+1), &
+                                                 dz_values(ix+1, iy+1, iz+1))
             end do
          end do
       end do
 
-      ! Precompute Hermite basis functions and derivatives
       h_x  = [h00(t_x), h01(t_x)]
       hx_d = [h10(t_x), h11(t_x)]
       h_y  = [h00(t_y), h01(t_y)]
@@ -366,64 +358,58 @@ contains
       h_z  = [h00(t_z), h01(t_z)]
       hz_d = [h10(t_z), h11(t_z)]
 
-      ! Final interpolation sum
-      sum = 0.0_dp
+      f_sum = 0.0_dp
       do iz = 1, 2
          do iy = 1, 2
             do ix = 1, 2
-               sum = sum + h_x(ix)*h_y(iy)*h_z(iz)     * values(ix, iy, iz)
-               sum = sum + hx_d(ix)*h_y(iy)*h_z(iz)    * dx * dx_values(ix, iy, iz)
-               sum = sum + h_x(ix)*hy_d(iy)*h_z(iz)    * dy * dy_values(ix, iy, iz)
-               sum = sum + h_x(ix)*h_y(iy)*hz_d(iz)    * dz * dz_values(ix, iy, iz)
+               f_sum = f_sum + h_x(ix)*h_y(iy)*h_z(iz)  * values(ix, iy, iz)
+               f_sum = f_sum + hx_d(ix)*h_y(iy)*h_z(iz) * dx * dx_values(ix, iy, iz)
+               f_sum = f_sum + h_x(ix)*hy_d(iy)*h_z(iz) * dy * dy_values(ix, iy, iz)
+               f_sum = f_sum + h_x(ix)*h_y(iy)*hz_d(iz) * dz * dz_values(ix, iy, iz)
             end do
          end do
       end do
 
-      f_interp = sum
+      f_interp = f_sum
    end function hermite_tensor_interp3d
 
 
-   !---------------------------------------------------------------------------
-   ! Compute derivatives at a grid point (3-D version, used by scalar path)
-   !---------------------------------------------------------------------------
-   subroutine compute_derivatives_at_point(f, i, j, k, nx, ny, nz, dx, dy, dz, &
+   subroutine compute_derivatives_at_point(f, i, j, k, nx, ny, nz, &
+                                           x_grid, y_grid, z_grid, &
                                            df_dx, df_dy, df_dz)
       real(dp), intent(in) :: f(:, :, :)
       integer, intent(in) :: i, j, k, nx, ny, nz
-      real(dp), intent(in) :: dx, dy, dz
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
       real(dp), intent(out) :: df_dx, df_dy, df_dz
 
-      ! Compute x derivative using centered differences where possible
-      if (dx < 1.0e-30_dp) then
-         df_dx = 0.0_dp  ! degenerate axis
+      if (nx == 1) then
+         df_dx = 0.0_dp
       else if (i > 1 .and. i < nx) then
-         df_dx = (f(i + 1, j, k) - f(i - 1, j, k))/(2.0_dp*dx)
+         df_dx = (f(i+1,j,k) - f(i-1,j,k)) / (x_grid(i+1) - x_grid(i-1))
       else if (i == 1) then
-         df_dx = (f(i + 1, j, k) - f(i, j, k))/dx
-      else ! i == nx
-         df_dx = (f(i, j, k) - f(i - 1, j, k))/dx
+         df_dx = (f(i+1,j,k) - f(i,j,k))   / (x_grid(i+1) - x_grid(i))
+      else
+         df_dx = (f(i,j,k)   - f(i-1,j,k)) / (x_grid(i)   - x_grid(i-1))
       end if
 
-      ! Compute y derivative using centered differences where possible
-      if (dy < 1.0e-30_dp) then
-         df_dy = 0.0_dp  ! degenerate axis
+      if (ny == 1) then
+         df_dy = 0.0_dp
       else if (j > 1 .and. j < ny) then
-         df_dy = (f(i, j + 1, k) - f(i, j - 1, k))/(2.0_dp*dy)
+         df_dy = (f(i,j+1,k) - f(i,j-1,k)) / (y_grid(j+1) - y_grid(j-1))
       else if (j == 1) then
-         df_dy = (f(i, j + 1, k) - f(i, j, k))/dy
-      else ! j == ny
-         df_dy = (f(i, j, k) - f(i, j - 1, k))/dy
+         df_dy = (f(i,j+1,k) - f(i,j,k))   / (y_grid(j+1) - y_grid(j))
+      else
+         df_dy = (f(i,j,k)   - f(i,j-1,k)) / (y_grid(j)   - y_grid(j-1))
       end if
 
-      ! Compute z derivative using centered differences where possible
-      if (dz < 1.0e-30_dp) then
-         df_dz = 0.0_dp  ! degenerate axis
+      if (nz == 1) then
+         df_dz = 0.0_dp
       else if (k > 1 .and. k < nz) then
-         df_dz = (f(i, j, k + 1) - f(i, j, k - 1))/(2.0_dp*dz)
+         df_dz = (f(i,j,k+1) - f(i,j,k-1)) / (z_grid(k+1) - z_grid(k-1))
       else if (k == 1) then
-         df_dz = (f(i, j, k + 1) - f(i, j, k))/dz
-      else ! k == nz
-         df_dz = (f(i, j, k) - f(i, j, k - 1))/dz
+         df_dz = (f(i,j,k+1) - f(i,j,k))   / (z_grid(k+1) - z_grid(k))
+      else
+         df_dz = (f(i,j,k)   - f(i,j,k-1)) / (z_grid(k)   - z_grid(k-1))
       end if
    end subroutine compute_derivatives_at_point
 

--- a/colors/private/knn_interp.f90
+++ b/colors/private/knn_interp.f90
@@ -17,99 +17,265 @@
 !
 ! ***********************************************************************
 
-! ***********************************************************************
-! K-Nearest Neighbors interpolation module for spectral energy distributions (SEDs)
-! ***********************************************************************
+! knn interpolation for SEDs
+!
+! data-loading strategy selected by rq%cube_loaded:
+!   .true.  -> extract neighbor SEDs from the preloaded 4-D cube
+!   .false. -> load individual SED files via the lookup table (fallback)
 
 module knn_interp
    use const_def, only: dp
-   use colors_utils, only: dilute_flux, load_sed
+   use colors_def, only: Colors_General_Info
+   use colors_utils, only: dilute_flux, load_sed_cached
    use utils_lib, only: mesa_error
    implicit none
 
    private
-   public :: construct_sed_knn, load_sed, interpolate_array, dilute_flux
+   public :: construct_sed_knn, interpolate_array
 
 contains
 
-   !---------------------------------------------------------------------------
-   ! Main entry point: Construct a SED using KNN interpolation
-   !---------------------------------------------------------------------------
-   subroutine construct_sed_knn(teff, log_g, metallicity, R, d, file_names, &
-                                lu_teff, lu_logg, lu_meta, stellar_model_dir, &
-                                wavelengths, fluxes)
+   ! main entry point -- construct a SED using KNN interpolation
+   ! strategy controlled by rq%cube_loaded (set at init)
+   subroutine construct_sed_knn(rq, teff, log_g, metallicity, R, d, &
+                                stellar_model_dir, wavelengths, fluxes)
+      type(Colors_General_Info), intent(inout) :: rq
       real(dp), intent(in) :: teff, log_g, metallicity, R, d
-      real(dp), intent(in) :: lu_teff(:), lu_logg(:), lu_meta(:)
       character(len=*), intent(in) :: stellar_model_dir
-      character(len=100), intent(in) :: file_names(:)
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
 
-      integer, dimension(4) :: closest_indices
-      real(dp), dimension(:), allocatable :: temp_wavelengths, temp_flux, common_wavelengths
-      real(dp), dimension(:, :), allocatable :: model_fluxes
-      real(dp), dimension(4) :: weights, distances
-      integer :: i, n_points
-      real(dp) :: sum_weights
-      real(dp), dimension(:), allocatable :: diluted_flux
+      integer :: n_lambda
+      real(dp), dimension(:), allocatable :: interp_flux, diluted_flux
 
-      ! Get the four closest stellar models
-      call get_closest_stellar_models(teff, log_g, metallicity, lu_teff, &
-                                      lu_logg, lu_meta, closest_indices)
+      if (rq%cube_loaded) then
+         ! fast path: extract neighbors from preloaded cube
+         call construct_sed_from_cube(rq, teff, log_g, metallicity, &
+                                      interp_flux, wavelengths)
+         n_lambda = size(wavelengths)
+      else
+         ! fallback path: load individual SED files
+         call construct_sed_from_files(rq, teff, log_g, metallicity, &
+                                       stellar_model_dir, interp_flux, wavelengths)
+         n_lambda = size(wavelengths)
+      end if
 
-      ! Load the first SED to define the wavelength grid
-      call load_sed(trim(stellar_model_dir)//trim(file_names(closest_indices(1))), &
-                    closest_indices(1), temp_wavelengths, temp_flux)
-
-      n_points = size(temp_wavelengths)
-      allocate (common_wavelengths(n_points))
-      common_wavelengths = temp_wavelengths
-
-      ! Allocate flux array for the models (4 models, n_points each)
-      allocate (model_fluxes(4, n_points))
-      call interpolate_array(temp_wavelengths, temp_flux, common_wavelengths, model_fluxes(1, :))
-
-      ! Load and interpolate remaining SEDs
-      do i = 2, 4
-         call load_sed(trim(stellar_model_dir)//trim(file_names(closest_indices(i))), &
-                       closest_indices(i), temp_wavelengths, temp_flux)
-
-         call interpolate_array(temp_wavelengths, temp_flux, common_wavelengths, model_fluxes(i, :))
-      end do
-
-      ! Compute distances and weights for the four models
-      do i = 1, 4
-         distances(i) = sqrt((lu_teff(closest_indices(i)) - teff)**2 + &
-                             (lu_logg(closest_indices(i)) - log_g)**2 + &
-                             (lu_meta(closest_indices(i)) - metallicity)**2)
-         if (distances(i) == 0.0_dp) distances(i) = 1.0d-10  ! Prevent division by zero
-         weights(i) = 1.0_dp/distances(i)
-      end do
-
-      ! Normalize weights
-      sum_weights = sum(weights)
-      weights = weights/sum_weights
-
-      ! Allocate output arrays
-      allocate (wavelengths(n_points), fluxes(n_points))
-      wavelengths = common_wavelengths
-      fluxes = 0.0_dp
-
-      ! Perform weighted combination of the model fluxes (still at the stellar surface)
-      do i = 1, 4
-         fluxes = fluxes + weights(i)*model_fluxes(i, :)
-      end do
-
-      ! Now, apply the dilution factor (R/d)^2 to convert the surface flux density
-      ! into the observed flux density at Earth.
-      allocate (diluted_flux(n_points))
-      call dilute_flux(fluxes, R, d, diluted_flux)
+      allocate (diluted_flux(n_lambda))
+      call dilute_flux(interp_flux, R, d, diluted_flux)
       fluxes = diluted_flux
 
    end subroutine construct_sed_knn
 
-   !---------------------------------------------------------------------------
-   ! Identify the four closest stellar models
-   !---------------------------------------------------------------------------
+   ! cube path: find 4 nearest grid points, extract their SEDs from cube_flux, blend by IDW
+   subroutine construct_sed_from_cube(rq, teff, log_g, metallicity, &
+                                      interp_flux, wavelengths)
+      type(Colors_General_Info), intent(inout) :: rq
+      real(dp), intent(in) :: teff, log_g, metallicity
+      real(dp), dimension(:), allocatable, intent(out) :: interp_flux, wavelengths
+
+      integer :: n_lambda, k
+      integer, dimension(4) :: nbr_it, nbr_ig, nbr_im
+      real(dp), dimension(4) :: distances, weights
+      real(dp) :: sum_weights
+
+      n_lambda = size(rq%cube_wavelengths)
+      allocate (wavelengths(n_lambda))
+      wavelengths = rq%cube_wavelengths
+
+      ! find the 4 nearest grid points in the structured cube
+      call get_closest_grid_points(teff, log_g, metallicity, &
+                                   rq%cube_teff_grid, rq%cube_logg_grid, &
+                                   rq%cube_meta_grid, &
+                                   nbr_it, nbr_ig, nbr_im, distances)
+
+      ! compute inverse-distance weights
+      do k = 1, 4
+         if (distances(k) == 0.0_dp) distances(k) = 1.0e-10_dp
+         weights(k) = 1.0_dp/distances(k)
+      end do
+      sum_weights = sum(weights)
+      weights = weights/sum_weights
+
+      ! blend neighbor SEDs from cube
+      allocate (interp_flux(n_lambda))
+      interp_flux = 0.0_dp
+      do k = 1, 4
+         interp_flux = interp_flux + weights(k)* &
+                       rq%cube_flux(nbr_it(k), nbr_ig(k), nbr_im(k), :)
+      end do
+
+   end subroutine construct_sed_from_cube
+
+   ! fallback path: find 4 nearest models in the lookup table, load SEDs, blend by IDW
+   subroutine construct_sed_from_files(rq, teff, log_g, metallicity, &
+                                       stellar_model_dir, interp_flux, wavelengths)
+      use colors_utils, only: resolve_path
+      type(Colors_General_Info), intent(inout) :: rq
+      real(dp), intent(in) :: teff, log_g, metallicity
+      character(len=*), intent(in) :: stellar_model_dir
+      real(dp), dimension(:), allocatable, intent(out) :: interp_flux, wavelengths
+
+      integer, dimension(4) :: closest_indices
+      real(dp), dimension(:), allocatable :: temp_flux, common_wavelengths
+      real(dp), dimension(:, :), allocatable :: model_fluxes
+      real(dp), dimension(4) :: weights, distances
+      integer :: i, n_points
+      real(dp) :: sum_weights
+      character(len=512) :: resolved_dir
+
+      resolved_dir = trim(resolve_path(stellar_model_dir))
+
+      ! get the four closest stellar models from the flat lookup table
+      call get_closest_stellar_models(teff, log_g, metallicity, &
+                                      rq%lu_teff, rq%lu_logg, rq%lu_meta, &
+                                      closest_indices)
+
+      ! load the first SED to define the wavelength grid (using cache)
+      call load_sed_cached(rq, resolved_dir, closest_indices(1), temp_flux)
+
+      ! get wavelengths from canonical copy on the handle
+      if (rq%fallback_wavelengths_set) then
+         n_points = size(rq%fallback_wavelengths)
+         allocate (common_wavelengths(n_points))
+         common_wavelengths = rq%fallback_wavelengths
+      else
+         ! should not happen -- load_sed_cached sets this on first call
+         print *, 'KNN fallback: wavelengths not set after first SED load'
+         call mesa_error(__FILE__, __LINE__)
+      end if
+
+      allocate (model_fluxes(4, n_points))
+      model_fluxes(1, :) = temp_flux(1:n_points)
+      if (allocated(temp_flux)) deallocate (temp_flux)
+
+      ! load and store remaining SEDs
+      do i = 2, 4
+         call load_sed_cached(rq, resolved_dir, closest_indices(i), temp_flux)
+         model_fluxes(i, :) = temp_flux(1:n_points)
+         if (allocated(temp_flux)) deallocate (temp_flux)
+      end do
+
+      ! compute distances and weights for the four models
+      do i = 1, 4
+         distances(i) = sqrt((rq%lu_teff(closest_indices(i)) - teff)**2 + &
+                             (rq%lu_logg(closest_indices(i)) - log_g)**2 + &
+                             (rq%lu_meta(closest_indices(i)) - metallicity)**2)
+         if (distances(i) == 0.0_dp) distances(i) = 1.0e-10_dp
+         weights(i) = 1.0_dp/distances(i)
+      end do
+
+      sum_weights = sum(weights)
+      weights = weights/sum_weights
+
+      allocate (wavelengths(n_points))
+      wavelengths = common_wavelengths
+
+      allocate (interp_flux(n_points))
+      interp_flux = 0.0_dp
+
+      ! weighted combination of model fluxes
+      do i = 1, 4
+         interp_flux = interp_flux + weights(i)*model_fluxes(i, :)
+      end do
+
+   end subroutine construct_sed_from_files
+
+   ! find the 4 closest grid points in the structured cube (normalised euclidean distance)
+   subroutine get_closest_grid_points(teff, log_g, metallicity, &
+                                      teff_grid, logg_grid, meta_grid, &
+                                      nbr_it, nbr_ig, nbr_im, distances)
+      real(dp), intent(in) :: teff, log_g, metallicity
+      real(dp), intent(in) :: teff_grid(:), logg_grid(:), meta_grid(:)
+      integer, dimension(4), intent(out) :: nbr_it, nbr_ig, nbr_im
+      real(dp), dimension(4), intent(out) :: distances
+
+      integer :: it, ig, im, j
+      real(dp) :: dist, norm_teff, norm_logg, norm_meta
+      real(dp) :: teff_min, teff_max, logg_min, logg_max, meta_min, meta_max
+      real(dp) :: scaled_t, scaled_g, scaled_m, dt, dg, dm
+      logical :: use_teff_dim, use_logg_dim, use_meta_dim
+
+      distances = huge(1.0_dp)
+      nbr_it = 1; nbr_ig = 1; nbr_im = 1
+
+      ! normalisation ranges
+      teff_min = minval(teff_grid); teff_max = maxval(teff_grid)
+      logg_min = minval(logg_grid); logg_max = maxval(logg_grid)
+      meta_min = minval(meta_grid); meta_max = maxval(meta_grid)
+
+      ! detect dummy axes
+      use_teff_dim = .not. (all(teff_grid == 0.0_dp) .or. &
+                            all(teff_grid == 999.0_dp) .or. all(teff_grid == -999.0_dp))
+      use_logg_dim = .not. (all(logg_grid == 0.0_dp) .or. &
+                            all(logg_grid == 999.0_dp) .or. all(logg_grid == -999.0_dp))
+      use_meta_dim = .not. (all(meta_grid == 0.0_dp) .or. &
+                            all(meta_grid == 999.0_dp) .or. all(meta_grid == -999.0_dp))
+
+      ! normalised target values
+      norm_teff = 0.0_dp; norm_logg = 0.0_dp; norm_meta = 0.0_dp
+      if (use_teff_dim .and. teff_max - teff_min > 0.0_dp) &
+         norm_teff = (teff - teff_min)/(teff_max - teff_min)
+      if (use_logg_dim .and. logg_max - logg_min > 0.0_dp) &
+         norm_logg = (log_g - logg_min)/(logg_max - logg_min)
+      if (use_meta_dim .and. meta_max - meta_min > 0.0_dp) &
+         norm_meta = (metallicity - meta_min)/(meta_max - meta_min)
+
+      do it = 1, size(teff_grid)
+         if (use_teff_dim .and. teff_max - teff_min > 0.0_dp) then
+            scaled_t = (teff_grid(it) - teff_min)/(teff_max - teff_min)
+         else
+            scaled_t = 0.0_dp
+         end if
+         dt = 0.0_dp
+         if (use_teff_dim) dt = (scaled_t - norm_teff)**2
+
+         do ig = 1, size(logg_grid)
+            if (use_logg_dim .and. logg_max - logg_min > 0.0_dp) then
+               scaled_g = (logg_grid(ig) - logg_min)/(logg_max - logg_min)
+            else
+               scaled_g = 0.0_dp
+            end if
+            dg = 0.0_dp
+            if (use_logg_dim) dg = (scaled_g - norm_logg)**2
+
+            do im = 1, size(meta_grid)
+               if (use_meta_dim .and. meta_max - meta_min > 0.0_dp) then
+                  scaled_m = (meta_grid(im) - meta_min)/(meta_max - meta_min)
+               else
+                  scaled_m = 0.0_dp
+               end if
+               dm = 0.0_dp
+               if (use_meta_dim) dm = (scaled_m - norm_meta)**2
+
+               dist = dt + dg + dm
+
+               ! insert into sorted top-4 if closer
+               do j = 1, 4
+                  if (dist < distances(j)) then
+                     if (j < 4) then
+                        distances(j + 1:4) = distances(j:3)
+                        nbr_it(j + 1:4) = nbr_it(j:3)
+                        nbr_ig(j + 1:4) = nbr_ig(j:3)
+                        nbr_im(j + 1:4) = nbr_im(j:3)
+                     end if
+                     distances(j) = dist
+                     nbr_it(j) = it
+                     nbr_ig(j) = ig
+                     nbr_im(j) = im
+                     exit
+                  end if
+               end do
+            end do
+         end do
+      end do
+
+      ! convert squared distances to actual distances for weighting
+      do j = 1, 4
+         distances(j) = sqrt(distances(j))
+      end do
+
+   end subroutine get_closest_grid_points
+
+   ! find the four closest stellar models in the flat lookup table
    subroutine get_closest_stellar_models(teff, log_g, metallicity, lu_teff, &
                                          lu_logg, lu_meta, closest_indices)
       real(dp), intent(in) :: teff, log_g, metallicity
@@ -129,7 +295,7 @@ contains
       min_distances = huge(1.0)
       indices = -1
 
-      ! Find min and max for normalization
+      ! find min and max for normalisation
       teff_min = minval(lu_teff)
       teff_max = maxval(lu_teff)
       logg_min = minval(lu_logg)
@@ -137,7 +303,6 @@ contains
       meta_min = minval(lu_meta)
       meta_max = maxval(lu_meta)
 
-      ! Allocate and scale lookup table values
       allocate (scaled_lu_teff(n), scaled_lu_logg(n), scaled_lu_meta(n))
 
       if (teff_max - teff_min > 0.0_dp) then
@@ -152,17 +317,16 @@ contains
          scaled_lu_meta = (lu_meta - meta_min)/(meta_max - meta_min)
       end if
 
-      ! Normalize input parameters
+      ! normalise input parameters
       norm_teff = (teff - teff_min)/(teff_max - teff_min)
       norm_logg = (log_g - logg_min)/(logg_max - logg_min)
       norm_meta = (metallicity - meta_min)/(meta_max - meta_min)
 
-      ! Detect dummy axes once (outside the loop)
+      ! detect dummy axes -- skip degenerate dimensions in distance calc
       use_teff_dim = .not. (all(lu_teff == 0.0_dp) .or. all(lu_teff == 999.0_dp) .or. all(lu_teff == -999.0_dp))
       use_logg_dim = .not. (all(lu_logg == 0.0_dp) .or. all(lu_logg == 999.0_dp) .or. all(lu_logg == -999.0_dp))
       use_meta_dim = .not. (all(lu_meta == 0.0_dp) .or. all(lu_meta == 999.0_dp) .or. all(lu_meta == -999.0_dp))
 
-      ! Find closest models
       do i = 1, n
          teff_dist = 0.0_dp
          logg_dist = 0.0_dp
@@ -180,7 +344,7 @@ contains
             meta_dist = scaled_lu_meta(i) - norm_meta
          end if
 
-         ! Compute distance using only valid dimensions
+         ! compute distance using only valid dimensions
          distance = 0.0_dp
          if (use_teff_dim) distance = distance + teff_dist**2
          if (use_logg_dim) distance = distance + logg_dist**2
@@ -188,7 +352,7 @@ contains
 
          do j = 1, 4
             if (distance < min_distances(j)) then
-               ! Shift larger distances down
+               ! shift larger distances down
                if (j < 4) then
                   min_distances(j + 1:4) = min_distances(j:3)
                   indices(j + 1:4) = indices(j:3)
@@ -203,15 +367,12 @@ contains
       closest_indices = indices
    end subroutine get_closest_stellar_models
 
-   !---------------------------------------------------------------------------
-   ! Linear interpolation (binary search version for efficiency)
-   !---------------------------------------------------------------------------
+   ! linear interpolation -- binary search
    subroutine linear_interpolate(x, y, x_val, y_val)
       real(dp), intent(in) :: x(:), y(:), x_val
       real(dp), intent(out) :: y_val
       integer :: low, high, mid
 
-      ! Validate input sizes
       if (size(x) < 2) then
          print *, "Error: x array has fewer than 2 points."
          y_val = 0.0_dp
@@ -224,7 +385,7 @@ contains
          return
       end if
 
-      ! Handle out-of-bounds cases
+      ! handle out-of-bounds cases
       if (x_val <= x(1)) then
          y_val = y(1)
          return
@@ -233,7 +394,7 @@ contains
          return
       end if
 
-      ! Binary search to find the proper interval [x(low), x(low+1)]
+      ! binary search to find interval [x(low), x(low+1)]
       low = 1
       high = size(x)
       do while (high - low > 1)
@@ -245,19 +406,15 @@ contains
          end if
       end do
 
-      ! Linear interpolation between x(low) and x(low+1)
       y_val = y(low) + (y(low + 1) - y(low))/(x(low + 1) - x(low))*(x_val - x(low))
    end subroutine linear_interpolate
 
-   !---------------------------------------------------------------------------
-   ! Array interpolation for SED construction
-   !---------------------------------------------------------------------------
+   ! array interpolation for SED/filter alignment
    subroutine interpolate_array(x_in, y_in, x_out, y_out)
       real(dp), intent(in) :: x_in(:), y_in(:), x_out(:)
       real(dp), intent(out) :: y_out(:)
       integer :: i
 
-      ! Validate input sizes
       if (size(x_in) < 2 .or. size(y_in) < 2) then
          print *, "Error: x_in or y_in arrays have fewer than 2 points."
          call mesa_error(__FILE__, __LINE__)

--- a/colors/private/linear_interp.f90
+++ b/colors/private/linear_interp.f90
@@ -1,6 +1,6 @@
 ! ***********************************************************************
 !
-!   Copyright (C) 2025  Niall Miller & The MESA Team
+!   Copyright (C) 2026  Niall Miller & The MESA Team
 !
 !   This program is free software: you can redistribute it and/or modify
 !   it under the terms of the GNU Lesser General Public License
@@ -17,289 +17,240 @@
 !
 ! ***********************************************************************
 
-! ***********************************************************************
-! Linear interpolation module for spectral energy distributions (SEDs)
-! ***********************************************************************
+! linear interpolation for SEDs
+!
+! data-loading strategy selected by rq%cube_loaded:
+!   .true.  -> use the preloaded 4-D flux cube on the handle
+!   .false. -> load individual SED files via the lookup table (fallback)
 
 module linear_interp
    use const_def, only: dp
-   use colors_utils, only: dilute_flux
+   use colors_def, only: Colors_General_Info
+   use colors_utils, only: dilute_flux, find_containing_cell, find_interval, &
+                           find_nearest_point, find_bracket_index, &
+                           load_sed_cached, load_stencil
    use utils_lib, only: mesa_error
    implicit none
 
    private
-   public :: construct_sed_linear, trilinear_interp, trilinear_interp_vector
+   public :: construct_sed_linear, trilinear_interp
 
 contains
 
-   !---------------------------------------------------------------------------
-   ! Main entry point: Construct a SED using linear interpolation
-   !---------------------------------------------------------------------------
-
-   subroutine construct_sed_linear(teff, log_g, metallicity, R, d, file_names, &
-                                   lu_teff, lu_logg, lu_meta, stellar_model_dir, &
-                                   wavelengths, fluxes)
-
+   ! main entry point -- construct a SED using trilinear interpolation
+   ! strategy controlled by rq%cube_loaded (set at init)
+   subroutine construct_sed_linear(rq, teff, log_g, metallicity, R, d, &
+                                   stellar_model_dir, wavelengths, fluxes)
+      type(Colors_General_Info), intent(inout) :: rq
       real(dp), intent(in) :: teff, log_g, metallicity, R, d
-      real(dp), intent(in) :: lu_teff(:), lu_logg(:), lu_meta(:)
       character(len=*), intent(in) :: stellar_model_dir
-      character(len=100), intent(in) :: file_names(:)
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
 
-      integer :: n_lambda, status, n_teff, n_logg, n_meta
+      integer :: n_lambda
       real(dp), dimension(:), allocatable :: interp_flux, diluted_flux
-      real(dp), dimension(:, :, :, :), allocatable :: precomputed_flux_cube
-      real(dp) :: min_flux, max_flux, mean_flux, progress_pct
 
-      ! Parameter grids
-      real(dp), allocatable :: teff_grid(:), logg_grid(:), meta_grid(:)
-      character(len=256) :: bin_filename, clean_path
-      logical :: file_exists
+      if (rq%cube_loaded) then
+         ! fast path: use preloaded cube from handle
+         n_lambda = size(rq%cube_wavelengths)
 
-      ! Clean up any double slashes in the path
-      clean_path = trim(stellar_model_dir)
-      if (clean_path(len_trim(clean_path):len_trim(clean_path)) == '/') then
-         bin_filename = trim(clean_path)//'flux_cube.bin'
+         allocate (wavelengths(n_lambda))
+         wavelengths = rq%cube_wavelengths
+
+         ! vectorised interpolation -- cell location computed once, reused across n_lambda
+         allocate (interp_flux(n_lambda))
+         call trilinear_interp_vector(teff, log_g, metallicity, &
+                                      rq%cube_teff_grid, rq%cube_logg_grid, &
+                                      rq%cube_meta_grid, &
+                                      rq%cube_flux, n_lambda, interp_flux)
       else
-         bin_filename = trim(clean_path)//'/flux_cube.bin'
+         ! fallback path: load individual SED files from lookup table
+         call construct_sed_from_files(rq, teff, log_g, metallicity, &
+                                       stellar_model_dir, interp_flux, wavelengths)
+         n_lambda = size(wavelengths)
       end if
 
-      ! Check if file exists first
-      INQUIRE (file=bin_filename, EXIST=file_exists)
-
-      if (.not. file_exists) then
-         print *, 'Missing required binary file for interpolation'
-         call mesa_error(__FILE__, __LINE__)
-      end if
-
-      ! Load the data from binary file
-      call load_binary_data(bin_filename, teff_grid, logg_grid, meta_grid, &
-                            wavelengths, precomputed_flux_cube, status)
-
-      if (status /= 0) then
-         print *, 'Binary data loading error'
-         call mesa_error(__FILE__, __LINE__)
-      end if
-
-      n_teff = size(teff_grid)
-      n_logg = size(logg_grid)
-      n_meta = size(meta_grid)
-      n_lambda = size(wavelengths)
-
-      ! Allocate space for interpolated flux
-      allocate (interp_flux(n_lambda))
-
-      ! Interpolate all wavelengths in one call — cell search and boundary
-      ! clamping are performed once and reused across the wavelength loop
-      ! inside the subroutine
-      call trilinear_interp_vector(teff, log_g, metallicity, &
-                                   teff_grid, logg_grid, meta_grid, &
-                                   precomputed_flux_cube, n_lambda, interp_flux)
-
-      ! Calculate statistics for validation
-      min_flux = minval(interp_flux)
-      max_flux = maxval(interp_flux)
-      mean_flux = sum(interp_flux)/n_lambda
-
-      ! Apply distance dilution to get observed flux
       allocate (diluted_flux(n_lambda))
       call dilute_flux(interp_flux, R, d, diluted_flux)
       fluxes = diluted_flux
 
-      ! Calculate statistics after dilution
-      min_flux = minval(diluted_flux)
-      max_flux = maxval(diluted_flux)
-      mean_flux = sum(diluted_flux)/n_lambda
-
    end subroutine construct_sed_linear
 
-   !---------------------------------------------------------------------------
-   ! Load data from binary file
-   !---------------------------------------------------------------------------
-   subroutine load_binary_data(filename, teff_grid, logg_grid, meta_grid, &
-                               wavelengths, flux_cube, status)
-      character(len=*), intent(in) :: filename
-      real(dp), allocatable, intent(out) :: teff_grid(:), logg_grid(:), meta_grid(:)
-      real(dp), allocatable, intent(out) :: wavelengths(:)
-      real(dp), allocatable, intent(out) :: flux_cube(:, :, :, :)
-      integer, intent(out) :: status
+   ! fallback: build a 2x2x2 sub-cube from SED files, then trilinear-interpolate
+   ! unlike hermite, no derivative context needed -- stencil is exactly the 2x2x2 cell corners
+   subroutine construct_sed_from_files(rq, teff, log_g, metallicity, &
+                                       stellar_model_dir, interp_flux, wavelengths)
+      use colors_utils, only: resolve_path, build_grid_to_lu_map
+      type(Colors_General_Info), intent(inout) :: rq
+      real(dp), intent(in) :: teff, log_g, metallicity
+      character(len=*), intent(in) :: stellar_model_dir
+      real(dp), dimension(:), allocatable, intent(out) :: interp_flux, wavelengths
 
-      integer :: unit, n_teff, n_logg, n_meta, n_lambda
+      integer :: i_t, i_g, i_m   ! bracketing indices in unique grids
+      integer :: lo_t, hi_t, lo_g, hi_g, lo_m, hi_m   ! stencil bounds
+      integer :: nt, ng, nm, n_lambda
+      character(len=512) :: resolved_dir
+      logical :: need_reload
 
-      unit = 99
-      status = 0
+      resolved_dir = trim(resolve_path(stellar_model_dir))
 
-      ! Open the binary file
-      open (unit=unit, file=filename, status='OLD', ACCESS='STREAM', FORM='UNFORMATTED', iostat=status)
-      if (status /= 0) then
-         !print *, 'Error opening binary file:', trim(filename)
-         return
+      ! ensure the grid-to-lu mapping exists (built once, then reused)
+      if (.not. rq%grid_map_built) call build_grid_to_lu_map(rq)
+
+      ! find bracketing cell in the unique grids
+      call find_bracket_index(rq%u_teff, teff, i_t)
+      call find_bracket_index(rq%u_logg, log_g, i_g)
+      call find_bracket_index(rq%u_meta, metallicity, i_m)
+
+      ! check if the stencil cache is still valid for this cell
+      need_reload = .true.
+      if (rq%stencil_valid .and. &
+          i_t == rq%stencil_i_t .and. &
+          i_g == rq%stencil_i_g .and. &
+          i_m == rq%stencil_i_m) then
+         need_reload = .false.
       end if
 
-      ! Read dimensions
-      read (unit, iostat=status) n_teff, n_logg, n_meta, n_lambda
-      if (status /= 0) then
-         !print *, 'Error reading dimensions from binary file'
-         close (unit)
-         return
+      if (need_reload) then
+         ! trilinear needs exactly the 2x2x2 cell corners -- no extension
+         nt = size(rq%u_teff)
+         ng = size(rq%u_logg)
+         nm = size(rq%u_meta)
+
+         if (nt < 2) then
+            lo_t = 1; hi_t = 1
+         else
+            lo_t = i_t
+            hi_t = min(nt, i_t + 1)
+         end if
+
+         if (ng < 2) then
+            lo_g = 1; hi_g = 1
+         else
+            lo_g = i_g
+            hi_g = min(ng, i_g + 1)
+         end if
+
+         if (nm < 2) then
+            lo_m = 1; hi_m = 1
+         else
+            lo_m = i_m
+            hi_m = min(nm, i_m + 1)
+         end if
+
+         ! load SEDs for every stencil point (using memory cache)
+         call load_stencil(rq, resolved_dir, lo_t, hi_t, lo_g, hi_g, lo_m, hi_m)
+
+         ! store subgrid arrays on the handle
+         if (allocated(rq%stencil_teff)) deallocate (rq%stencil_teff)
+         if (allocated(rq%stencil_logg)) deallocate (rq%stencil_logg)
+         if (allocated(rq%stencil_meta)) deallocate (rq%stencil_meta)
+
+         allocate (rq%stencil_teff(hi_t - lo_t + 1))
+         allocate (rq%stencil_logg(hi_g - lo_g + 1))
+         allocate (rq%stencil_meta(hi_m - lo_m + 1))
+         rq%stencil_teff = rq%u_teff(lo_t:hi_t)
+         rq%stencil_logg = rq%u_logg(lo_g:hi_g)
+         rq%stencil_meta = rq%u_meta(lo_m:hi_m)
+
+         rq%stencil_i_t = i_t
+         rq%stencil_i_g = i_g
+         rq%stencil_i_m = i_m
+         rq%stencil_valid = .true.
       end if
 
-      ! Allocate arrays based on dimensions
-      allocate (teff_grid(n_teff), STAT=status)
-      if (status /= 0) then
-         !print *, 'Error allocating teff_grid array'
-         close (unit)
-         return
-      end if
+      n_lambda = size(rq%stencil_wavelengths)
+      allocate (wavelengths(n_lambda))
+      wavelengths = rq%stencil_wavelengths
 
-      allocate (logg_grid(n_logg), STAT=status)
-      if (status /= 0) then
-         !print *, 'Error allocating logg_grid array'
-         close (unit)
-         return
-      end if
+      allocate (interp_flux(n_lambda))
+      call trilinear_interp_vector(teff, log_g, metallicity, &
+                                   rq%stencil_teff, rq%stencil_logg, rq%stencil_meta, &
+                                   rq%stencil_fluxes, n_lambda, interp_flux)
 
-      allocate (meta_grid(n_meta), STAT=status)
-      if (status /= 0) then
-         !print *, 'Error allocating meta_grid array'
-         close (unit)
-         return
-      end if
+   end subroutine construct_sed_from_files
 
-      allocate (wavelengths(n_lambda), STAT=status)
-      if (status /= 0) then
-         !print *, 'Error allocating wavelengths array'
-         close (unit)
-         return
-      end if
-
-      allocate (flux_cube(n_teff, n_logg, n_meta, n_lambda), STAT=status)
-      if (status /= 0) then
-         !print *, 'Error allocating flux_cube array'
-         close (unit)
-         return
-      end if
-
-      ! Read grid arrays
-      read (unit, iostat=status) teff_grid
-      if (status /= 0) then
-         !print *, 'Error reading teff_grid'
-         GOTO 999  ! Cleanup and return
-      end if
-
-      read (unit, iostat=status) logg_grid
-      if (status /= 0) then
-         !print *, 'Error reading logg_grid'
-         GOTO 999  ! Cleanup and return
-      end if
-
-      read (unit, iostat=status) meta_grid
-      if (status /= 0) then
-         !print *, 'Error reading meta_grid'
-         GOTO 999  ! Cleanup and return
-      end if
-
-      read (unit, iostat=status) wavelengths
-      if (status /= 0) then
-         !print *, 'Error reading wavelengths'
-         GOTO 999  ! Cleanup and return
-      end if
-
-      ! Read flux cube
-      read (unit, iostat=status) flux_cube
-      if (status /= 0) then
-         !print *, 'Error reading flux_cube'
-         GOTO 999  ! Cleanup and return
-      end if
-
-      ! Close file and return success
-      close (unit)
-      return
-
-999   CONTINUE
-      ! Cleanup on error
-      close (unit)
-      return
-
-! After reading the grid arrays
-!print *, 'Teff grid min/max:', minval(teff_grid), maxval(teff_grid)
-!print *, 'logg grid min/max:', minval(logg_grid), maxval(logg_grid)
-!print *, 'meta grid min/max:', minval(meta_grid), maxval(meta_grid)
-
-   end subroutine load_binary_data
-
-   !---------------------------------------------------------------------------
-   ! Vectorized trilinear interpolation over all wavelengths.
-   ! The cell search and boundary clamping depend only on (teff, logg, meta)
-   ! and the sub-grids — not on wavelength. Computing them once and reusing
-   ! across all n_lambda samples eliminates redundant binary searches.
-   !---------------------------------------------------------------------------
+   ! vectorised trilinear interpolation over all wavelengths
+   ! cell location depends only on (teff, logg, meta) -- computed once, reused across n_lambda
    subroutine trilinear_interp_vector(x_val, y_val, z_val, &
-                                       x_grid, y_grid, z_grid, &
-                                       f_values_4d, n_lambda, result_flux)
+                                      x_grid, y_grid, z_grid, &
+                                      f_values_4d, n_lambda, result_flux)
       real(dp), intent(in) :: x_val, y_val, z_val
       real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
-      real(dp), intent(in) :: f_values_4d(:,:,:,:)   ! (nx, ny, nz, n_lambda)
+      real(dp), intent(in) :: f_values_4d(:, :, :, :)   ! (nx, ny, nz, n_lambda)
       integer, intent(in) :: n_lambda
       real(dp), intent(out) :: result_flux(n_lambda)
 
       integer :: i_x, i_y, i_z, lam
       real(dp) :: t_x, t_y, t_z
+      integer :: nx, ny, nz
       real(dp) :: c000, c001, c010, c011, c100, c101, c110, c111
       real(dp) :: c00, c01, c10, c11, c0, c1
-      real(dp) :: log_result, lin_result
+      real(dp) :: lin_result, log_result
       real(dp), parameter :: tiny_value = 1.0e-10_dp
 
-      ! find containing cell (done once for all wavelengths)
+      nx = size(x_grid)
+      ny = size(y_grid)
+      nz = size(z_grid)
+
+      ! locate the cell once
       call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
                                 i_x, i_y, i_z, t_x, t_y, t_z)
 
-      ! boundary clamping (done once for all wavelengths)
-      if (i_x < lbound(x_grid,1)) i_x = lbound(x_grid,1)
-      if (i_y < lbound(y_grid,1)) i_y = lbound(y_grid,1)
-      if (i_z < lbound(z_grid,1)) i_z = lbound(z_grid,1)
-      if (i_x >= ubound(x_grid,1)) i_x = ubound(x_grid,1) - 1
-      if (i_y >= ubound(y_grid,1)) i_y = ubound(y_grid,1) - 1
-      if (i_z >= ubound(z_grid,1)) i_z = ubound(z_grid,1) - 1
+      ! boundary safety check
+      if (i_x < 1) i_x = 1
+      if (i_y < 1) i_y = 1
+      if (i_z < 1) i_z = 1
+      if (i_x >= nx) i_x = max(1, nx - 1)
+      if (i_y >= ny) i_y = max(1, ny - 1)
+      if (i_z >= nz) i_z = max(1, nz - 1)
 
+      ! clamp interpolation parameters to [0,1]
       t_x = max(0.0_dp, min(1.0_dp, t_x))
       t_y = max(0.0_dp, min(1.0_dp, t_y))
       t_z = max(0.0_dp, min(1.0_dp, t_z))
 
-      ! loop over wavelengths — the hot loop
+      ! loop over wavelengths with the same cell location
       do lam = 1, n_lambda
-
-         c000 = max(tiny_value, f_values_4d(i_x,     i_y,     i_z,     lam))
-         c001 = max(tiny_value, f_values_4d(i_x,     i_y,     i_z + 1, lam))
-         c010 = max(tiny_value, f_values_4d(i_x,     i_y + 1, i_z,     lam))
-         c011 = max(tiny_value, f_values_4d(i_x,     i_y + 1, i_z + 1, lam))
-         c100 = max(tiny_value, f_values_4d(i_x + 1, i_y,     i_z,     lam))
-         c101 = max(tiny_value, f_values_4d(i_x + 1, i_y,     i_z + 1, lam))
-         c110 = max(tiny_value, f_values_4d(i_x + 1, i_y + 1, i_z,     lam))
+         ! get the 8 corners of the cube with safety floor
+         c000 = max(tiny_value, f_values_4d(i_x, i_y, i_z, lam))
+         c001 = max(tiny_value, f_values_4d(i_x, i_y, i_z + 1, lam))
+         c010 = max(tiny_value, f_values_4d(i_x, i_y + 1, i_z, lam))
+         c011 = max(tiny_value, f_values_4d(i_x, i_y + 1, i_z + 1, lam))
+         c100 = max(tiny_value, f_values_4d(i_x + 1, i_y, i_z, lam))
+         c101 = max(tiny_value, f_values_4d(i_x + 1, i_y, i_z + 1, lam))
+         c110 = max(tiny_value, f_values_4d(i_x + 1, i_y + 1, i_z, lam))
          c111 = max(tiny_value, f_values_4d(i_x + 1, i_y + 1, i_z + 1, lam))
 
-         ! linear interpolation first (safer)
+         ! standard linear interpolation first (safer)
          c00 = c000*(1.0_dp - t_x) + c100*t_x
          c01 = c001*(1.0_dp - t_x) + c101*t_x
          c10 = c010*(1.0_dp - t_x) + c110*t_x
          c11 = c011*(1.0_dp - t_x) + c111*t_x
-         c0  = c00*(1.0_dp - t_y)  + c10*t_y
-         c1  = c01*(1.0_dp - t_y)  + c11*t_y
+
+         c0 = c00*(1.0_dp - t_y) + c10*t_y
+         c1 = c01*(1.0_dp - t_y) + c11*t_y
+
          lin_result = c0*(1.0_dp - t_z) + c1*t_z
 
-         ! if valid, try log-space interpolation
+         ! if valid, try log-space interpolation (smoother for flux)
          if (lin_result > tiny_value) then
             c00 = log(c000)*(1.0_dp - t_x) + log(c100)*t_x
             c01 = log(c001)*(1.0_dp - t_x) + log(c101)*t_x
             c10 = log(c010)*(1.0_dp - t_x) + log(c110)*t_x
             c11 = log(c011)*(1.0_dp - t_x) + log(c111)*t_x
-            c0  = c00*(1.0_dp - t_y) + c10*t_y
-            c1  = c01*(1.0_dp - t_y) + c11*t_y
+
+            c0 = c00*(1.0_dp - t_y) + c10*t_y
+            c1 = c01*(1.0_dp - t_y) + c11*t_y
+
             log_result = c0*(1.0_dp - t_z) + c1*t_z
-            if (log_result == log_result) lin_result = exp(log_result)  ! NaN check
+
+            ! only use log-space result if valid
+            if (log_result == log_result) then  ! NaN check
+               lin_result = exp(log_result)
+            end if
          end if
 
-         ! final sanity check — fall back to nearest neighbour if still bad
+         ! final sanity check -- fall back to nearest neighbour
          if (lin_result /= lin_result .or. lin_result <= 0.0_dp) then
             call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
                                     i_x, i_y, i_z)
@@ -307,20 +258,17 @@ contains
          end if
 
          result_flux(lam) = lin_result
-
       end do
 
    end subroutine trilinear_interp_vector
 
-   !---------------------------------------------------------------------------
-   ! Log-space trilinear interpolation function with normalization
-   !---------------------------------------------------------------------------
+   ! scalar trilinear interpolation (external callers / single-wavelength use)
+   ! retained for backward compatibility
    function trilinear_interp(x_val, y_val, z_val, x_grid, y_grid, z_grid, f_values) result(f_interp)
       real(dp), intent(in) :: x_val, y_val, z_val
       real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
       real(dp), intent(in) :: f_values(:, :, :)
       real(dp) :: f_interp
-      ! Compute log-space result
       real(dp) :: log_result
       integer :: i_x, i_y, i_z
       real(dp) :: t_x, t_y, t_z
@@ -328,24 +276,24 @@ contains
       real(dp) :: c00, c01, c10, c11, c0, c1
       real(dp), parameter :: tiny_value = 1.0e-10_dp
 
-      ! Find containing cell and parameter values using binary search
+      ! find containing cell and parameter values using binary search
       call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
                                 i_x, i_y, i_z, t_x, t_y, t_z)
 
-      ! Boundary safety check
-      if (i_x < lbound(x_grid,1)) i_x = lbound(x_grid,1)
-      if (i_y < lbound(y_grid,1)) i_y = lbound(y_grid,1)
-      if (i_z < lbound(z_grid,1)) i_z = lbound(z_grid,1)
-      if (i_x >= ubound(x_grid,1)) i_x = ubound(x_grid,1) - 1
-      if (i_y >= ubound(y_grid,1)) i_y = ubound(y_grid,1) - 1
-      if (i_z >= ubound(z_grid,1)) i_z = ubound(z_grid,1) - 1
+      ! boundary safety check
+      if (i_x < lbound(x_grid, 1)) i_x = lbound(x_grid, 1)
+      if (i_y < lbound(y_grid, 1)) i_y = lbound(y_grid, 1)
+      if (i_z < lbound(z_grid, 1)) i_z = lbound(z_grid, 1)
+      if (i_x >= ubound(x_grid, 1)) i_x = ubound(x_grid, 1) - 1
+      if (i_y >= ubound(y_grid, 1)) i_y = ubound(y_grid, 1) - 1
+      if (i_z >= ubound(z_grid, 1)) i_z = ubound(z_grid, 1) - 1
 
-      ! Force interpolation parameters to be in [0,1]
+      ! clamp interpolation parameters to [0,1]
       t_x = max(0.0_dp, MIN(1.0_dp, t_x))
       t_y = max(0.0_dp, MIN(1.0_dp, t_y))
       t_z = max(0.0_dp, MIN(1.0_dp, t_z))
 
-      ! Get the corners of the cube with safety checks
+      ! get the corners of the cube with safety checks
       c000 = max(tiny_value, f_values(i_x, i_y, i_z))
       c001 = max(tiny_value, f_values(i_x, i_y, i_z + 1))
       c010 = max(tiny_value, f_values(i_x, i_y + 1, i_z))
@@ -355,7 +303,7 @@ contains
       c110 = max(tiny_value, f_values(i_x + 1, i_y + 1, i_z))
       c111 = max(tiny_value, f_values(i_x + 1, i_y + 1, i_z + 1))
 
-      ! Try standard linear interpolation first (safer)
+      ! try standard linear interpolation first (safer)
       c00 = c000*(1.0_dp - t_x) + c100*t_x
       c01 = c001*(1.0_dp - t_x) + c101*t_x
       c10 = c010*(1.0_dp - t_x) + c110*t_x
@@ -366,9 +314,8 @@ contains
 
       f_interp = c0*(1.0_dp - t_z) + c1*t_z
 
-      ! If the linear result is valid and non-zero, try log space
+      ! if valid, try log-space interpolation (smoother for flux)
       if (f_interp > tiny_value) then
-         ! Perform log-space interpolation
          c00 = log(c000)*(1.0_dp - t_x) + log(c100)*t_x
          c01 = log(c001)*(1.0_dp - t_x) + log(c101)*t_x
          c10 = log(c010)*(1.0_dp - t_x) + log(c110)*t_x
@@ -379,133 +326,17 @@ contains
 
          log_result = c0*(1.0_dp - t_z) + c1*t_z
 
-         ! Only use the log-space result if it's valid
+         ! only use the log-space result if it's valid
          if (log_result == log_result) then  ! NaN check
             f_interp = EXP(log_result)
          end if
       end if
 
-      ! Final sanity check
+      ! final sanity check
       if (f_interp /= f_interp .or. f_interp <= 0.0_dp) then
-         ! If we somehow still got an invalid result, use nearest neighbor
          call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, i_x, i_y, i_z)
          f_interp = max(tiny_value, f_values(i_x, i_y, i_z))
       end if
    end function trilinear_interp
-
-   !---------------------------------------------------------------------------
-   ! Find the cell containing the interpolation point
-   !---------------------------------------------------------------------------
-   subroutine find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
-                                   i_x, i_y, i_z, t_x, t_y, t_z)
-      real(dp), intent(in) :: x_val, y_val, z_val
-      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
-      integer, intent(out) :: i_x, i_y, i_z
-      real(dp), intent(out) :: t_x, t_y, t_z
-
-      ! Find x interval
-      call find_interval(x_grid, x_val, i_x, t_x)
-
-      ! Find y interval
-      call find_interval(y_grid, y_val, i_y, t_y)
-
-      ! Find z interval
-      call find_interval(z_grid, z_val, i_z, t_z)
-   end subroutine find_containing_cell
-
-   !---------------------------------------------------------------------------
-   ! Find the interval in a sorted array containing a value
-   !---------------------------------------------------------------------------
-   subroutine find_interval(x, val, i, t)
-      real(dp), intent(in) :: x(:), val
-      integer, intent(out) :: i
-      real(dp), intent(out) :: t
-
-      integer :: n, lo, hi, mid
-      logical :: dummy_axis
-
-      n = size(x)
-
-      ! Detect dummy axis
-      dummy_axis = all(x == 0.0_dp) .or. all(x == 999.0_dp) .or. all(x == -999.0_dp)
-
-      if (dummy_axis) then
-         ! Collapse: use the first element of the axis, no interpolation
-         i = 1
-         t = 0.0_dp
-         return
-      end if
-
-      ! --- ORIGINAL CODE BELOW ---
-      if (val <= x(1)) then
-         i = 1
-         t = 0.0_dp
-         return
-      else if (val >= x(n)) then
-         i = n - 1
-         t = 1.0_dp
-         return
-      end if
-
-      lo = 1
-      hi = n
-      do while (hi - lo > 1)
-         mid = (lo + hi)/2
-         if (val >= x(mid)) then
-            lo = mid
-         else
-            hi = mid
-         end if
-      end do
-
-      i = lo
-      t = (val - x(i))/(x(i + 1) - x(i))
-   end subroutine find_interval
-
-   !---------------------------------------------------------------------------
-   ! Find the nearest grid point
-   !---------------------------------------------------------------------------
-   subroutine find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
-                                 i_x, i_y, i_z)
-      real(dp), intent(in) :: x_val, y_val, z_val
-      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
-      integer, intent(out) :: i_x, i_y, i_z
-
-      integer :: i
-      real(dp) :: min_dist, dist
-
-      ! Find nearest x grid point
-      min_dist = abs(x_val - x_grid(1))
-      i_x = 1
-      do i = 2, size(x_grid)
-         dist = abs(x_val - x_grid(i))
-         if (dist < min_dist) then
-            min_dist = dist
-            i_x = i
-         end if
-      end do
-
-      ! Find nearest y grid point
-      min_dist = abs(y_val - y_grid(1))
-      i_y = 1
-      do i = 2, size(y_grid)
-         dist = abs(y_val - y_grid(i))
-         if (dist < min_dist) then
-            min_dist = dist
-            i_y = i
-         end if
-      end do
-
-      ! Find nearest z grid point
-      min_dist = abs(z_val - z_grid(1))
-      i_z = 1
-      do i = 2, size(z_grid)
-         dist = abs(z_val - z_grid(i))
-         if (dist < min_dist) then
-            min_dist = dist
-            i_z = i
-         end if
-      end do
-   end subroutine find_nearest_point
 
 end module linear_interp

--- a/colors/private/linear_interp.f90
+++ b/colors/private/linear_interp.f90
@@ -28,7 +28,7 @@ module linear_interp
    implicit none
 
    private
-   public :: construct_sed_linear, trilinear_interp
+   public :: construct_sed_linear, trilinear_interp, trilinear_interp_vector
 
 contains
 
@@ -46,10 +46,9 @@ contains
       character(len=100), intent(in) :: file_names(:)
       real(dp), dimension(:), allocatable, intent(out) :: wavelengths, fluxes
 
-      integer :: i, n_lambda, status, n_teff, n_logg, n_meta
+      integer :: n_lambda, status, n_teff, n_logg, n_meta
       real(dp), dimension(:), allocatable :: interp_flux, diluted_flux
       real(dp), dimension(:, :, :, :), allocatable :: precomputed_flux_cube
-      real(dp), dimension(:, :, :), allocatable :: flux_cube_lambda
       real(dp) :: min_flux, max_flux, mean_flux, progress_pct
 
       ! Parameter grids
@@ -89,21 +88,13 @@ contains
 
       ! Allocate space for interpolated flux
       allocate (interp_flux(n_lambda))
-      allocate (flux_cube_lambda(n_teff, n_logg, n_meta))
 
-      ! Perform trilinear interpolation for each wavelength
-      do i = 1, n_lambda
-
-         ! Extract the 3D grid for this wavelength
-         flux_cube_lambda = precomputed_flux_cube(:, :, :, i)
-
-         ! Simple trilinear interpolation at the target parameters
-         interp_flux(i) = trilinear_interp(teff, log_g, metallicity, &
-                                           teff_grid, logg_grid, meta_grid, flux_cube_lambda)
-      end do
-
-
-      deallocate(flux_cube_lambda)
+      ! Interpolate all wavelengths in one call — cell search and boundary
+      ! clamping are performed once and reused across the wavelength loop
+      ! inside the subroutine
+      call trilinear_interp_vector(teff, log_g, metallicity, &
+                                   teff_grid, logg_grid, meta_grid, &
+                                   precomputed_flux_cube, n_lambda, interp_flux)
 
       ! Calculate statistics for validation
       min_flux = minval(interp_flux)
@@ -238,11 +229,92 @@ contains
    end subroutine load_binary_data
 
    !---------------------------------------------------------------------------
-   ! Simple trilinear interpolation function
+   ! Vectorized trilinear interpolation over all wavelengths.
+   ! The cell search and boundary clamping depend only on (teff, logg, meta)
+   ! and the sub-grids — not on wavelength. Computing them once and reusing
+   ! across all n_lambda samples eliminates redundant binary searches.
    !---------------------------------------------------------------------------
-!---------------------------------------------------------------------------
-! Log-space trilinear interpolation function with normalization
-!---------------------------------------------------------------------------
+   subroutine trilinear_interp_vector(x_val, y_val, z_val, &
+                                       x_grid, y_grid, z_grid, &
+                                       f_values_4d, n_lambda, result_flux)
+      real(dp), intent(in) :: x_val, y_val, z_val
+      real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)
+      real(dp), intent(in) :: f_values_4d(:,:,:,:)   ! (nx, ny, nz, n_lambda)
+      integer, intent(in) :: n_lambda
+      real(dp), intent(out) :: result_flux(n_lambda)
+
+      integer :: i_x, i_y, i_z, lam
+      real(dp) :: t_x, t_y, t_z
+      real(dp) :: c000, c001, c010, c011, c100, c101, c110, c111
+      real(dp) :: c00, c01, c10, c11, c0, c1
+      real(dp) :: log_result, lin_result
+      real(dp), parameter :: tiny_value = 1.0e-10_dp
+
+      ! find containing cell (done once for all wavelengths)
+      call find_containing_cell(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                i_x, i_y, i_z, t_x, t_y, t_z)
+
+      ! boundary clamping (done once for all wavelengths)
+      if (i_x < lbound(x_grid,1)) i_x = lbound(x_grid,1)
+      if (i_y < lbound(y_grid,1)) i_y = lbound(y_grid,1)
+      if (i_z < lbound(z_grid,1)) i_z = lbound(z_grid,1)
+      if (i_x >= ubound(x_grid,1)) i_x = ubound(x_grid,1) - 1
+      if (i_y >= ubound(y_grid,1)) i_y = ubound(y_grid,1) - 1
+      if (i_z >= ubound(z_grid,1)) i_z = ubound(z_grid,1) - 1
+
+      t_x = max(0.0_dp, min(1.0_dp, t_x))
+      t_y = max(0.0_dp, min(1.0_dp, t_y))
+      t_z = max(0.0_dp, min(1.0_dp, t_z))
+
+      ! loop over wavelengths — the hot loop
+      do lam = 1, n_lambda
+
+         c000 = max(tiny_value, f_values_4d(i_x,     i_y,     i_z,     lam))
+         c001 = max(tiny_value, f_values_4d(i_x,     i_y,     i_z + 1, lam))
+         c010 = max(tiny_value, f_values_4d(i_x,     i_y + 1, i_z,     lam))
+         c011 = max(tiny_value, f_values_4d(i_x,     i_y + 1, i_z + 1, lam))
+         c100 = max(tiny_value, f_values_4d(i_x + 1, i_y,     i_z,     lam))
+         c101 = max(tiny_value, f_values_4d(i_x + 1, i_y,     i_z + 1, lam))
+         c110 = max(tiny_value, f_values_4d(i_x + 1, i_y + 1, i_z,     lam))
+         c111 = max(tiny_value, f_values_4d(i_x + 1, i_y + 1, i_z + 1, lam))
+
+         ! linear interpolation first (safer)
+         c00 = c000*(1.0_dp - t_x) + c100*t_x
+         c01 = c001*(1.0_dp - t_x) + c101*t_x
+         c10 = c010*(1.0_dp - t_x) + c110*t_x
+         c11 = c011*(1.0_dp - t_x) + c111*t_x
+         c0  = c00*(1.0_dp - t_y)  + c10*t_y
+         c1  = c01*(1.0_dp - t_y)  + c11*t_y
+         lin_result = c0*(1.0_dp - t_z) + c1*t_z
+
+         ! if valid, try log-space interpolation
+         if (lin_result > tiny_value) then
+            c00 = log(c000)*(1.0_dp - t_x) + log(c100)*t_x
+            c01 = log(c001)*(1.0_dp - t_x) + log(c101)*t_x
+            c10 = log(c010)*(1.0_dp - t_x) + log(c110)*t_x
+            c11 = log(c011)*(1.0_dp - t_x) + log(c111)*t_x
+            c0  = c00*(1.0_dp - t_y) + c10*t_y
+            c1  = c01*(1.0_dp - t_y) + c11*t_y
+            log_result = c0*(1.0_dp - t_z) + c1*t_z
+            if (log_result == log_result) lin_result = exp(log_result)  ! NaN check
+         end if
+
+         ! final sanity check — fall back to nearest neighbour if still bad
+         if (lin_result /= lin_result .or. lin_result <= 0.0_dp) then
+            call find_nearest_point(x_val, y_val, z_val, x_grid, y_grid, z_grid, &
+                                    i_x, i_y, i_z)
+            lin_result = max(tiny_value, f_values_4d(i_x, i_y, i_z, lam))
+         end if
+
+         result_flux(lam) = lin_result
+
+      end do
+
+   end subroutine trilinear_interp_vector
+
+   !---------------------------------------------------------------------------
+   ! Log-space trilinear interpolation function with normalization
+   !---------------------------------------------------------------------------
    function trilinear_interp(x_val, y_val, z_val, x_grid, y_grid, z_grid, f_values) result(f_interp)
       real(dp), intent(in) :: x_val, y_val, z_val
       real(dp), intent(in) :: x_grid(:), y_grid(:), z_grid(:)

--- a/colors/private/synthetic.f90
+++ b/colors/private/synthetic.f90
@@ -28,21 +28,16 @@ module synthetic
 
    private
    public :: calculate_synthetic
-   ! Export zero-point computation functions for precomputation at initialization
    public :: compute_vega_zero_point, compute_ab_zero_point, compute_st_zero_point
 
 contains
 
-   !****************************
-   ! Calculate Synthetic Photometry Using SED and Filter
-   ! Uses precomputed zero-point from filter data
-   !****************************
+   ! calculate synthetic magnitude; uses precomputed zero-point from filter_data
    real(dp) function calculate_synthetic(temperature, gravity, metallicity, ierr, &
                                          wavelengths, fluxes, &
                                          filter_wavelengths, filter_trans, &
                                          zero_point_flux, &
-                                         filter_name, make_sed, colors_results_directory)
-      ! Input arguments
+                                         filter_name, make_sed, sed_per_model, colors_results_directory, model_number)
       real(dp), intent(in) :: temperature, gravity, metallicity
       character(len=*), intent(in) :: filter_name, colors_results_directory
       integer, intent(out) :: ierr
@@ -50,11 +45,12 @@ contains
       real(dp), dimension(:), intent(in) :: wavelengths, fluxes
       real(dp), dimension(:), intent(in) :: filter_wavelengths, filter_trans
       real(dp), intent(in) :: zero_point_flux  ! precomputed at initialization
-      logical, intent(in) :: make_sed
+      logical, intent(in) :: make_sed, sed_per_model
+      integer, intent(in) :: model_number
 
-      ! Local variables
       real(dp), dimension(:), allocatable :: convolved_flux, filter_on_sed_grid
       character(len=256) :: csv_file
+      character(len=20) :: model_str
       character(len=1000) :: line
       real(dp) :: synthetic_flux
       integer :: max_size, i
@@ -62,27 +58,33 @@ contains
 
       ierr = 0
 
-      ! Allocate working arrays
-      allocate(convolved_flux(size(wavelengths)))
-      allocate(filter_on_sed_grid(size(wavelengths)))
+      allocate (convolved_flux(size(wavelengths)))
+      allocate (filter_on_sed_grid(size(wavelengths)))
 
-      ! Interpolate filter onto SED wavelength grid
       call interpolate_array(filter_wavelengths, filter_trans, wavelengths, filter_on_sed_grid)
 
-      ! Convolve SED with filter
-      convolved_flux = fluxes * filter_on_sed_grid
+      convolved_flux = fluxes*filter_on_sed_grid
 
-      ! Write SED to CSV if requested
       if (make_sed) then
          if (.not. folder_exists(trim(colors_results_directory))) call mkdir(trim(colors_results_directory))
-         csv_file = trim(colors_results_directory)//'/'//trim(remove_dat(filter_name))//'_SED.csv'
+
+         ! track model number internally when write_sed_per_model is enabled
+         if (sed_per_model) then
+
+            write (model_str, '(I8.8)') model_number
+            csv_file = trim(colors_results_directory)//'/'//trim(remove_dat(filter_name))//'_SED_'//trim(model_str)//'.csv'
+
+         else
+            csv_file = trim(colors_results_directory)//'/'//trim(remove_dat(filter_name))//'_SED.csv'
+         end if
 
          max_size = max(size(wavelengths), size(filter_wavelengths))
 
          open (unit=10, file=csv_file, status='REPLACE', action='write', iostat=ierr)
          if (ierr /= 0) then
             print *, "Error opening file for writing"
-            deallocate(convolved_flux, filter_on_sed_grid)
+            deallocate (convolved_flux, filter_on_sed_grid)
+            calculate_synthetic = huge(1.0_dp)
             return
          end if
 
@@ -103,12 +105,10 @@ contains
          close (10)
       end if
 
-      ! Calculate synthetic flux using photon-counting integration
       call calculate_synthetic_flux(wavelengths, convolved_flux, filter_on_sed_grid, synthetic_flux)
 
-      ! Calculate magnitude
       if (zero_point_flux > 0.0_dp .and. synthetic_flux > 0.0_dp) then
-         calculate_synthetic = -2.5d0 * log10(synthetic_flux / zero_point_flux)
+         calculate_synthetic = -2.5d0*log10(synthetic_flux/zero_point_flux)
       else
          if (zero_point_flux <= 0.0_dp) then
             print *, "Error: Zero point flux is zero or negative for filter ", trim(filter_name)
@@ -119,34 +119,29 @@ contains
          calculate_synthetic = huge(1.0_dp)
       end if
 
-      deallocate(convolved_flux, filter_on_sed_grid)
+      deallocate (convolved_flux, filter_on_sed_grid)
    end function calculate_synthetic
 
-   !****************************
-   ! Calculate Synthetic Flux (photon-counting integration)
-   !****************************
+   ! photon-counting synthetic flux (numerator and denominator weighted by lambda)
    subroutine calculate_synthetic_flux(wavelengths, convolved_flux, filter_on_sed_grid, synthetic_flux)
       real(dp), dimension(:), intent(in) :: wavelengths, convolved_flux, filter_on_sed_grid
       real(dp), intent(out) :: synthetic_flux
 
       real(dp) :: integrated_flux, integrated_filter
 
-      ! Photon-counting: weight by wavelength
-      call simpson_integration(wavelengths, convolved_flux * wavelengths, integrated_flux)
-      call simpson_integration(wavelengths, filter_on_sed_grid * wavelengths, integrated_filter)
+      ! photon-counting: weight by wavelength
+      call simpson_integration(wavelengths, convolved_flux*wavelengths, integrated_flux)
+      call simpson_integration(wavelengths, filter_on_sed_grid*wavelengths, integrated_filter)
 
       if (integrated_filter > 0.0_dp) then
-         synthetic_flux = integrated_flux / integrated_filter
+         synthetic_flux = integrated_flux/integrated_filter
       else
          print *, "Error: Integrated filter transmission is zero."
          synthetic_flux = -1.0_dp
       end if
    end subroutine calculate_synthetic_flux
 
-   !****************************
-   ! Compute Vega Zero Point Flux
-   ! Called once at initialization, result cached in filter_data
-   !****************************
+   ! vega zero-point -- called once at init, result cached in filter_data
    real(dp) function compute_vega_zero_point(vega_wave, vega_flux, filt_wave, filt_trans)
       real(dp), dimension(:), intent(in) :: vega_wave, vega_flux
       real(dp), dimension(:), intent(in) :: filt_wave, filt_trans
@@ -154,34 +149,28 @@ contains
       real(dp) :: int_flux, int_filter
       real(dp), allocatable :: filt_on_vega_grid(:), conv_flux(:)
 
-      allocate(filt_on_vega_grid(size(vega_wave)))
-      allocate(conv_flux(size(vega_wave)))
+      allocate (filt_on_vega_grid(size(vega_wave)))
+      allocate (conv_flux(size(vega_wave)))
 
-      ! Interpolate filter onto Vega wavelength grid
       call interpolate_array(filt_wave, filt_trans, vega_wave, filt_on_vega_grid)
 
-      ! Convolve Vega with filter
-      conv_flux = vega_flux * filt_on_vega_grid
+      conv_flux = vega_flux*filt_on_vega_grid
 
-      ! Photon-counting integration
-      call simpson_integration(vega_wave, vega_wave * conv_flux, int_flux)
-      call simpson_integration(vega_wave, vega_wave * filt_on_vega_grid, int_filter)
+      ! photon-counting integration
+      call simpson_integration(vega_wave, vega_wave*conv_flux, int_flux)
+      call simpson_integration(vega_wave, vega_wave*filt_on_vega_grid, int_filter)
 
       if (int_filter > 0.0_dp) then
-         compute_vega_zero_point = int_flux / int_filter
+         compute_vega_zero_point = int_flux/int_filter
       else
          compute_vega_zero_point = -1.0_dp
       end if
 
-      deallocate(filt_on_vega_grid, conv_flux)
+      deallocate (filt_on_vega_grid, conv_flux)
    end function compute_vega_zero_point
 
-   !****************************
-   ! Compute AB Zero Point Flux
-   ! f_nu = 3631 Jy = 3.631e-20 erg/s/cm^2/Hz
-   ! f_lambda = f_nu * c / lambda^2
-   ! Called once at initialization, result cached in filter_data
-   !****************************
+   ! ab zero-point -- f_nu = 3631 Jy, converted to f_lambda = f_nu * c / lambda^2
+   ! called once at init, result cached in filter_data
    real(dp) function compute_ab_zero_point(filt_wave, filt_trans)
       real(dp), dimension(:), intent(in) :: filt_wave, filt_trans
 
@@ -189,57 +178,53 @@ contains
       real(dp), allocatable :: ab_sed_flux(:)
       integer :: i
 
-      allocate(ab_sed_flux(size(filt_wave)))
+      allocate (ab_sed_flux(size(filt_wave)))
 
-      ! Construct AB spectrum (f_lambda) on the filter wavelength grid
-      ! 3631 Jy = 3.631E-20 erg/s/cm^2/Hz
-      ! clight in cm/s, wavelength in Angstroms, need to convert
+      ! construct ab spectrum (f_lambda) on the filter wavelength grid
+      ! 3631 Jy = 3.631e-20 erg/s/cm^2/Hz; clight in cm/s, wavelength in angstroms
       do i = 1, size(filt_wave)
          if (filt_wave(i) > 0.0_dp) then
-            ab_sed_flux(i) = 3.631d-20 * ((clight * 1.0d8) / (filt_wave(i)**2))
+            ab_sed_flux(i) = 3.631d-20*((clight*1.0d8)/(filt_wave(i)**2))
          else
             ab_sed_flux(i) = 0.0_dp
          end if
       end do
 
-      ! Photon-counting integration
-      call simpson_integration(filt_wave, ab_sed_flux * filt_trans * filt_wave, int_flux)
-      call simpson_integration(filt_wave, filt_wave * filt_trans, int_filter)
+      ! photon-counting integration
+      call simpson_integration(filt_wave, ab_sed_flux*filt_trans*filt_wave, int_flux)
+      call simpson_integration(filt_wave, filt_wave*filt_trans, int_filter)
 
       if (int_filter > 0.0_dp) then
-         compute_ab_zero_point = int_flux / int_filter
+         compute_ab_zero_point = int_flux/int_filter
       else
          compute_ab_zero_point = -1.0_dp
       end if
 
-      deallocate(ab_sed_flux)
+      deallocate (ab_sed_flux)
    end function compute_ab_zero_point
 
-   !****************************
-   ! Compute ST Zero Point Flux
-   ! f_lambda = 3.63e-9 erg/s/cm^2/A (Constant)
-   ! Called once at initialization, result cached in filter_data
-   !****************************
+   ! st zero-point -- f_lambda = 3.63e-9 erg/s/cm^2/A (flat spectrum)
+   ! called once at init, result cached in filter_data
    real(dp) function compute_st_zero_point(filt_wave, filt_trans)
       real(dp), dimension(:), intent(in) :: filt_wave, filt_trans
 
       real(dp) :: int_flux, int_filter
       real(dp), allocatable :: st_sed_flux(:)
 
-      allocate(st_sed_flux(size(filt_wave)))
+      allocate (st_sed_flux(size(filt_wave)))
       st_sed_flux = 3.63d-9
 
-      ! Photon-counting integration
-      call simpson_integration(filt_wave, st_sed_flux * filt_trans * filt_wave, int_flux)
-      call simpson_integration(filt_wave, filt_wave * filt_trans, int_filter)
+      ! photon-counting integration
+      call simpson_integration(filt_wave, st_sed_flux*filt_trans*filt_wave, int_flux)
+      call simpson_integration(filt_wave, filt_wave*filt_trans, int_filter)
 
       if (int_filter > 0.0_dp) then
-         compute_st_zero_point = int_flux / int_filter
+         compute_st_zero_point = int_flux/int_filter
       else
          compute_st_zero_point = -1.0_dp
       end if
 
-      deallocate(st_sed_flux)
+      deallocate (st_sed_flux)
    end function compute_st_zero_point
 
 end module synthetic

--- a/colors/public/colors_def.f90
+++ b/colors/public/colors_def.f90
@@ -23,21 +23,24 @@ module colors_def
 
    implicit none
 
-   ! Make everything in this module public by default
    public
 
-   ! Type to hold individual filter data
+   ! max number of SEDs to keep in the memory cache
+   ! each slot holds one wavelength array (~1200 doubles ~ 10 KB),
+   ! so 256 slots ~ 2.5 MB -- negligible even when the full cube
+   ! cannot be allocated
+   integer, parameter :: sed_mem_cache_cap = 256
+
    type :: filter_data
       character(len=100) :: name
       real(dp), allocatable :: wavelengths(:)
       real(dp), allocatable :: transmission(:)
-      ! Precomputed zero-point fluxes (computed once at initialization)
+      ! precomputed zero-point fluxes, computed once at init
       real(dp) :: vega_zero_point = -1.0_dp
       real(dp) :: ab_zero_point = -1.0_dp
       real(dp) :: st_zero_point = -1.0_dp
    end type filter_data
 
-   ! Colors Module control parameters
    type :: Colors_General_Info
       character(len=256) :: instrument
       character(len=256) :: vega_sed
@@ -47,25 +50,72 @@ module colors_def
       real(dp) :: metallicity
       real(dp) :: distance
       logical :: make_csv
+      logical :: sed_per_model
       logical :: use_colors
       integer :: handle
       logical :: in_use
 
-      ! Cached lookup table data
+      ! cached lookup table data
       logical :: lookup_loaded = .false.
       character(len=100), allocatable :: lu_file_names(:)
       real(dp), allocatable :: lu_logg(:)
       real(dp), allocatable :: lu_meta(:)
       real(dp), allocatable :: lu_teff(:)
 
-      ! Cached Vega SED
+      ! cached vega SED
       logical :: vega_loaded = .false.
       real(dp), allocatable :: vega_wavelengths(:)
       real(dp), allocatable :: vega_fluxes(:)
 
-      ! Cached filter data (includes precomputed zero-points)
+      ! cached filter data (includes precomputed zero-points)
       logical :: filters_loaded = .false.
       type(filter_data), allocatable :: filters(:)
+
+      ! cached flux cube
+      logical :: cube_loaded = .false.
+      real(dp), allocatable :: cube_flux(:, :, :, :)    ! (n_teff, n_logg, n_meta, n_lambda)
+      real(dp), allocatable :: cube_teff_grid(:)
+      real(dp), allocatable :: cube_logg_grid(:)
+      real(dp), allocatable :: cube_meta_grid(:)
+      real(dp), allocatable :: cube_wavelengths(:)
+
+      ! unique sorted grids (built once from lookup table at init)
+      logical :: unique_grids_built = .false.
+      real(dp), allocatable :: u_teff(:), u_logg(:), u_meta(:)
+
+      ! grid_to_lu(i_t, i_g, i_m) gives the lookup-table row index for
+      ! (u_teff(i_t), u_logg(i_g), u_meta(i_m)) -- avoids O(n_lu)
+      ! nearest-neighbour searches at runtime
+      logical :: grid_map_built = .false.
+      integer, allocatable :: grid_to_lu(:, :, :)
+
+      ! fallback-path caches (used only when cube_loaded == .false.)
+
+      ! stencil cache: the extended neighbourhood around the current
+      ! interpolation cell, includes derivative-context points
+      ! (i-1 .. i+2 per axis, clamped to boundaries) so that
+      ! hermite_tensor_interp3d gives the same result as the cube path
+      logical :: stencil_valid = .false.
+      integer :: stencil_i_t = -1, stencil_i_g = -1, stencil_i_m = -1
+      real(dp), allocatable :: stencil_fluxes(:, :, :, :)   ! (st, sg, sm, n_lambda)
+      real(dp), allocatable :: stencil_wavelengths(:)     ! (n_lambda)
+      real(dp), allocatable :: stencil_teff(:)            ! subgrid values (st)
+      real(dp), allocatable :: stencil_logg(:)            ! subgrid values (sg)
+      real(dp), allocatable :: stencil_meta(:)            ! subgrid values (sm)
+
+      ! canonical wavelength grid for fallback SEDs (set once on first disk
+      ! read -- all SEDs in a given atmosphere grid share the same wavelengths)
+      logical :: fallback_wavelengths_set = .false.
+      real(dp), allocatable :: fallback_wavelengths(:)    ! (n_lambda)
+
+      ! bounded SED memory cache (circular buffer, keyed by lu index)
+      ! avoids re-reading text files for SEDs we've already parsed
+      logical :: sed_mcache_init = .false.
+      integer :: sed_mcache_count = 0
+      integer :: sed_mcache_next = 1
+      integer :: sed_mcache_nlam = 0
+      integer, allocatable :: sed_mcache_keys(:)          ! (sed_mem_cache_cap)
+      real(dp), allocatable :: sed_mcache_data(:, :)       ! (n_lambda, sed_mem_cache_cap)
 
    end type Colors_General_Info
 
@@ -104,6 +154,18 @@ contains
          colors_handles(i)%lookup_loaded = .false.
          colors_handles(i)%vega_loaded = .false.
          colors_handles(i)%filters_loaded = .false.
+         colors_handles(i)%cube_loaded = .false.
+         colors_handles(i)%unique_grids_built = .false.
+         colors_handles(i)%grid_map_built = .false.
+         colors_handles(i)%stencil_valid = .false.
+         colors_handles(i)%stencil_i_t = -1
+         colors_handles(i)%stencil_i_g = -1
+         colors_handles(i)%stencil_i_m = -1
+         colors_handles(i)%sed_mcache_init = .false.
+         colors_handles(i)%sed_mcache_count = 0
+         colors_handles(i)%sed_mcache_next = 1
+         colors_handles(i)%sed_mcache_nlam = 0
+         colors_handles(i)%fallback_wavelengths_set = .false.
       end do
 
       colors_temp_cache_dir = trim(mesa_temp_caches_dir)//'/colors_cache'
@@ -149,35 +211,84 @@ contains
 
       if (handle < 1 .or. handle > max_colors_handles) return
 
-      ! Free lookup table arrays
       if (allocated(colors_handles(handle)%lu_file_names)) &
-         deallocate(colors_handles(handle)%lu_file_names)
+         deallocate (colors_handles(handle)%lu_file_names)
       if (allocated(colors_handles(handle)%lu_logg)) &
-         deallocate(colors_handles(handle)%lu_logg)
+         deallocate (colors_handles(handle)%lu_logg)
       if (allocated(colors_handles(handle)%lu_meta)) &
-         deallocate(colors_handles(handle)%lu_meta)
+         deallocate (colors_handles(handle)%lu_meta)
       if (allocated(colors_handles(handle)%lu_teff)) &
-         deallocate(colors_handles(handle)%lu_teff)
+         deallocate (colors_handles(handle)%lu_teff)
       colors_handles(handle)%lookup_loaded = .false.
 
-      ! Free Vega SED arrays
       if (allocated(colors_handles(handle)%vega_wavelengths)) &
-         deallocate(colors_handles(handle)%vega_wavelengths)
+         deallocate (colors_handles(handle)%vega_wavelengths)
       if (allocated(colors_handles(handle)%vega_fluxes)) &
-         deallocate(colors_handles(handle)%vega_fluxes)
+         deallocate (colors_handles(handle)%vega_fluxes)
       colors_handles(handle)%vega_loaded = .false.
 
-      ! Free filter data arrays
       if (allocated(colors_handles(handle)%filters)) then
          do i = 1, size(colors_handles(handle)%filters)
             if (allocated(colors_handles(handle)%filters(i)%wavelengths)) &
-               deallocate(colors_handles(handle)%filters(i)%wavelengths)
+               deallocate (colors_handles(handle)%filters(i)%wavelengths)
             if (allocated(colors_handles(handle)%filters(i)%transmission)) &
-               deallocate(colors_handles(handle)%filters(i)%transmission)
+               deallocate (colors_handles(handle)%filters(i)%transmission)
          end do
-         deallocate(colors_handles(handle)%filters)
+         deallocate (colors_handles(handle)%filters)
       end if
       colors_handles(handle)%filters_loaded = .false.
+
+      if (allocated(colors_handles(handle)%cube_flux)) &
+         deallocate (colors_handles(handle)%cube_flux)
+      if (allocated(colors_handles(handle)%cube_teff_grid)) &
+         deallocate (colors_handles(handle)%cube_teff_grid)
+      if (allocated(colors_handles(handle)%cube_logg_grid)) &
+         deallocate (colors_handles(handle)%cube_logg_grid)
+      if (allocated(colors_handles(handle)%cube_meta_grid)) &
+         deallocate (colors_handles(handle)%cube_meta_grid)
+      if (allocated(colors_handles(handle)%cube_wavelengths)) &
+         deallocate (colors_handles(handle)%cube_wavelengths)
+      colors_handles(handle)%cube_loaded = .false.
+
+      if (allocated(colors_handles(handle)%u_teff)) &
+         deallocate (colors_handles(handle)%u_teff)
+      if (allocated(colors_handles(handle)%u_logg)) &
+         deallocate (colors_handles(handle)%u_logg)
+      if (allocated(colors_handles(handle)%u_meta)) &
+         deallocate (colors_handles(handle)%u_meta)
+      colors_handles(handle)%unique_grids_built = .false.
+
+      if (allocated(colors_handles(handle)%grid_to_lu)) &
+         deallocate (colors_handles(handle)%grid_to_lu)
+      colors_handles(handle)%grid_map_built = .false.
+
+      if (allocated(colors_handles(handle)%stencil_fluxes)) &
+         deallocate (colors_handles(handle)%stencil_fluxes)
+      if (allocated(colors_handles(handle)%stencil_wavelengths)) &
+         deallocate (colors_handles(handle)%stencil_wavelengths)
+      if (allocated(colors_handles(handle)%stencil_teff)) &
+         deallocate (colors_handles(handle)%stencil_teff)
+      if (allocated(colors_handles(handle)%stencil_logg)) &
+         deallocate (colors_handles(handle)%stencil_logg)
+      if (allocated(colors_handles(handle)%stencil_meta)) &
+         deallocate (colors_handles(handle)%stencil_meta)
+      colors_handles(handle)%stencil_valid = .false.
+      colors_handles(handle)%stencil_i_t = -1
+      colors_handles(handle)%stencil_i_g = -1
+      colors_handles(handle)%stencil_i_m = -1
+
+      if (allocated(colors_handles(handle)%sed_mcache_keys)) &
+         deallocate (colors_handles(handle)%sed_mcache_keys)
+      if (allocated(colors_handles(handle)%sed_mcache_data)) &
+         deallocate (colors_handles(handle)%sed_mcache_data)
+      colors_handles(handle)%sed_mcache_init = .false.
+      colors_handles(handle)%sed_mcache_count = 0
+      colors_handles(handle)%sed_mcache_next = 1
+      colors_handles(handle)%sed_mcache_nlam = 0
+
+      if (allocated(colors_handles(handle)%fallback_wavelengths)) &
+         deallocate (colors_handles(handle)%fallback_wavelengths)
+      colors_handles(handle)%fallback_wavelengths_set = .false.
 
    end subroutine free_colors_cache
 
@@ -196,10 +307,8 @@ contains
    subroutine do_free_colors_tables
       integer :: i
 
-      ! Free the filter names array
-      if (allocated(color_filter_names)) deallocate(color_filter_names)
+      if (allocated(color_filter_names)) deallocate (color_filter_names)
 
-      ! Free cached data for all handles
       do i = 1, max_colors_handles
          call free_colors_cache(i)
       end do

--- a/colors/public/colors_lib.f90
+++ b/colors/public/colors_lib.f90
@@ -22,7 +22,8 @@ module colors_lib
    use const_def, only: dp, strlen, mesa_dir
    use bolometric, only: calculate_bolometric
    use synthetic, only: calculate_synthetic
-   use colors_utils, only: read_strings_from_file, load_lookup_table, load_filter, load_vega_sed
+   use colors_utils, only: read_strings_from_file, load_lookup_table, load_filter, load_vega_sed, &
+                           resolve_path, load_flux_cube, build_unique_grids, build_grid_to_lu_map
    use colors_history, only: how_many_colors_history_columns, data_for_colors_history_columns
 
    implicit none
@@ -33,21 +34,22 @@ module colors_lib
    public :: alloc_colors_handle, alloc_colors_handle_using_inlist, free_colors_handle
    public :: colors_ptr
    public :: colors_setup_tables, colors_setup_hooks
-   ! Main functions
+
    public :: calculate_bolometric, calculate_synthetic
    public :: how_many_colors_history_columns, data_for_colors_history_columns
-   ! Old bolometric correction functions that MESA expects (stub implementations, remove later):
+   ! old bolometric correction stubs that MESA expects (remove later):
    public :: get_bc_id_by_name, get_lum_band_by_id, get_abs_mag_by_id
    public :: get_bc_by_id, get_bc_name_by_id, get_bc_by_name
    public :: get_abs_bolometric_mag, get_abs_mag_by_name, get_bcs_all
    public :: get_lum_band_by_name
+
 contains
 
    ! call this routine to initialize the colors module.
    ! only needs to be done once at start of run.
-   ! Reads data from the 'colors' directory in the data_dir.
-   ! If use_cache is true and there is a 'colors/cache' directory, it will try that first.
-   ! If it doesn't find what it needs in the cache,
+   ! reads data from the 'colors' directory in the data_dir.
+   ! if use_cache is true and there is a 'colors/cache' directory, it will try that first.
+   ! if it doesn't find what it needs in the cache,
    ! it reads the data and writes the cache for next time.
    subroutine colors_init(use_cache, colors_cache_dir, ierr)
       use colors_def, only: colors_def_init, colors_use_cache, colors_is_initialized
@@ -80,6 +82,7 @@ contains
       character(len=*), intent(in) :: inlist  ! empty means just use defaults.
       integer, intent(out) :: ierr  ! 0 means AOK.
       ierr = 0
+      handle = -1
       if (.not. colors_is_initialized) then
          ierr = -1
          return
@@ -124,64 +127,68 @@ contains
 
       type(Colors_General_Info), pointer :: rq
       character(len=256) :: lookup_file, filter_dir, filter_filepath, vega_filepath
-      REAL, allocatable :: lookup_table(:,:)  ! unused but required by load_lookup_table
+      REAL, allocatable :: lookup_table(:, :)  ! unused but required by load_lookup_table
       integer :: i
 
       ierr = 0
       call get_colors_ptr(handle, rq, ierr)
       if (ierr /= 0) return
 
-      ! Read filter names from instrument directory
       call read_strings_from_file(rq, color_filter_names, num_color_filters, ierr)
       if (ierr /= 0) return
 
-      ! =========================================
-      ! Load lookup table (stellar atmosphere grid)
-      ! =========================================
+      ! load lookup table (stellar atmosphere grid)
       if (.not. rq%lookup_loaded) then
-         lookup_file = trim(mesa_dir)//trim(rq%stellar_atm)//'/lookup_table.csv'
+         lookup_file = trim(resolve_path(rq%stellar_atm))//'/lookup_table.csv'
          call load_lookup_table(lookup_file, lookup_table, &
                                 rq%lu_file_names, rq%lu_logg, rq%lu_meta, rq%lu_teff)
          rq%lookup_loaded = .true.
-         if (allocated(lookup_table)) deallocate(lookup_table)
+         if (allocated(lookup_table)) deallocate (lookup_table)
+
+         ! build unique sorted grids once for fallback interpolation
+         call build_unique_grids(rq)
+
+         ! build the grid-to-lu mapping for O(1) stencil lookups
+         call build_grid_to_lu_map(rq)
       end if
 
-      ! =========================================
-      ! Load Vega SED (needed for Vega mag system)
-      ! =========================================
+      ! load vega SED
       if (.not. rq%vega_loaded) then
-         vega_filepath = trim(mesa_dir)//trim(rq%vega_sed)
+         vega_filepath = trim(resolve_path(rq%vega_sed))
          call load_vega_sed(vega_filepath, rq%vega_wavelengths, rq%vega_fluxes)
          rq%vega_loaded = .true.
       end if
 
-      ! =========================================
-      ! Load all filter transmission curves and precompute zero-points
-      ! =========================================
+      ! load filter transmission curves and precompute zero-points
       if (.not. rq%filters_loaded) then
-         filter_dir = trim(mesa_dir)//trim(rq%instrument)
+         filter_dir = trim(resolve_path(rq%instrument))
 
-         allocate(rq%filters(num_color_filters))
+         allocate (rq%filters(num_color_filters))
 
          do i = 1, num_color_filters
             rq%filters(i)%name = color_filter_names(i)
             filter_filepath = trim(filter_dir)//'/'//trim(color_filter_names(i))
             call load_filter(filter_filepath, rq%filters(i)%wavelengths, rq%filters(i)%transmission)
 
-            ! Precompute zero-points for all magnitude systems
-            ! These are constant for each filter and never need recalculation
+            ! precompute zero-points for all magnitude systems
             rq%filters(i)%vega_zero_point = compute_vega_zero_point( &
-               rq%vega_wavelengths, rq%vega_fluxes, &
-               rq%filters(i)%wavelengths, rq%filters(i)%transmission)
+                                            rq%vega_wavelengths, rq%vega_fluxes, &
+                                            rq%filters(i)%wavelengths, rq%filters(i)%transmission)
 
             rq%filters(i)%ab_zero_point = compute_ab_zero_point( &
-               rq%filters(i)%wavelengths, rq%filters(i)%transmission)
+                                          rq%filters(i)%wavelengths, rq%filters(i)%transmission)
 
             rq%filters(i)%st_zero_point = compute_st_zero_point( &
-               rq%filters(i)%wavelengths, rq%filters(i)%transmission)
+                                          rq%filters(i)%wavelengths, rq%filters(i)%transmission)
          end do
 
          rq%filters_loaded = .true.
+      end if
+
+      ! try to load the full flux cube -- if allocation fails, cube_loaded stays
+      ! .false. and we fall back to loading individual SED files
+      if (.not. rq%cube_loaded) then
+         call load_flux_cube(rq, rq%stellar_atm)
       end if
 
    end subroutine colors_setup_tables
@@ -200,9 +207,7 @@ contains
 
    end subroutine colors_setup_hooks
 
-   !-----------------------------------------------------------------------
-   ! Bolometric correction interface (stub implementations)
-   !-----------------------------------------------------------------------
+   ! bolometric correction stubs (legacy mesa interface)
 
    real(dp) function get_bc_by_name(name, log_Teff, log_g, M_div_h, ierr)
       character(len=*), intent(in) :: name
@@ -244,7 +249,7 @@ contains
 
    real(dp) function get_abs_bolometric_mag(lum)
       use const_def, only: dp
-      real(dp), intent(in) :: lum  ! Luminosity in lsun units
+      real(dp), intent(in) :: lum  ! luminosity in lsun
 
       get_abs_bolometric_mag = -99.9d0
    end function get_abs_bolometric_mag
@@ -254,7 +259,7 @@ contains
       real(dp), intent(in) :: log_Teff  ! log10 of surface temp
       real(dp), intent(in) :: M_div_h  ! [M/H]
       real(dp), intent(in) :: log_g  ! log_10 of surface gravity
-      real(dp), intent(in) :: lum  ! Luminosity in lsun units
+      real(dp), intent(in) :: lum  ! luminosity in lsun
       integer, intent(inout) :: ierr
 
       ierr = 0
@@ -266,7 +271,7 @@ contains
       real(dp), intent(in) :: log_Teff  ! log10 of surface temp
       real(dp), intent(in) :: log_g  ! log_10 of surface gravity
       real(dp), intent(in) :: M_div_h  ! [M/H]
-      real(dp), intent(in) :: lum  ! Luminosity in lsun units
+      real(dp), intent(in) :: lum  ! luminosity in lsun
       integer, intent(inout) :: ierr
 
       ierr = 0
@@ -289,7 +294,7 @@ contains
       real(dp), intent(in) :: log_Teff  ! log10 of surface temp
       real(dp), intent(in) :: M_div_h  ! [M/H]
       real(dp), intent(in) :: log_g  ! log_10 of surface gravity
-      real(dp), intent(in) :: lum  ! Total luminosity in lsun units
+      real(dp), intent(in) :: lum  ! luminosity in lsun
       integer, intent(inout) :: ierr
 
       ierr = 0
@@ -301,7 +306,7 @@ contains
       real(dp), intent(in) :: log_Teff  ! log10 of surface temp
       real(dp), intent(in) :: log_g  ! log_10 of surface gravity
       real(dp), intent(in) :: M_div_h  ! [M/H]
-      real(dp), intent(in) :: lum  ! Total luminosity in lsun units
+      real(dp), intent(in) :: lum  ! luminosity in lsun
       integer, intent(inout) :: ierr
 
       ierr = 0

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -267,8 +267,10 @@ contains
          end if
          colors_col_names(1:num_colors_cols) = 'unknown'
          colors_col_vals(1:num_colors_cols) = -1d99
-         call data_for_colors_history_columns(s%T(1), log10(s%grav(1)), s%R(1), s%kap_rq%Zbase, &
-            s% colors_handle, num_colors_cols, colors_col_names, colors_col_vals, ierr)
+
+         call data_for_colors_history_columns(s%T(1), safe_log10(s%grav(1)), s%R(1), s%kap_rq%Zbase, &
+            s% model_number, s% colors_handle, num_colors_cols, colors_col_names, colors_col_vals, ierr)
+
          if (ierr /= 0) then
             call dealloc
             return
@@ -279,6 +281,7 @@ contains
             end if
          end do
       end if
+
 
       i0 = 1
       if (write_flag .and. (open_close_log .or. s% model_number == -100)) then

--- a/star/test_suite/custom_colors/inlist_colors
+++ b/star/test_suite/custom_colors/inlist_colors
@@ -57,14 +57,14 @@
       ! This points to a directory containing Johnson filter transmission curves.
       ! The Johnson directory should contain files like:
       !   - U.dat, B.dat, V.dat, R.dat, I.dat, J.dat, M.dat   (filter transmission curves)
-      instrument = '/data/colors_data/filters/Generic/Johnson'
+      instrument = 'data/colors_data/filters/Generic/Johnson'
 
       ! Stellar atmosphere model directory
       ! Should contain:
       ! - lookup_table.csv: mapping file with columns for filename, Teff, log_g, metallicity
       ! - Individual SED files: wavelength vs surface flux for each stellar model
       ! - flux_cube.bin: pre-computed interpolation grid (if using linear/hermite interpolation)
-      stellar_atm = '/data/colors_data/stellar_models/Kurucz2003all/'
+      stellar_atm = 'data/colors_data/stellar_models/Kurucz2003all/'
       
       ! Physical parameters for synthetic photometry
       distance = 3.0857d19         ! Distance to star in cm (1 pc = 3.0857e16 m for absolute mags)
@@ -80,7 +80,7 @@
       ! Vega spectrum for zero-point calibration
       ! This file should contain wavelength (Å) and flux (erg/s/cm²/Å) columns
       ! Used to define the zero-point of the magnitude system (Vega = 0.0 mag)
-      vega_sed = '/data/colors_data/stellar_models/vega_flam.csv'
+      vega_sed = 'data/colors_data/stellar_models/vega_flam.csv'
 
 
 / ! end of colors namelist


### PR DESCRIPTION
 - Interpolation techniques have been optimised to remove data structures that were not needed.
 
 
 - Added ``sed_per_model``.  If .true., each SED output file is suffixed with the model number, preserving the full SED history rather than overwriting.
 
 
 
- Added a more intelligent parser for the colours data file paths with this logic: 

```
  clean up the input path

  if path starts with "./" or "../":
      use it as-is

  else if path starts with "/":
      if that absolute path exists:
          use it as-is
      else:
          treat it as relative to mesa_dir

  else:
      treat it as relative to mesa_dir
```



- Added memory aware flux cube loading where, if the flux cube is too big to fit into ram, the individual CSV files are loaded. This is much slower for IO but stops it from crashing the run. This is the logic:

```
if no flux_cube.bin:
    use per-file SED loading

read n_teff, n_logg, n_meta, n_lambda from file

try allocate cube[n_teff, n_logg, n_meta, n_lambda]:
    if success:
        load cube from file
    if fail:
        use per-file SED loading
```
