### PR TITLE
Bugfix colors segfault

### DIFF
--- a/colors/public/colors_lib.f90
+++ b/colors/public/colors_lib.f90
@@ -133,6 +133,7 @@ contains
       ierr = 0
       call get_colors_ptr(handle, rq, ierr)
       if (ierr /= 0) return
+      if (.not. rq%use_colors) return
 
       call read_strings_from_file(rq, color_filter_names, num_color_filters, ierr)
       if (ierr /= 0) return

--- a/colors/public/colors_lib.f90
+++ b/colors/public/colors_lib.f90
@@ -77,10 +77,11 @@ contains
    end function alloc_colors_handle
 
    integer function alloc_colors_handle_using_inlist(inlist, ierr) result(handle)
-      use colors_def, only: do_alloc_colors, colors_is_initialized
+      use colors_def, only: Colors_General_Info, do_alloc_colors, colors_is_initialized, get_colors_ptr
       use colors_ctrls_io, only: read_namelist
       character(len=*), intent(in) :: inlist  ! empty means just use defaults.
       integer, intent(out) :: ierr  ! 0 means AOK.
+      type(Colors_General_Info), pointer :: rq
       ierr = 0
       handle = -1
       if (.not. colors_is_initialized) then
@@ -91,6 +92,10 @@ contains
       if (ierr /= 0) return
       call read_namelist(handle, inlist, ierr)
       if (ierr /= 0) return
+      call get_colors_ptr(handle, rq, ierr)
+      if (ierr /= 0) return
+      ! skip colors table setup and hooks if use_colors = .false.
+      if (.not. rq%use_colors) return     
       call colors_setup_tables(handle, ierr)
       call colors_setup_hooks(handle, ierr)
    end function alloc_colors_handle_using_inlist
@@ -133,7 +138,6 @@ contains
       ierr = 0
       call get_colors_ptr(handle, rq, ierr)
       if (ierr /= 0) return
-      if (.not. rq%use_colors) return
 
       call read_strings_from_file(rq, color_filter_names, num_color_filters, ierr)
       if (ierr /= 0) return

--- a/colors/test/src/test_colors.f90
+++ b/colors/test/src/test_colors.f90
@@ -41,8 +41,8 @@ program test_colors
    use colors_lib, only: &
       colors_init, colors_shutdown, &
       alloc_colors_handle_using_inlist, free_colors_handle, colors_ptr, &
-      how_many_colors_history_columns, data_for_colors_history_columns, &
-      calculate_bolometric
+      colors_setup_tables, colors_setup_hooks, how_many_colors_history_columns, &
+      data_for_colors_history_columns, calculate_bolometric
    use colors_def, only: Colors_General_Info
    use const_def,  only: dp, rsun, boltz_sigma
    use utils_lib,  only: mesa_error
@@ -149,9 +149,23 @@ program test_colors
       stop 1
    end if
 
-   ! enable photometry so how_many_colors_history_columns returns > 0
+   ! enable photometry and explicitly load colors data, since the default
+   ! namelist leaves use_colors = .false. and skips setup at handle.
+   ! To do : This could be replaced by reading from an inlist instead in the future.
    cs%use_colors = .true.
    cs%mag_system = 'Vega'
+   call colors_setup_tables(handle, ierr)
+   if (ierr /= 0) then
+      write(*,*) 'colors_setup_tables failed, ierr =', ierr
+      stop 1
+   end if
+
+   ! probably unecessary since this is empty right now.
+   call colors_setup_hooks(handle, ierr)
+   if (ierr /= 0) then
+      write(*,*) 'colors_setup_hooks failed, ierr =', ierr
+      stop 1
+   end if
 
    n_cols = how_many_colors_history_columns(handle)
    if (n_cols == 0) then

--- a/star/private/rsp.f90
+++ b/star/private/rsp.f90
@@ -972,10 +972,11 @@
          TET = s% time
          cycle_complete = .false.
          UN=s% v(1)
+         ! ULL is not set for the first model.
+         if (s% model_number==1) return
          if(UN>0.d0.and.ULL<=0.d0) then
             RMIN=s% r(1)/SUNR
          end if
-         if (s% model_number==1) return
          if (.not. s% RSP_have_set_velocities) return
          if (s% r(1)/SUNR < s% RSP_min_max_R_for_periods) return
          if (UN/s% csound(1) > VMAX) then


### PR DESCRIPTION
for r26.4.1, This pr introduces a minor tweak to colors that prevents the flux cube from being loaded into memory when use_colors = .false. . Given where we placed the return statement, we now need to explicitly load the flux cube In colors/test/test_colors.f90, since it's running without a namelist. I add a comment that we might want a separate inlist for this test case, but I left it as a comment for now.

+ (and 1 minor cleanup in rsp, does not need to be included)

Let me know if this is fine to merge, once it compiles. Hopefully it passes testing as well.