### PR TITLE
Reintroducing precomputed BC table support (photo_precompute mode)

### DIFF
--- a/colors/defaults/colors.defaults
+++ b/colors/defaults/colors.defaults
@@ -73,7 +73,10 @@
       colors_results_directory = 'SED'
       mag_system = 'Vega'
       sed_per_model = .false.
-
+      photo_precompute = .false.
+      color_num_files = 0
+      color_num_colors = 0
+      color_file_names = ''
 
    ! ``z_over_x_ref``
    ! ~~~~~~~~~~~~~~~~

--- a/colors/defaults/colors.defaults
+++ b/colors/defaults/colors.defaults
@@ -74,9 +74,14 @@
       mag_system = 'Vega'
       sed_per_model = .false.
       photo_precompute = .false.
-      color_num_files = 0
-      color_num_colors = 0
-      color_file_names = ''
+
+      color_num_files = 2
+      color_file_names(1) = 'lcb98cor.dat'
+      color_num_colors(1) = 11
+      color_file_names(2) = 'blackbody_johnson.dat'
+      color_num_colors(2) = 5
+
+
 
    ! ``z_over_x_ref``
    ! ~~~~~~~~~~~~~~~~

--- a/colors/make/makefile_base
+++ b/colors/make/makefile_base
@@ -14,9 +14,9 @@ include $(MESA_DIR)/utils/makefile_header
 
 SRCS = \
    colors_def.f90 \
+   mod_colors.f90 \
    colors_ctrls_io.f90 \
    colors_history.f90 \
-   colors_def.f90 \
    hermite_interp.f90 \
    knn_interp.f90 \
    linear_interp.f90 \
@@ -24,7 +24,7 @@ SRCS = \
    bolometric.f90 \
    synthetic.f90 \
    colors_lib.f90
-
+   
 #################################################################
 #
 # LIBRARIES

--- a/colors/private/colors_ctrls_io.f90
+++ b/colors/private/colors_ctrls_io.f90
@@ -20,7 +20,7 @@
 module colors_ctrls_io
 
    use const_def, only: dp, strlen, max_extra_inlists
-   use colors_def, only: Colors_General_Info, get_colors_ptr
+   use colors_def, only: Colors_General_Info, get_colors_ptr, max_num_color_files
 
    implicit none
 
@@ -43,6 +43,13 @@ module colors_ctrls_io
    logical :: sed_per_model
    logical :: use_colors
 
+   !photometric pre compute
+   logical :: photo_precompute
+   integer :: color_num_files
+   integer, dimension(max_num_color_files) :: color_num_colors
+   character(len=256), dimension(max_num_color_files) :: color_file_names
+
+
    namelist /colors/ &
       instrument, &
       vega_sed, &
@@ -53,6 +60,10 @@ module colors_ctrls_io
       sed_per_model, &
       mag_system, &
       colors_results_directory, &
+      photo_precompute, &
+      color_num_files, &
+      color_num_colors, &
+      color_file_names, &
       use_colors, &
       read_extra_colors_inlist, &
       extra_colors_inlist_name
@@ -161,6 +172,10 @@ contains
       rq%make_csv = make_csv
       rq%sed_per_model = sed_per_model
       rq%colors_results_directory = colors_results_directory
+      rq%photo_precompute = photo_precompute
+      rq%color_num_files = color_num_files
+      rq%color_num_colors = color_num_colors
+      rq%color_file_names = color_file_names
       rq%use_colors = use_colors
       rq%mag_system = mag_system
 
@@ -199,6 +214,10 @@ contains
       make_csv = rq%make_csv
       sed_per_model = rq%sed_per_model
       colors_results_directory = rq%colors_results_directory
+      photo_precompute = rq%photo_precompute
+      color_num_files = rq%color_num_files
+      color_num_colors = rq%color_num_colors
+      color_file_names = rq%color_file_names
       use_colors = rq%use_colors
       mag_system = rq%mag_system
 

--- a/colors/private/colors_history.f90
+++ b/colors/private/colors_history.f90
@@ -19,12 +19,13 @@
 
 module colors_history
 
-   use const_def, only: dp
+   use const_def, only: dp, mbolsun, Teffsun, rsun
    use utils_lib, only: mesa_error
    use colors_def, only: Colors_General_Info, get_colors_ptr, num_color_filters, color_filter_names
    use colors_utils, only: remove_dat, resolve_path
    use bolometric, only: calculate_bolometric
    use synthetic, only: calculate_synthetic
+   use mod_colors, only: Eval_Colors, thead_all, num_thead, lgt_list, max_num_bcs_per_file
 
    implicit none
 
@@ -55,6 +56,8 @@ contains
    subroutine data_for_colors_history_columns( &
       t_eff, log_g, R, metallicity, model_number, &
       colors_handle, n, names, vals, ierr)
+      use const_def, only: mbolsun, Teffsun, rsun
+      use mod_colors, only: Eval_Colors, thead_all, num_thead, lgt_list, max_num_bcs_per_file
       real(dp), intent(in) :: t_eff, log_g, R, metallicity
       integer, intent(in) :: colors_handle, n
       character(len=80) :: names(n)
@@ -62,13 +65,15 @@ contains
       integer, intent(out) :: ierr
       integer, intent(in) :: model_number
 
-      type(Colors_General_Info), pointer :: cs  ! colors_settings
-      integer :: i, filter_offset
+      type(Colors_General_Info), pointer :: cs
+      integer :: i, j, k, filter_offset
       real(dp) :: d, bolometric_magnitude, bolometric_flux, interpolation_radius
-      real(dp) :: zero_point
+      real(dp) :: zero_point, lum
       character(len=256) :: sed_filepath
       character(len=80) :: filter_name
       logical :: make_sed
+      real(dp), dimension(max_num_bcs_per_file) :: bcs
+      type(lgt_list), pointer :: thead
 
       real(dp), dimension(:), allocatable :: wavelengths, fluxes
 
@@ -79,78 +84,115 @@ contains
          return
       end if
 
-      ! verify data was loaded at initialization
-      if (.not. cs%lookup_loaded) then
-         write (*, *) 'colors error: lookup table not loaded'
-         ierr = -1
-         return
-      end if
-      if (.not. cs%filters_loaded) then
-         write (*, *) 'colors error: filter data not loaded'
-         ierr = -1
-         return
-      end if
+      !write(0,*) 'DEBUG colors_history: n=', n, 'num_color_filters=', num_color_filters, &
+      !           'photo_precompute=', cs%photo_precompute
+      !flush(0)
 
-      d = cs%distance
-      sed_filepath = trim(resolve_path(cs%stellar_atm))
-      make_sed = cs%make_csv
+      if (cs%photo_precompute) then
 
-      call calculate_bolometric(cs, t_eff, log_g, metallicity, R, d, &
-                                bolometric_magnitude, bolometric_flux, wavelengths, fluxes, &
-                                sed_filepath, interpolation_radius)
+         lum = (R / rsun)**2 * (t_eff / Teffsun)**4
+         bolometric_magnitude = mbolsun - 2.5_dp * log10(lum)
 
-      names(1) = "Mag_bol"
-      vals(1) = bolometric_magnitude
-      names(2) = "Flux_bol"
-      vals(2) = bolometric_flux
-      names(3) = "Interp_rad"
-      vals(3) = interpolation_radius
-      filter_offset = 3
+         names(1) = 'Mag_bol'
+         vals(1) = bolometric_magnitude
+         names(2) = 'Flux_bol'
+         vals(2) = -1.0_dp
+         names(3) = 'Interp_rad'
+         vals(3) = -1.0_dp
+         filter_offset = 3
 
-      if (n == num_color_filters + filter_offset) then
-         do i = 1, num_color_filters
-            filter_name = trim(remove_dat(color_filter_names(i)))
-            names(i + filter_offset) = filter_name
-
-            ! Negative [M/H] values are valid for metal-poor atmosphere grids.
-            ! so we do not apply a limit on the "metallicity" parameter.
-            if (t_eff >= 0) then
-               ! Select precomputed zero-point based on magnitude system
-               select case (trim(cs%mag_system))
-               case ('VEGA', 'Vega', 'vega')
-                  zero_point = cs%filters(i)%vega_zero_point
-               case ('AB', 'ab')
-                  zero_point = cs%filters(i)%ab_zero_point
-               case ('ST', 'st')
-                  zero_point = cs%filters(i)%st_zero_point
-               case default
-                  write (*, *) 'colors error: unknown magnitude system: ', trim(cs%mag_system)
-                  zero_point = -1.0_dp
-               end select
-
-               vals(i + filter_offset) = calculate_synthetic(t_eff, log_g, metallicity, ierr, &
-                                                             wavelengths, fluxes, &
-                                                             cs%filters(i)%wavelengths, &
-                                                             cs%filters(i)%transmission, &
-                                                             zero_point, &
-                                                             color_filter_names(i), &
-                                                             make_sed, cs%sed_per_model, &
-                                                             cs%colors_results_directory, model_number)
-
-               if (ierr /= 0) vals(i + filter_offset) = -1.0_dp
-            else
-               vals(i + filter_offset) = -1.0_dp
-               ierr = 1
-            end if
+         k = 0
+         do j = 1, num_thead
+            thead => thead_all(j)%thead
+            call Eval_Colors(log10(t_eff), log_g, metallicity, bcs, thead, thead_all(j)%n_colors, ierr)
+            do i = 1, thead_all(j)%n_colors
+               k = k + 1
+               filter_name = trim(remove_dat(color_filter_names(k)))
+               names(k + filter_offset) = filter_name
+               if (ierr /= 0) then
+                  vals(k + filter_offset) = -1.0_dp
+               else
+                  vals(k + filter_offset) = bolometric_magnitude - bcs(i)
+               end if
+            end do
          end do
-      else
-         ierr = 1
-         call mesa_error(__FILE__, __LINE__, 'colors: data_for_colors_history_columns array size mismatch')
-      end if
 
-      ! clean up
-      if (allocated(wavelengths)) deallocate (wavelengths)
-      if (allocated(fluxes)) deallocate (fluxes)
+      else
+
+         ! verify data was loaded at initialization
+         if (.not. cs%lookup_loaded) then
+            write (*, *) 'colors error: lookup table not loaded'
+            ierr = -1
+            return
+         end if
+         if (.not. cs%filters_loaded) then
+            write (*, *) 'colors error: filter data not loaded'
+            ierr = -1
+            return
+         end if
+
+         d = cs%distance
+         sed_filepath = trim(resolve_path(cs%stellar_atm))
+         make_sed = cs%make_csv
+
+         call calculate_bolometric(cs, t_eff, log_g, metallicity, R, d, &
+                                   bolometric_magnitude, bolometric_flux, wavelengths, fluxes, &
+                                   sed_filepath, interpolation_radius)
+
+         names(1) = "Mag_bol"
+         vals(1) = bolometric_magnitude
+         names(2) = "Flux_bol"
+         vals(2) = bolometric_flux
+         names(3) = "Interp_rad"
+         vals(3) = interpolation_radius
+         filter_offset = 3
+
+         if (n == num_color_filters + filter_offset) then
+            do i = 1, num_color_filters
+               filter_name = trim(remove_dat(color_filter_names(i)))
+               names(i + filter_offset) = filter_name
+
+               ! Negative [M/H] values are valid for metal-poor atmosphere grids.
+               ! so we do not apply a limit on the "metallicity" parameter.
+               if (t_eff >= 0) then
+                  ! Select precomputed zero-point based on magnitude system
+                  select case (trim(cs%mag_system))
+                  case ('VEGA', 'Vega', 'vega')
+                     zero_point = cs%filters(i)%vega_zero_point
+                  case ('AB', 'ab')
+                     zero_point = cs%filters(i)%ab_zero_point
+                  case ('ST', 'st')
+                     zero_point = cs%filters(i)%st_zero_point
+                  case default
+                     write (*, *) 'colors error: unknown magnitude system: ', trim(cs%mag_system)
+                     zero_point = -1.0_dp
+                  end select
+
+                  vals(i + filter_offset) = calculate_synthetic(t_eff, log_g, metallicity, ierr, &
+                                                                wavelengths, fluxes, &
+                                                                cs%filters(i)%wavelengths, &
+                                                                cs%filters(i)%transmission, &
+                                                                zero_point, &
+                                                                color_filter_names(i), &
+                                                                make_sed, cs%sed_per_model, &
+                                                                cs%colors_results_directory, model_number)
+
+                  if (ierr /= 0) vals(i + filter_offset) = -1.0_dp
+               else
+                  vals(i + filter_offset) = -1.0_dp
+                  ierr = 1
+               end if
+            end do
+         else
+            ierr = 1
+            call mesa_error(__FILE__, __LINE__, 'colors: data_for_colors_history_columns array size mismatch')
+         end if
+
+         ! clean up
+         if (allocated(wavelengths)) deallocate (wavelengths)
+         if (allocated(fluxes)) deallocate (fluxes)
+
+      end if
 
    end subroutine data_for_colors_history_columns
 

--- a/colors/private/mod_colors.f90
+++ b/colors/private/mod_colors.f90
@@ -1,0 +1,725 @@
+! ***********************************************************************
+!
+!   Copyright (C) 2010-2019  The MESA Team
+!
+!   MESA is free software; you can use it and/or modify
+!   it under the combined terms and restrictions of the MESA MANIFESTO
+!   and the GNU General Library Public License as published
+!   by the Free Software Foundation; either version 2 of the License,
+!   or (at your option) any later version.
+!
+!   You should have received a copy of the MESA MANIFESTO along with
+!   this software; if not, it is available at the mesa website:
+!   http://mesa.sourceforge.net/
+!
+!   MESA is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+!   See the GNU Library General Public License for more details.
+!
+!   You should have received a copy of the GNU Library General Public License
+!   along with this software; if not, write to the Free Software
+!   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+!
+!
+! ***********************************************************************
+
+   module mod_colors
+      use const_def, only: dp, strlen
+      use math_lib
+      use utils_lib
+
+      implicit none
+      private
+      public :: do_colors_init, free_colors_all, Eval_Colors
+      public :: thead_all, num_thead, bc_total_num_colors, color_is_initialized
+      public :: lgt_list, lgg_list, lgz_list, col_list, max_num_bcs_per_file
+
+      integer, parameter :: max_num_color_files = 10
+      integer, parameter :: max_num_bcs_per_file = 20
+
+      logical :: color_is_initialized = .false.
+      integer :: bc_total_num_colors
+      integer :: num_thead
+
+      type :: lgz_list ! sorted in decreasing order of lgz ([M/H])
+         real(dp) :: lgz ! [Fe/H]
+         type(lgz_list), pointer :: nxt => null()
+         real(dp), dimension(max_num_bcs_per_file) :: colors = -1d99
+      end type lgz_list
+
+      type :: lgg_list ! sorted in decreasing order of lgg
+         real(dp) :: lgg ! log g
+         type(lgg_list), pointer :: nxt => null()
+         type(lgz_list), pointer :: zlist => null()
+      end type lgg_list
+
+      type :: lgt_list ! sorted in decreasing order of lgt
+         real(dp) :: lgt ! logTeff
+         integer :: n_colors
+         type(lgt_list), pointer :: nxt => null()
+         type(lgg_list), pointer :: glist => null()
+      end type lgt_list
+
+      type :: col_list
+         type(lgt_list), pointer :: thead => null()
+         character(len=strlen), dimension(max_num_bcs_per_file) :: color_names
+         integer :: n_colors
+      end type col_list
+
+      type(col_list), dimension(:), pointer :: thead_all => null()
+
+      contains
+
+      subroutine do_colors_init(num_files,fnames,num_colors,ierr)
+         integer,intent(in) :: num_files
+         integer,dimension(:),intent(in) :: num_colors
+         character(len=*),dimension(:),intent(in) :: fnames
+         character(len=strlen) :: fname
+         type (lgt_list), pointer :: thead =>null()
+
+         integer, intent(out) :: ierr
+         integer :: i
+
+         ierr = 0
+         num_thead=num_files
+
+         if(num_thead<1)THEN
+            color_is_initialized=.false.
+            !Not a failure just dont have any files to read
+            ierr=0
+            return
+         END IF
+
+         ALLOCATE(thead_all(1:num_thead),STAT=ierr)
+         if (ierr /= 0) then
+            write(*,*) 'colors can not allocate memory in do_colors_init'
+            ierr=-1
+            return
+         end if
+
+         bc_total_num_colors=0
+         do i=1,num_thead
+            allocate(thead_all(i)%thead)
+
+            thead=>thead_all(i)%thead
+
+            fname=fnames(i)
+            thead_all(i)%n_colors=num_colors(i)
+            if(len(fname)==0)THEN
+               exit
+            end if
+
+            if(thead_all(i)%n_colors<1)THEN
+               write(*,*) "num_colors must be > 0"
+               ierr=-1
+               return
+            end if
+
+            call init_colors(fname,thead,thead_all(i)%color_names,thead_all(i)%n_colors,ierr)
+
+            thead_all(i)%thead=>thead
+            bc_total_num_colors=bc_total_num_colors+thead_all(i)%n_colors
+            nullify(thead)
+         end do
+
+         color_is_initialized=.true.
+
+      end subroutine do_colors_init
+
+
+      subroutine init_colors(fname, thead, col_names, n_colors, ierr)
+         integer, intent(out) :: ierr
+         character(len=*),intent(in) :: fname
+         type (lgt_list), pointer :: thead
+         character(len=*),dimension(:) :: col_names
+         integer, intent(in) :: n_colors
+         call Read_Colors_Data(fname, thead, col_names, n_colors, ierr)
+      end subroutine init_colors
+
+      subroutine free_colors_all
+         integer :: i
+         type (lgt_list), pointer :: thead => null()
+
+         do i=1,num_thead
+            if(associated(thead_all(i)%thead))then
+               thead=>thead_all(i)%thead
+               call free_colors(thead)
+            end if
+         end do
+         deallocate(thead_all)
+
+      end subroutine free_colors_all
+
+      subroutine free_colors(thead)
+         type (lgt_list), pointer :: thead
+         type(lgt_list),pointer :: tlist => null(), tnxt => null()
+
+         tlist => thead
+         do while (associated(tlist))
+            tnxt => tlist% nxt
+            call free_glist(tlist% glist)
+            deallocate(tlist)
+            tlist => tnxt
+         end do
+         nullify(thead)
+
+         contains
+
+         subroutine free_glist(gptr)
+            type (lgg_list), pointer :: gptr
+            type (lgg_list), pointer :: glist   => null()
+            type (lgg_list), pointer :: gnxt => null()
+            glist => gptr
+            do while (associated(glist))
+               gnxt => glist% nxt
+               call free_zlist(glist% zlist)
+               deallocate(glist)
+               glist => gnxt
+            end do
+         end subroutine free_glist
+
+         subroutine free_zlist(zptr)
+            type (lgz_list), pointer :: zptr
+            type (lgz_list), pointer :: zlist => null()
+            type (lgz_list), pointer :: znxt => null()
+            zlist => zptr
+            do while (associated(zlist))
+               znxt => zlist% nxt
+               deallocate(zlist)
+               zlist => znxt
+            end do
+         end subroutine free_zlist
+
+      end subroutine free_colors
+
+
+      subroutine show_tree(thead)
+         type (lgt_list), pointer :: thead
+         type (lgt_list), pointer :: tlist => null(), tnxt => null()
+
+         tlist => thead
+         do while (associated(tlist))
+            write(*,*) 'tlist lgt', exp10(tlist% lgt)
+            tnxt => tlist% nxt
+            call show_glist(tlist% glist)
+            tlist => tnxt
+         end do
+
+         contains
+
+         subroutine show_glist(gptr)
+            type (lgg_list), pointer :: gptr
+            type (lgg_list), pointer :: glist => null(), gnxt => null()
+
+            glist => gptr
+            do while (associated(glist))
+               write(*,*) 'glist% lgg', glist% lgg
+               gnxt => glist% nxt
+               call show_zlist(glist% zlist)
+               glist => gnxt
+            end do
+         end subroutine show_glist
+
+         subroutine show_zlist(zptr)
+            type (lgz_list), pointer :: zptr
+            type (lgz_list), pointer :: zlist => null()
+            type (lgz_list), pointer :: znxt => null()
+            zlist => zptr
+            do while (associated(zlist))
+               write(*,*) 'zlist% lgz', zlist% lgz
+               znxt => zlist% nxt
+               zlist => znxt
+            end do
+         end subroutine show_zlist
+
+      end subroutine show_tree
+
+
+      subroutine Read_One_Colors_Data(fname, thead, n_colors, col_names, ierr)
+         use const_def, only: mesa_data_dir
+         integer, intent(out) :: ierr ! 0 means ok
+         type (lgt_list), pointer,intent(inout) :: thead
+
+         ! read file and build lists
+         integer :: ios, cnt
+         integer,intent(in) :: n_colors
+         character (len=*) :: fname
+         real(dp) :: lgt, lgg, lgz
+         type (lgg_list), pointer :: glist => null()
+         type (lgt_list), pointer :: tlist => null()
+         type (lgz_list), pointer :: zlist => null()
+         real(dp), dimension(max_num_bcs_per_file) :: colors
+         character(len=*),dimension(:),intent(out) :: col_names
+         character(len=256) :: tmp_cols(3+n_colors)
+
+         character(len=4096) :: tmp
+         integer :: num_entries, num_made, IO_UBV
+
+
+         open(NEWUNIT=IO_UBV, FILE=trim(fname), ACTION='READ', STATUS='OLD', IOSTAT=ios)
+         if(ios/=0) THEN
+            ! Try colors data dir
+            open(NEWUNIT=IO_UBV, FILE=trim(mesa_data_dir)//'/colors_data/photo_precompute/'//trim(fname), &
+                 ACTION='READ', STATUS='OLD', IOSTAT=ios)
+            if (ios /= 0) then
+               write(*,*) 'colors_init: failed to open ' // trim(fname)
+               write(*,*) 'or ',trim(mesa_data_dir)//'/colors_data/photo_precompute/'//trim(fname)
+               ierr = 1; return
+            endif
+         end if
+
+         ierr = 0
+         num_entries = 0
+         cnt = 0
+         tmp = ''
+         !First line should be a header and containing the name of the colours
+         !#teff logg m_div_h col_1 col_2 etc
+         read(IO_UBV,'(a)') tmp
+
+         call split_line(tmp,3+n_colors,tmp_cols)
+
+         col_names(1:n_colors) = tmp_cols(4:n_colors+3)
+
+         do while (.true.)
+            read(IO_UBV,fmt=*,iostat=ios) lgt, lgg, lgz, colors(1:n_colors)
+            if (ios /= 0) exit
+            cnt = cnt + 1
+            lgt = log10(lgt)
+
+            if(cnt==1) thead%lgt = lgt
+
+            call get_tlist(thead, lgt, tlist, ierr)
+            if (ierr /= 0) exit
+
+            call get_glist(tlist% glist, lgg, glist, ierr)
+            if (ierr /= 0) exit
+
+            call get_zlist(glist% zlist, lgz, zlist, num_entries, ierr)
+            if (ierr /= 0) exit
+
+            if(zlist% colors(1) > -1d98) then
+               write(*,*) "Warning found duplicated color data for (T, log g, M/H)=", 10**lgT, lgg, lgz
+            end if
+
+            zlist% colors = colors
+
+         end do
+
+         close(IO_UBV)
+         if (ierr /= 0) return
+
+         num_made = 0
+
+         tlist => thead
+         lgt = 1d99
+         do while (associated(tlist))
+            if (tlist% lgt >= lgt) then ! bad tlist order
+               ierr = -1; return
+            end if
+            lgt = tlist% lgt
+            glist => tlist% glist
+            lgg = 1d99
+            do while (associated(glist))
+               if (glist% lgg >= lgg) then ! bad glist order
+                  ierr = -2; return
+               end if
+               lgg = glist% lgg
+               zlist => glist% zlist
+               lgz = 1d99
+               do while (associated(zlist))
+                  if (zlist% lgz >= lgz) then ! bad zlist order
+                     ierr = -3; return
+                  end if
+                  lgz = zlist% lgz
+                  num_made = num_made + 1
+                  zlist => zlist% nxt
+               end do
+               glist => glist% nxt
+            end do
+            tlist => tlist% nxt
+         end do
+
+         if(num_entries /= num_made)then
+            write(0,*) "Error fond less colors than expected ",num_entries,num_made
+            stop
+         end if
+
+      end subroutine Read_One_Colors_Data
+
+
+      subroutine Read_Colors_Data(fname, thead, col_names, n_colors, ierr)
+         integer, intent(out) :: ierr ! 0 means ok
+         type (lgt_list), pointer,intent(inout) :: thead
+         character (len=*),intent(in) :: fname
+         character(len=*),dimension(:),intent(out) :: col_names
+         integer, intent(in) :: n_colors
+
+         Call Read_One_Colors_Data(fname, thead, n_colors, col_names, ierr)
+         if (ierr /= 0) THEN
+            write(*,*) "Read_Colors_One_Data error"
+            stop
+         end if
+
+      end subroutine Read_Colors_Data
+
+      subroutine get_tlist(head, lgt, tlist, ierr)
+         type (lgt_list), pointer :: head
+         real(dp), intent(in) :: lgt
+         type (lgt_list), pointer :: tlist
+         integer, intent(out) :: ierr ! 0 means ok
+
+         type (lgt_list), pointer :: t1=>null(), t2=>null()
+
+         ierr = 0
+
+         if (.not. associated(head)) then ! first time
+            if (.not. alloc_tlist()) return
+            head => tlist
+            return
+         end if
+
+         if (head% lgt == lgt) then ! matches head of list
+            tlist => head
+            return
+         end if
+
+         if (head% lgt < lgt) then ! becomes new head of list
+            if (.not. alloc_tlist()) return
+            tlist% nxt => head
+            head => tlist
+            return
+         end if
+
+         ! check list
+         t1 => head
+         do while (associated(t1% nxt))
+            t2 => t1% nxt
+            if (t2% lgt == lgt) then
+               tlist => t2; return
+            end if
+            if (t2% lgt < lgt) then ! insert new one before t2
+               if (.not. alloc_tlist()) return
+               tlist% nxt => t2
+               t1% nxt => tlist
+               return
+            end if
+            t1 => t2
+         end do
+         ! add to end of list after t1
+         if (.not. alloc_tlist()) return
+         t1% nxt => tlist
+
+         contains
+
+         logical function alloc_tlist()
+            integer :: istat
+            allocate(tlist,stat=istat)
+            if (istat /= 0) then
+               alloc_tlist = .false.; ierr = -1; return
+            end if
+            nullify(tlist% glist)
+            nullify(tlist% nxt)
+            tlist% lgt = lgt
+            alloc_tlist = .true.
+         end function alloc_tlist
+
+      end subroutine get_tlist
+
+
+      subroutine get_glist(head, lgg, glist, ierr)
+         type (lgg_list), pointer :: head
+         real(dp), intent(in) :: lgg
+         type (lgg_list), pointer :: glist
+         integer, intent(out) :: ierr
+
+         type (lgg_list), pointer :: g1 => null(), g2 => null()
+
+         ierr = 0
+
+         if (.not. associated(head)) then ! first time
+            if (.not. alloc_glist()) return
+            head => glist
+            return
+         end if
+
+         if (head% lgg == lgg) then ! matches head of list
+            glist => head
+            return
+         end if
+
+         if (head% lgg < lgg) then ! becomes new head of list
+            if (.not. alloc_glist()) return
+            glist% nxt => head
+            head => glist
+            return
+         end if
+
+         ! check list
+         g1 => head
+         do while (associated(g1% nxt))
+            g2 => g1% nxt
+            if (g2% lgg == lgg) then
+               glist => g2; return
+            end if
+            if (g2% lgg < lgg) then ! insert new one before g2
+               if (.not. alloc_glist()) return
+               glist% nxt => g2
+               g1% nxt => glist
+               return
+            end if
+            g1 => g2
+         end do
+         ! add to end of list after g1
+         if (.not. alloc_glist()) return
+         g1% nxt => glist
+
+         contains
+
+         logical function alloc_glist()
+            integer :: istat
+            allocate(glist,stat=istat)
+            if (istat /= 0) then ! allocate failed in alloc_glist
+               alloc_glist = .false.; ierr = -1; return
+            end if
+            nullify(glist% zlist)
+            nullify(glist% nxt)
+            glist% lgg = lgg
+            alloc_glist = .true.
+         end function alloc_glist
+
+      end subroutine get_glist
+
+      subroutine get_zlist(head, lgz, zlist, num_entries, ierr)
+         type (lgz_list), pointer :: head
+         real(dp), intent(in) :: lgz
+         type (lgz_list), pointer :: zlist
+         integer, intent(out) :: ierr ! 0 means ok
+         integer,intent(inout) :: num_entries
+
+         type (lgz_list), pointer :: z1=>null(), z2=>null()
+
+         ierr = 0
+
+         if (.not. associated(head)) then ! first time
+            if (.not. alloc_zlist()) return
+            head => zlist
+            return
+         end if
+
+         if (head% lgz == lgz) then ! matches head of list
+            zlist => head
+            return
+         end if
+
+         if (head% lgz < lgz) then ! becomes new head of list
+            if (.not. alloc_zlist()) return
+            zlist% nxt => head
+            head => zlist
+            return
+         end if
+
+         ! check list
+         z1 => head
+         do while (associated(z1% nxt))
+            z2 => z1% nxt
+            if (z2% lgz == lgz) then
+               zlist => z2; return
+            end if
+            if (z2% lgz < lgz) then ! insert new one before z2
+               if (.not. alloc_zlist()) return
+               zlist% nxt => z2
+               z1% nxt => zlist
+               return
+            end if
+            z1 => z2
+         end do
+         ! add to end of list after z1
+         if (.not. alloc_zlist()) return
+         z1% nxt => zlist
+
+         contains
+
+         logical function alloc_zlist()
+            integer :: istat
+            allocate(zlist,stat=istat)
+            if (istat /= 0) then
+               alloc_zlist = .false.; ierr = -1; return
+            end if
+            nullify(zlist% nxt)
+            num_entries=num_entries+1
+            zlist% lgz = lgz
+            alloc_zlist = .true.
+         end function alloc_zlist
+
+      end subroutine get_zlist
+
+
+      subroutine Eval_Colors(log_Teff,log_g, M_div_h_in, results, thead, n_colors, ierr)
+         real(dp), intent(in)  :: log_Teff ! log10 of surface temp
+         real(dp), intent(in)  :: M_div_h_in ! [M/H]
+         real(dp),dimension(:), intent(out) :: results
+         real(dp), intent(in) :: log_g
+         integer, intent(in) :: n_colors
+         integer, intent(out) :: ierr
+         type (lgt_list), pointer,intent(inout) :: thead
+
+         real(dp) :: lgg, lgz, lgt, alfa, beta
+         real(dp),dimension(max_num_bcs_per_file) :: results1, results2
+         type (lgt_list), pointer :: tlist => null(), tnxt => null()
+
+         lgg=log_g
+         lgz=M_div_h_in
+         lgt=log_Teff
+
+         if (.not. associated(thead)) then
+            ierr = -1; return
+         end if
+
+         ierr = 0
+
+         if (lgt >= thead% lgt) then ! use the largest lgt
+            call get_glist_results( &
+               thead% glist, lgg, lgz, results1, thead%n_colors, ierr)
+            if (ierr /= 0) return
+            results = results1
+         else
+
+            tlist => thead
+            do while (associated(tlist% nxt))
+               tnxt => tlist% nxt
+               if (lgt == tnxt% lgt) then ! use tnxt
+                  call get_glist_results( &
+                     tnxt% glist, lgg, lgz, results1, n_colors, ierr)
+                     if (ierr /= 0) return
+                  results = results1
+                  return
+               end if
+               if (lgt >= tnxt% lgt) then ! interpolate between tlist and tnxt
+                  call get_glist_results(tlist% glist, lgg, lgz, results1, n_colors, ierr)
+                  if (ierr /= 0) return
+                  call get_glist_results(tnxt% glist, lgg, lgz, results2, n_colors, ierr)
+                  if (ierr /= 0) return
+                  alfa = (lgt - tnxt% lgt) / (tlist% lgt - tnxt% lgt)
+                  beta = 1.d0 - alfa
+                  results(1:n_colors) = alfa * results1(1:n_colors) + beta * results2(1:n_colors)
+                  return
+               end if
+               tlist => tnxt
+            end do
+
+            if (.not. (associated(tlist% nxt))) then
+               ! use the smallest lgt
+               call get_glist_results( &
+                  tlist% glist, lgg, lgz, results1, n_colors,ierr)
+               if (ierr /= 0) return
+               results = results1
+            end if
+
+         end if
+
+      end subroutine Eval_Colors
+
+
+      subroutine get_glist_results(gptr, lgg, lgz, results, n_colors, ierr)
+         type (lgg_list), pointer :: gptr
+         real(dp), intent(in) :: lgg, lgz
+         real(dp),dimension(:), intent(out) :: results
+         integer,intent(in) :: n_colors
+         integer,intent(out) :: ierr
+
+         type (lgg_list), pointer :: glist => null(), gnxt => null()
+         real(dp),dimension(max_num_bcs_per_file) :: results1, results2
+         real(dp) :: alfa, beta
+
+         glist => gptr
+         ierr = -1
+         if (.not. associated(glist)) then
+            write(*,*) 'bad glist for get_glist_results'
+            ierr = -1
+            return
+         end if
+
+         if (lgg >= glist% lgg) then ! use the largest lgg
+            call get_zlist_results( &
+               glist% zlist, lgz, results1, n_colors, ierr)
+            if (ierr /= 0) return
+            results = results1
+            return
+         end if
+
+         do while (associated(glist% nxt))
+            gnxt => glist% nxt
+            if (lgg == gnxt% lgg) then ! use gnxt
+               call get_zlist_results(gnxt% zlist, lgz, results1, n_colors, ierr)
+               if (ierr /= 0) return
+               results=results1
+               return
+            end if
+            if (lgg >= gnxt% lgg) then ! interpolate between lgg's
+               call get_zlist_results(glist% zlist, lgz, results1, n_colors, ierr)
+               if (ierr /= 0) return
+               call get_zlist_results(gnxt% zlist, lgz, results2, n_colors, ierr)
+               if (ierr /= 0) return
+               alfa = (lgg - gnxt% lgg) / (glist% lgg - gnxt% lgg)
+               beta = 1.d0 - alfa
+               results(1:n_colors) = alfa * results1(1:n_colors) + beta * results2(1:n_colors)
+               return
+            end if
+            glist => gnxt
+         end do
+
+         ! use the smallest lgg
+         call get_zlist_results(glist% zlist, lgz, results1, n_colors, ierr)
+         if (ierr /= 0) return
+         results = results1
+
+      end subroutine get_glist_results
+
+
+      subroutine get_zlist_results(zptr, lgz, results, n_colors, ierr)
+         type (lgz_list), pointer :: zptr
+         real(dp), intent(in) :: lgz
+         real(dp),dimension(:), intent(out) :: results
+         integer, intent(in) :: n_colors
+         integer, intent(out) :: ierr
+
+         type (lgz_list), pointer :: zlist => null(), znxt => null()
+         real(dp) :: alfa, beta
+
+         zlist => zptr
+
+         ierr = 0
+         if (.not. associated(zlist)) then
+            write(*,*) 'bad zlist for get_zlist_results'
+            ierr = -1
+            return
+         end if
+
+         if (lgz >= zlist% lgz) then ! use the largest lgz
+            results = zlist% colors
+            return
+         end if
+
+         do while (associated(zlist% nxt))
+            znxt => zlist% nxt
+            if (lgz == znxt% lgz) then ! use znxt
+               results(1:n_colors) = znxt% colors(1:n_colors)
+               return
+            end if
+            if (lgz >= znxt% lgz) then ! interpolate between zlist and znxt
+               alfa = (lgz - znxt% lgz) / (zlist% lgz - znxt% lgz)
+               beta = 1 - alfa
+               results(1:n_colors) = alfa * zlist% colors(1:n_colors) + beta * znxt% colors(1:n_colors)
+               return
+            end if
+            zlist => znxt
+         end do
+
+         ! use the smallest lgz
+         results = zlist% colors
+
+      end subroutine get_zlist_results
+
+
+      end module mod_colors

--- a/colors/public/colors_def.f90
+++ b/colors/public/colors_def.f90
@@ -19,11 +19,13 @@
 
 module colors_def
 
-   use const_def, only: dp
+   use const_def, only: dp, strlen
 
    implicit none
 
    public
+
+   integer, parameter :: max_num_color_files = 10
 
    ! max number of SEDs to keep in the memory cache
    ! each slot holds one wavelength array (~1200 doubles ~ 10 KB),
@@ -55,6 +57,12 @@ module colors_def
       logical :: use_colors
       integer :: handle
       logical :: in_use
+
+      ! photo pre compute
+      logical :: photo_precompute = .false.
+      integer :: color_num_files = 0
+      integer, dimension(max_num_color_files) :: color_num_colors = 0
+      character(len=strlen), dimension(max_num_color_files) :: color_file_names = ''
 
       ! cached lookup table data
       logical :: lookup_loaded = .false.

--- a/colors/public/colors_lib.f90
+++ b/colors/public/colors_lib.f90
@@ -119,20 +119,46 @@ contains
 
    end subroutine colors_ptr
 
+
    subroutine colors_setup_tables(handle, ierr)
       use colors_def, only: Colors_General_Info, get_colors_ptr, color_filter_names, num_color_filters
+      use mod_colors, only: do_colors_init, bc_total_num_colors, thead_all, num_thead  ! add this
       use synthetic, only: compute_vega_zero_point, compute_ab_zero_point, compute_st_zero_point
       integer, intent(in) :: handle
       integer, intent(out):: ierr
 
       type(Colors_General_Info), pointer :: rq
       character(len=256) :: lookup_file, filter_dir, filter_filepath, vega_filepath
-      REAL, allocatable :: lookup_table(:, :)  ! unused but required by load_lookup_table
-      integer :: i
+      REAL, allocatable :: lookup_table(:, :)
+      integer :: i, j, k   ! add j, k
 
       ierr = 0
       call get_colors_ptr(handle, rq, ierr)
       if (ierr /= 0) return
+
+      if (rq%photo_precompute) then
+         call do_colors_init(rq%color_num_files, rq%color_file_names, rq%color_num_colors, ierr)
+         if (ierr /= 0) then
+            write(*,*) 'colors error: failed to load precomputed BC tables'
+            return
+         end if
+         num_color_filters = bc_total_num_colors
+         allocate(color_filter_names(num_color_filters))
+         k = 0
+         do i = 1, num_thead
+            do j = 1, thead_all(i)%n_colors
+               k = k + 1
+               color_filter_names(k) = trim(thead_all(i)%color_names(j))
+            end do
+         end do
+         ! lu_meta is accessed by MESA's history code for metallicity clamping.
+         ! Populate with the range of the loaded BC tables.
+         allocate(rq%lu_meta(2))
+         rq%lu_meta(1) = -5.0_dp   ! minimum [Fe/H] in standard BC tables
+         rq%lu_meta(2) =  1.0_dp   ! maximum [Fe/H] in standard BC tables
+         rq%lookup_loaded = .true.
+         return
+      end if
 
       call read_strings_from_file(rq, color_filter_names, num_color_filters, ierr)
       if (ierr /= 0) return

--- a/data/colors_data/colors_data.txz
+++ b/data/colors_data/colors_data.txz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc471071ceabf9c2d7ec0fda7a4948298f2e0f8c340cc88d3b7ae0e360fc28c1
-size 75622184
+oid sha256:5d4eeb8f5c88bbf3755fad3eaf288152fef381b0e5f67b26fdf7a304bbe4e93c
+size 75777768

--- a/star/test_suite/custom_colors_legacy/.gitignore
+++ b/star/test_suite/custom_colors_legacy/.gitignore
@@ -1,0 +1,7 @@
+#ignore data folders and things not in top level git
+LOGS/
+SED/
+star
+photos/
+data/
+custom_colors_end.mod

--- a/star/test_suite/custom_colors_legacy/README.rst
+++ b/star/test_suite/custom_colors_legacy/README.rst
@@ -1,534 +1,187 @@
 .. _custom_colors:
 
-******
-Colors
-******
+**************************************
+Legacy Colors (precomputed photometry)
+**************************************
 
-This test suite case demonstrates the functionality of the MESA ``colors`` module.
+This test suite exercises the **legacy colors path** of the MESA ``colors``
+module: precomputed photometry / bolometric-correction tables loaded through
+``photo_precompute = .true.``.
 
-Running the Test Suite
+This is **not** the standard runtime SED-convolution workflow. In this suite,
+magnitudes come from tabulated bolometric corrections, not from interpolated
+stellar atmosphere spectra convolved with filter transmission curves.
+
+What this test demonstrates
+===========================
+
+This case is meant to show that the legacy colors implementation still works
+and still produces photometric history columns during a normal stellar
+evolution run.
+
+Specifically, it demonstrates that:
+
+* the ``&colors`` namelist is configured for legacy mode via
+  ``photo_precompute = .true.``;
+* legacy BC tables are loaded from the filenames listed in
+  ``color_file_names(:)``;
+* the photometric history columns are populated from those BC tables; and
+* the run bypasses the standard SED / filter-convolution path.
+
+How this suite proves it is using legacy colors
+===============================================
+
+The legacy branch in ``colors_history.f90`` has a distinctive output
+signature:
+
+* ``photo_precompute = .true.`` in ``inlist_colors``;
+* ``Mag_bol`` is computed from the stellar luminosity;
+* ``Flux_bol`` is written as ``-1``;
+* ``Interp_rad`` is written as ``-1``; and
+* the filter magnitudes are computed as ``Mag_bol - BC`` using the loaded
+  legacy bolometric-correction tables.
+
+By contrast, the standard colors path:
+
+* loads atmosphere grids and filters;
+* computes a full SED;
+* computes a physical ``Flux_bol``;
+* computes a physical ``Interp_rad``; and
+* evaluates synthetic magnitudes by convolving the SED with filter response
+  curves.
+
+So, for this suite, the simplest post-run proof of legacy mode is:
+
+* ``photo_precompute = .true.`` in the inlist,
+* finite photometric magnitudes in ``LOGS/history.data``, and
+* ``Flux_bol = -1`` and ``Interp_rad = -1`` throughout the run.
+
+A validation helper script is provided below for exactly that purpose.
+
+Running the test suite
 ======================
 
-
-The ``custom_colors`` test suite case evolves a 7 M☉ star from the pre-main sequence through core hydrogen burning, up to the point of X_He,c < 0.01.
-
-The test is not scientifically rigorous—the pre-MS relaxation settings are aggressive and the mesh is fine—its purpose is solely to exercise the colors module across a wide range of stellar parameters (T_eff, log g) in a reasonable wall-clock time.
-
-
-The ``custom_colors`` test suite is a standard MESA work directory. Before running it for the first time—or after making changes to the ``colors`` module source—the binary must be compiled.
-
-``./clean``
-   Removes all previously compiled object files and binaries from the ``build/`` directory. Run this before recompiling to ensure a clean state, particularly after switching MESA versions or modifying source files.
-
-``./mk``
-   Compiles the test suite and links it against the installed MESA libraries (including ``libcolors``). When it completes successfully it produces the ``build/bin/star`` executable.
-
-``./rn``
-   Runs the compiled stellar evolution model. MESA evolves the star according to the parameters in ``inlist_colors``, writing history and profile data to ``LOGS/`` and photometric outputs to ``SED/``.
-
-A typical run workflow is:
+This is a standard MESA work directory.
 
 .. code-block:: bash
 
-   ./clean   # wipe any previous build
-   ./mk      # compile
-   ./rn      # run
+   ./clean
+   ./mk
+   ./rn
 
-If ``./mk`` completes without errors and ``./rn`` begins printing timestep output, the colors module is working correctly.
+The run evolves a 7 Msun model from a pre-main-sequence start until the
+configured central-helium termination criterion is reached.
 
-----
+After a successful run you should have at least:
 
-What is MESA colors?
-====================
+* ``LOGS/history.data``
+* ``final.mod``
 
-MESA colors is a runtime module that allows users to generate observer-ready data directly from stellar evolution models. Instead of limiting output to theoretical quantities like Luminosity (L) and Surface Temperature (T_eff), the colors module computes:
+If you add the validation helper to ``python_helpers/``, you can then verify
+that the run really used legacy colors with:
 
-* **Bolometric Magnitude** (M_bol)
-* **Bolometric Flux** (F_bol)
-* **Synthetic Magnitudes** in specific photometric filters (e.g., Johnson V, Gaia G, 2MASS J).
+.. code-block:: bash
 
-How does the MESA colors module work?
-=====================================
+   cd python_helpers
+   python check_legacy_mode.py
 
-1.  At each timestep, the module takes the star's current surface parameters—Effective Temperature (T_eff), Surface Gravity (log g), and Metallicity ([M/H])—and queries a user-specified library of stellar atmospheres (defined in ``stellar_atm``). It interpolates within this grid to construct a specific Spectral Energy Distribution (SED) for the star's current parameters.
+Key controls used by this suite
+===============================
 
-2.  This SED is then convolved with filter transmission curves (defined in ``instrument``) to calculate the flux passing through each filter.
-
-3.  The fluxes are converted into magnitudes using the user-selected magnitude system (AB, ST, or Vega).
-
-----
-
-Inlist Options & Parameters
-===========================
-
-The colors module is controlled via the ``&colors`` namelist in ``inlist_colors``. Below is a detailed guide to the key parameters. Default values for all parameters are defined in ``colors.defaults``.
-
-use_colors
-----------
-
-**Default:** ``.false.``
-
-Master switch for the module. Must be set to ``.true.`` to enable any photometric output.
-
-**Example:**
+The important settings in ``inlist_colors`` are:
 
 .. code-block:: fortran
 
-   use_colors = .true.
-
-
-instrument
-----------
-
-**Default:** ``'data/colors_data/filters/Generic/Johnson'``
-
-Path to the filter instrument directory, structured as ``facility/instrument``.
-
-* The directory must contain an index file with the same name as the instrument
-  (e.g., ``Johnson``), listing one filter filename per line.
-* The module loads every ``.dat`` transmission curve listed in that index and
-  creates a corresponding history column for each.
-
-.. rubric:: Note on paths
-
-All path parameters (``instrument``, ``stellar_atm``, ``vega_sed``) are resolved
-using the same logic:
-
-* ``'data/colors_data/...'`` — no leading slash; ``$MESA_DIR`` is prepended. This
-  is the recommended form for all standard data paths.
-* ``'/absolute/path/...'`` — tested on disk first; if found, used as-is. If not
-  found, ``$MESA_DIR`` is prepended (preserves backwards compatibility).
-* ``'./local/path/...'`` or ``'../up/one/...'`` — used exactly as supplied,
-  relative to the MESA working directory.
-
-**Example:**
-
-.. code-block:: fortran
-
-   instrument = 'data/colors_data/filters/GAIA/GAIA'
-
-
-stellar_atm
------------
-
-**Default:** ``'data/colors_data/stellar_models/Kurucz2003all/'``
-
-Path to the directory containing the grid of stellar atmosphere models. Paths may be relative to ``$MESA_DIR``, relative to the working directory, or absolute. This directory must contain:
-
-1.  **lookup_table.csv**: A map linking filenames to physical parameters (T_eff, log g, [M/H]).
-2.  **SED files**: The actual spectra (text or binary format).
-3.  **flux_cube.bin**: (Optional but recommended) A binary cube for rapid interpolation.
-
-The module queries this grid using the star's current parameters. If the star evolves outside the grid boundaries, the module will clamp to the nearest edge.
-
-No header is required. All SED files within a given atmosphere grid must share the same wavelength grid; if they do not (e.g. BT-Settl), the stencil loader will interpolate non-conforming files onto the canonical wavelength grid of the first file loaded.
-
-The colors data ships with the Kurucz2003 models for solar alpha and alpha = 0.4.
-
-Spectral Grid Variants
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :widths: 24 8 10 18 16 16 20
-   :header-rows: 1
-
-   * - Name
-     - [α/Fe]
-     - N Spectra
-     - Teff (K)
-     - logg
-     - [M/H]
-     - Wavelength (Å)
-   * - Kurucz2003all
-     - 0.0
-     - 3808
-     - 3500-50000 (76 pt)
-     - 0.00-5.00 (11 pt)
-     - -2.50-0.50 (8 pt)
-     - 147-1600000 (1199 pt)
-   * - Kurucz2003all__alpha_04
-     - 0.4
-     - 4284
-     - 3500-50000 (76 pt)
-     - 0.00-5.00 (11 pt)
-     - -4.00-0.50 (9 pt)
-     - 147-1600000 (1199 pt)
-
-**[α/Fe]** is the alpha-element enhancement - the abundance of O, Ne, Mg, Si, S, Ar, Ca, and Ti relative to iron compared to solar.
-A value of 0.4 means those elements are enhanced by 0.4 dex above solar relative to iron.
-The alpha-enhanced grid goes down to lower metallicity (-4.00 vs -2.50) because alpha-enhanced stars are usually old, metal-poor Pop II stars.
-
-`Castelli & Kurucz 2003 <https://arxiv.org/abs/astro-ph/0405087>`__
-
-`SVO model <https://svo2.cab.inta-csic.es/theory/newov2/index.php?models=Kurucz2003all>`__
-
-**Example:**
-
-.. code-block:: fortran
-
-   stellar_atm = 'data/colors_data/stellar_models/sg-SPHINX/'
-
-distance
---------
-
-**Default:** ``3.0857d19`` (10 parsecs in cm)
-
-The distance to the star in centimetres, used to convert surface flux to observed flux.
-
-* **Default Behaviour:** At 10 parsecs (3.0857 × 10^19 cm) the output is **Absolute Magnitudes**.
-* **Custom Usage:** Set this to a specific source distance to calculate Apparent Magnitudes.
-
-**Example:**
-
-.. code-block:: fortran
-
-   distance = 5.1839d20
-
-
-make_csv
---------
-
-**Default:** ``.false.``
-
-If set to ``.true.``, the module exports the full calculated SED at every profile interval.
-
-* **Destination:** Files are saved to the directory defined by ``colors_results_directory``.
-* **Format:** CSV files containing Wavelength vs. Flux.
-* **Use Case:** Useful for debugging or plotting the full spectrum of the star at a specific evolutionary age.
-
-**Example:**
-
-.. code-block:: fortran
-
-   make_csv = .true.
-
-
-sed_per_model
--------------
-
-**Default:** ``.false.``
-
-Requires ``make_csv = .true.``. If set to ``.true.``, each SED output file is suffixed with the model number, preserving the full SED history rather than overwriting the previous file.
-
-.. warning::
-
-   This can produce very large numbers of files over a long run. Ensure adequate disk space before enabling.
-
-**Example:**
-
-.. code-block:: fortran
-
-   sed_per_model = .true.
-
-
-colors_results_directory
-------------------------
-
-**Default:** ``'SED'``
-
-The folder where CSV files (if ``make_csv = .true.``) and other outputs are saved.
-
-**Example:**
-
-.. code-block:: fortran
-
-   colors_results_directory = 'sed'
-
-
-mag_system
-----------
-
-**Default:** ``'Vega'``
-
-Defines the zero-point system for magnitude calculations. Options are:
-
-* ``'AB'``: Based on a flat spectral flux density of 3631 Jy.
-* ``'ST'``: Based on a flat spectral flux density per unit wavelength.
-* ``'Vega'``: Calibrated such that Vega has magnitude 0 in all bands.
-
-**Example:**
-
-.. code-block:: fortran
-
-   mag_system = 'AB'
-
-
-vega_sed
---------
-
-**Default:** ``'data/colors_data/stellar_models/vega_flam.csv'``
-
-Required only if ``mag_system = 'Vega'``. Points to the reference SED file for Vega, used to compute photometric zero-points. Paths may be relative to ``$MESA_DIR``, relative to the working directory, or absolute.
-
-**Example:**
-
-.. code-block:: fortran
-
-   vega_sed = '/path/to/my/vega_SED.csv'
-
-
-Extra Inlist Controls
----------------------
-
-The ``&colors`` namelist can be split across multiple files using the extra inlist mechanism. This works recursively—extra inlists can themselves read further extra inlists.
-
-``read_extra_colors_inlist(1..5)``
-   If ``.true.``, the module reads an additional ``&colors`` namelist from the file named by the corresponding ``extra_colors_inlist_name`` entry.
-
-``extra_colors_inlist_name(1..5)``
-   Filename to read when the corresponding ``read_extra_colors_inlist`` entry is ``.true.``.
-
-**Example:**
-
-.. code-block:: fortran
-
-   read_extra_colors_inlist(1) = .true.
-   extra_colors_inlist_name(1) = 'inlist_colors_extra'
-
-Defaults Reference
-==================
-
-.. code-block:: fortran
-
-   use_colors               = .false.
-   instrument               = 'data/colors_data/filters/Generic/Johnson'
-   stellar_atm              = 'data/colors_data/stellar_models/Kurucz2003all/'
-   vega_sed                 = 'data/colors_data/stellar_models/vega_flam.csv'
-   distance                 = 3.0857d19     ! 10 parsecs in cm -> Absolute Magnitudes
-   make_csv                 = .false.
-   sed_per_model            = .false.
-   colors_results_directory = 'SED'
-   mag_system               = 'Vega'
-
-   read_extra_colors_inlist(:) = .false.
-   extra_colors_inlist_name(:) = 'undefined'
-
-----
-
-Visual Summary of Data Flow
-===========================
+   &colors
+      use_colors = .true.
+      photo_precompute = .true.
+
+      color_num_files = 2
+      color_file_names(1) = 'lcb98cor.dat'
+      color_num_colors(1) = 11
+      color_file_names(2) = 'blackbody_johnson.dat'
+      color_num_colors(2) = 5
+   /
+
+These settings select the legacy bolometric-correction-table path.
+
+Where the legacy tables are loaded from
+=======================================
+
+The legacy loader first tries the filename exactly as supplied in
+``color_file_names(:)``. If that fails, it falls back to:
 
 .. code-block:: text
 
-   +----------------+
-   |   MESA Model   |
-   | (Teff, logg, Z)|
-   +----------------+
-           |
-           v
-   +-------------------------------------------------------------------------+
-   |                        MESA COLORS MODULE                               |
-   | 1. Query Stellar Atmosphere Grid with input model                       |
-   | 2. Interpolate grid to construct specific SED                           |
-   | 3. Convolve SED with filters to generate band flux                      |
-   | 4. Apply distance flux dilution to generate bolometric flux -> Flux_bol |
-   | 5. Apply zero point (Vega/AB/ST) to generate magnitudes                 |
-   |                                    (Both bolometric and per filter)     |
-   +-------------------------------------------------------------------------+
-           |
-           v
-   +----------------------+
-   |    history.data      |
-   | age, Teff, ...       |
-   | Mag_bol, Flux_bol    |
-   | V, B, I, ...         |
-   +----------------------+
+   $MESA_DIR/data/colors_data/photo_precompute/<filename>
 
+So, for the default configuration in this suite, MESA looks for:
 
-----
+* ``lcb98cor.dat``
+* ``blackbody_johnson.dat``
 
-Python Helper Scripts
-=====================
+in the current working directory first, then in MESA's
+``data/colors_data/photo_precompute/`` directory.
 
-All Python helpers live in ``python_helpers/`` and are run from that directory.
-All paths default to ``../LOGS/`` and ``../SED/`` relative to that location, matching the standard test suite layout.
+Important differences from standard colors
+==========================================
 
-plot_history_live.py
---------------------
+This suite is intentionally testing the legacy path, so several standard
+``colors`` controls are not the main story here.
 
-**Purpose:** Live-updating four-panel diagnostic viewer for ``history.data``, designed to run *during* a MESA simulation.
+In legacy mode as currently implemented:
 
-**What it shows:**
+* ``instrument`` is not used;
+* ``stellar_atm`` is not used;
+* ``vega_sed`` is not used;
+* ``make_csv`` / ``sed_per_model`` are not part of the legacy photometry path;
+* ``mag_system`` is not used by the legacy branch in ``colors_history.f90``;
+* ``Flux_bol`` is not computed and is written as ``-1``;
+* ``Interp_rad`` is not computed and is written as ``-1``; and
+* ``distance`` is not applied in the legacy branch.
 
-* **Top-left**: Color–magnitude diagram (CMD) constructed automatically from whichever filters are present in the history file. Filter priority for color index selection follows: Gaia (Gbp−Grp), then Johnson (B−R or B−V), then Sloan (g−r), with a fallback to the first and last available filter.
-* **Top-right**: Classical HR diagram (Teff vs. log L).
-* **Bottom-left**: Color index as a function of stellar age.
-* **Bottom-right**: Light curves for all available filter bands simultaneously.
-
-All four panels are color-coded by MESA's ``phase_of_evolution`` integer if that column is present in the history file. If it is absent, points are colored by stellar age using a compressed inferno colormap that emphasises the most recent evolution.
-
-The script polls ``../LOGS/history.data`` every 0.1 seconds and updates the plot whenever the file changes. It will print a change notification for the first five updates, then go silent to avoid log spam. Close the window to exit.
-
-
-plot_history.py
----------------
-
-**Purpose:** Single-shot (non-live) version of the history viewer. Reads the completed ``history.data`` once and renders the same four-panel figure. Intended for post-run analysis and as a shared library imported by ``plot_history_live.py``, ``movie_history.py``, and ``movie_cmd_3d.py``.
-
-Produces a static figure and then calls ``plt.show()``. The script also exports ``MesaView``, ``read_header_columns``, and ``setup_hr_diagram_params`` for use by the other scripts.
-
-**Note:** The first 5 model rows are skipped (``MesaView`` skip=5) to avoid noisy pre-MS relaxation artifacts at the very start of the run.
-
-plot_sed_live.py
-----------------
-
-**Purpose:** Live-updating SED viewer that monitors the ``SED/`` directory for CSV files written by the colors module (requires ``make_csv = .true.`` in ``inlist_colors``).
-
-**What it shows:** A single plot with a logarithmic wavelength axis showing:
-
-* The full stellar SED (black line, plotted once from the first file found).
-* The filter-convolved flux for each band (one colored line per filter).
-* The Vega reference SED if a ``VEGA_*`` file is present.
-* Colored background bands marking the X-ray, UV, optical, and IR regions of the electromagnetic spectrum.
-* A text box in the corner showing the stellar mass, metallicity, and distance parsed from ``inlist_colors``.
-
-The x-axis auto-scales to the wavelength range where the SED has flux above 1% of its peak; the y-axis scales to the range of convolved fluxes.
-
-Runs live, refreshing every 0.1 s. Close the window or press Ctrl-C to stop. Can also be configured to save a video instead of displaying live by setting ``save_video=True`` in the ``SEDChecker`` constructor.
-
-
-plot_sed.py
------------
-
-**Purpose:** Single-shot SED plot that reads all ``*SED.csv`` files in ``../SED/`` and overlays them in one figure. Simpler than ``plot_sed_live.py``—no live monitoring, no EM region shading, no inlist parsing.
-
-Displays the combined SED figure. The x-axis is cropped to 0–60000 Å by default; edit the ``xlim`` argument in ``main()`` to change this.
-
-
-plot_cmd_3d.py
---------------
-
-**Purpose:** Interactive 3D scatter plot of the CMD with a user-selectable third axis. Useful for visualising how any history column correlates with the photometric evolution of the star.
-
-On launch, the script prints all available columns from ``history.data`` and prompts you to type the name of the column to use for the Z axis (default: ``Interp_rad``, the interpolation radius in the atmosphere grid). Press Enter to accept the default or type any other column name. A rotatable 3D matplotlib window then opens showing color index vs. magnitude vs. your chosen column.
-
-
-plot_zero_points.py
--------------------
-
-**Purpose:** Runs MESA three times in sequence with ``mag_system`` set to ``'Vega'``, ``'AB'``, and ``'ST'`` respectively, then overlays the resulting CMDs in a single comparison figure. Useful for quantifying the offsets between magnitude systems for a given set of filters.
-
-The script must be run from within ``python_helpers/`` (it changes directory to ``../`` before calling ``./rn``). It temporarily modifies ``inlist_colors`` to set the magnitude system and to disable PGstar, restores the original file after each run, and saves each LOGS directory as ``LOGS_Vega``, ``LOGS_AB``, and ``LOGS_ST``. The comparison figure is saved to ``mag_system_comparison.png``.
-
-.. warning::
-
-   This script runs the full simulation three times. For large or slow models, consider reducing ``initial_mass`` or loosening ``varcontrol_target`` and ``mesh_delta_coeff`` inside the ``FAST_RUN_OVERRIDES`` dictionary at the top of the script before running.
-
-
-plot_newton_iter.py
--------------------
-
-**Purpose:** Plots the per-Newton-iteration photometry data written to ``SED/iteration_colors.data`` by the colors module's solver-monitor hook. This file records the photometry at every Newton iteration within each timestep, capturing sub-timestep variability during convergence.
-
-The script supports both an **interactive mode** (a terminal UI with a filterable column picker) and a **batch mode** driven by command-line arguments. Both modes support arbitrary column expressions (e.g., ``B-V``, ``(V-U)/(B-V)``, ``Teff/1000``) in addition to named columns. When a ``history.data`` file is present, the history track is overlaid on the plot in grey for comparison. Plots are saved as both PDF and JPG.
-
-You will be prompted to select the plot type (2D scatter, 2D line, or 3D scatter), then the X, Y, (optionally Z), and color axes from a grid display. The picker supports substring filtering (``/text``), negative filtering (``!text``), and regex filtering (``//pattern``). You can also type a column name directly.
-
-
-movie_history.py
-----------------
-
-**Purpose:** Renders the same four-panel display as ``plot_history_live.py`` into an MP4 video, with one frame per model row. Points accumulate from left to right in time, so the full evolutionary track builds up across the video.
-
-Writes ``history.mp4`` in the current directory at 24 fps, 150 dpi. Requires ``ffmpeg`` to be installed and accessible on ``$PATH``. Progress is shown with a ``tqdm`` progress bar if that package is available.
-
-
-movie_newton_iter.py
---------------------
-
-**Purpose:** Creates an animated MP4 showing the Newton iteration data accumulating point by point over time. Iterations are sorted by model number then iteration number, so the animation follows the physical sequence of the simulation. History file points are overlaid incrementally—a new history point appears each time a model's full set of iterations is complete. Outliers are removed via iterative sigma clipping before rendering. Axis limits expand smoothly as new data arrives.
-
-The script supports the same interactive and batch modes as ``plot_newton_iter.py``, and imports all shared functionality (terminal UI, data loading, expression parsing) directly from that module.
-
-You will be prompted for X, Y, and color axes, video duration, FPS, output filename, and sigma-clipping threshold.
-
-Requires ``ffmpeg``. For GIF output, ``pillow`` can be used instead by changing the writer in the source.
-
-
-movie_cmd_3d.py
----------------
-
-**Purpose:** Creates a 3D rotation video that starts looking straight down the ``Interp_rad`` axis (showing a plain CMD) and rotates to an oblique 3D perspective over 10 seconds, with 1-second holds at each end.
-
-Writes ``cmd_interp_rad_rotation.mp4`` in the current directory at 30 fps. Requires ``ffmpeg``.
-
-
-run_batch.py
-------------
-
-**Purpose:** Runs MESA in batch over a list of parameter files, each of which defines a different stellar type (M dwarf, Pop III, OB star, etc.). After each run, the history file is renamed to avoid being overwritten by the next run.
-
-
-Edit ``param_options`` at the top of the script to list the ``extra_controls_inlist_name`` files you want to loop over, then run:
-
-
-The script: (1) comments out all parameter entries in ``inlist_1.0``, (2) uncomments one entry at a time, (3) runs ``./clean``, ``./mk``, and ``./rn`` in the MESA work directory, (4) renames the resulting ``history.data`` to ``history_<param_name>.data``, and (5) re-comments all entries at the end. If a run fails, a warning is printed and the loop continues with the next parameter set.
-
-**Note:** The MESA work directory is assumed to be one level above the location of ``run_batch.py`` (i.e., ``../``). The inlist to modify is ``inlist_1.0``. Adjust these paths at the top of the script if your layout differs.
-
-
-test_paths.py
--------------
-
-**Purpose:** Validates that all path parameters in ``inlist_colors`` resolve correctly on the current system. Checks that ``instrument``, ``stellar_atm``, and ``vega_sed`` point to accessible directories and files, and that required sub-structure (``lookup_table.csv``, filter index file, ``*.dat`` curves) is present.
-
-
-test_timings.py
----------------
-
-**Purpose:** Benchmarks the wall-clock overhead introduced by the colors module under different flag combinations. Runs the MESA model repeatedly with varying settings (e.g., ``make_csv``, ``sed_per_model``) and reports timing statistics, helping to characterise I/O vs. compute cost for a given atmosphere grid and filter set.
-
-----
-
-Data Preparation (SED_Tools)
-============================
-
-The ``colors`` module requires pre-processed stellar atmospheres and filter
-profiles organised in a specific directory structure. To automate this
-entire workflow, we provide the dedicated repository:
-
-**Repository:** `SED_Tools <https://github.com/nialljmiller/SED_Tools>`_
-
-SED_Tools downloads, validates, and converts raw spectral atmosphere grids and
-filter transmission curves from the following public archives:
-
-* `SVO Filter Profile Service <http://svo2.cab.inta-csic.es/theory/fps/>`_
-* `MAST BOSZ Stellar Atmosphere Library <https://archive.stsci.edu/prepds/bosz/>`_
-* `MSG / Townsend Atmosphere Grids <https://www.astro.wisc.edu/~townsend/msg/>`_
-
-These sources provide heterogeneous formats and file organisations. SED_Tools
-standardises them into the exact structure required by MESA:
-
-* ``lookup_table.csv``
-* Raw SED files (text and/or HDF5)
-* ``flux_cube.bin`` (binary cube for fast interpolation)
-* Filter index files and ``*.dat`` transmission curves
-
-SED_Tools produces:
+That last point matters: the current legacy implementation computes
+``Mag_bol`` from the luminosity scaling alone,
 
 .. code-block:: text
 
-    data/
-    ├── stellar_models/<ModelName>/
-    │   ├── flux_cube.bin
-    │   ├── lookup_table.csv
-    │   ├── *.txt / *.h5
-    └── filters/<Facility>/<Instrument>/
-        ├── *.dat
-        └── <Instrument>
+   Mag_bol = Mbol_sun - 2.5 log10(L / L_sun)
 
-These directories can be copied or symlinked directly into your MESA
-installation.
+with no distance term. So this suite should be documented as a test of legacy
+precomputed photometry, not as a test of apparent-magnitude generation.
 
-A browsable online mirror of the processed SED_Tools output is also available:
+Recommended validation script
+=============================
 
-`SED Tools Web Interface (mirror) <https://nillmill.ddns.net/sed_tools/>`_
+A good minimal regression check for this suite is:
 
-This server provides a live view of:
+1. confirm ``photo_precompute = .true.`` in ``inlist_colors``;
+2. confirm that ``Mag_bol`` exists and is finite;
+3. confirm that ``Flux_bol`` exists and is always ``-1``;
+4. confirm that ``Interp_rad`` exists and is always ``-1``; and
+5. confirm that at least one photometric column after ``Interp_rad`` contains
+   finite values.
 
-* All downloaded stellar atmosphere grids
-* All available filter facilities and instruments
-* File counts, disk usage, and metadata
-* Direct links to the directory structure used by MESA
+This verifies the characteristic legacy output signature without depending on
+any one specific filter set.
 
+Notes and caveats
+=================
 
+The current ``inlist_colors`` file contains a distance comment that should be
+corrected:
+
+.. code-block:: fortran
+
+   distance = 3.0857d19
+
+This value is **10 parsecs in cm**, not 1 parsec.
+
+Also note that the file currently enables:
+
+.. code-block:: fortran
+
+   pgstar_flag = .true.
+
+That may be useful for interactive local runs, but for automated CI-style test
+execution you may prefer ``.false.``.

--- a/star/test_suite/custom_colors_legacy/README.rst
+++ b/star/test_suite/custom_colors_legacy/README.rst
@@ -1,0 +1,534 @@
+.. _custom_colors:
+
+******
+Colors
+******
+
+This test suite case demonstrates the functionality of the MESA ``colors`` module.
+
+Running the Test Suite
+======================
+
+
+The ``custom_colors`` test suite case evolves a 7 M☉ star from the pre-main sequence through core hydrogen burning, up to the point of X_He,c < 0.01.
+
+The test is not scientifically rigorous—the pre-MS relaxation settings are aggressive and the mesh is fine—its purpose is solely to exercise the colors module across a wide range of stellar parameters (T_eff, log g) in a reasonable wall-clock time.
+
+
+The ``custom_colors`` test suite is a standard MESA work directory. Before running it for the first time—or after making changes to the ``colors`` module source—the binary must be compiled.
+
+``./clean``
+   Removes all previously compiled object files and binaries from the ``build/`` directory. Run this before recompiling to ensure a clean state, particularly after switching MESA versions or modifying source files.
+
+``./mk``
+   Compiles the test suite and links it against the installed MESA libraries (including ``libcolors``). When it completes successfully it produces the ``build/bin/star`` executable.
+
+``./rn``
+   Runs the compiled stellar evolution model. MESA evolves the star according to the parameters in ``inlist_colors``, writing history and profile data to ``LOGS/`` and photometric outputs to ``SED/``.
+
+A typical run workflow is:
+
+.. code-block:: bash
+
+   ./clean   # wipe any previous build
+   ./mk      # compile
+   ./rn      # run
+
+If ``./mk`` completes without errors and ``./rn`` begins printing timestep output, the colors module is working correctly.
+
+----
+
+What is MESA colors?
+====================
+
+MESA colors is a runtime module that allows users to generate observer-ready data directly from stellar evolution models. Instead of limiting output to theoretical quantities like Luminosity (L) and Surface Temperature (T_eff), the colors module computes:
+
+* **Bolometric Magnitude** (M_bol)
+* **Bolometric Flux** (F_bol)
+* **Synthetic Magnitudes** in specific photometric filters (e.g., Johnson V, Gaia G, 2MASS J).
+
+How does the MESA colors module work?
+=====================================
+
+1.  At each timestep, the module takes the star's current surface parameters—Effective Temperature (T_eff), Surface Gravity (log g), and Metallicity ([M/H])—and queries a user-specified library of stellar atmospheres (defined in ``stellar_atm``). It interpolates within this grid to construct a specific Spectral Energy Distribution (SED) for the star's current parameters.
+
+2.  This SED is then convolved with filter transmission curves (defined in ``instrument``) to calculate the flux passing through each filter.
+
+3.  The fluxes are converted into magnitudes using the user-selected magnitude system (AB, ST, or Vega).
+
+----
+
+Inlist Options & Parameters
+===========================
+
+The colors module is controlled via the ``&colors`` namelist in ``inlist_colors``. Below is a detailed guide to the key parameters. Default values for all parameters are defined in ``colors.defaults``.
+
+use_colors
+----------
+
+**Default:** ``.false.``
+
+Master switch for the module. Must be set to ``.true.`` to enable any photometric output.
+
+**Example:**
+
+.. code-block:: fortran
+
+   use_colors = .true.
+
+
+instrument
+----------
+
+**Default:** ``'data/colors_data/filters/Generic/Johnson'``
+
+Path to the filter instrument directory, structured as ``facility/instrument``.
+
+* The directory must contain an index file with the same name as the instrument
+  (e.g., ``Johnson``), listing one filter filename per line.
+* The module loads every ``.dat`` transmission curve listed in that index and
+  creates a corresponding history column for each.
+
+.. rubric:: Note on paths
+
+All path parameters (``instrument``, ``stellar_atm``, ``vega_sed``) are resolved
+using the same logic:
+
+* ``'data/colors_data/...'`` — no leading slash; ``$MESA_DIR`` is prepended. This
+  is the recommended form for all standard data paths.
+* ``'/absolute/path/...'`` — tested on disk first; if found, used as-is. If not
+  found, ``$MESA_DIR`` is prepended (preserves backwards compatibility).
+* ``'./local/path/...'`` or ``'../up/one/...'`` — used exactly as supplied,
+  relative to the MESA working directory.
+
+**Example:**
+
+.. code-block:: fortran
+
+   instrument = 'data/colors_data/filters/GAIA/GAIA'
+
+
+stellar_atm
+-----------
+
+**Default:** ``'data/colors_data/stellar_models/Kurucz2003all/'``
+
+Path to the directory containing the grid of stellar atmosphere models. Paths may be relative to ``$MESA_DIR``, relative to the working directory, or absolute. This directory must contain:
+
+1.  **lookup_table.csv**: A map linking filenames to physical parameters (T_eff, log g, [M/H]).
+2.  **SED files**: The actual spectra (text or binary format).
+3.  **flux_cube.bin**: (Optional but recommended) A binary cube for rapid interpolation.
+
+The module queries this grid using the star's current parameters. If the star evolves outside the grid boundaries, the module will clamp to the nearest edge.
+
+No header is required. All SED files within a given atmosphere grid must share the same wavelength grid; if they do not (e.g. BT-Settl), the stencil loader will interpolate non-conforming files onto the canonical wavelength grid of the first file loaded.
+
+The colors data ships with the Kurucz2003 models for solar alpha and alpha = 0.4.
+
+Spectral Grid Variants
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 24 8 10 18 16 16 20
+   :header-rows: 1
+
+   * - Name
+     - [α/Fe]
+     - N Spectra
+     - Teff (K)
+     - logg
+     - [M/H]
+     - Wavelength (Å)
+   * - Kurucz2003all
+     - 0.0
+     - 3808
+     - 3500-50000 (76 pt)
+     - 0.00-5.00 (11 pt)
+     - -2.50-0.50 (8 pt)
+     - 147-1600000 (1199 pt)
+   * - Kurucz2003all__alpha_04
+     - 0.4
+     - 4284
+     - 3500-50000 (76 pt)
+     - 0.00-5.00 (11 pt)
+     - -4.00-0.50 (9 pt)
+     - 147-1600000 (1199 pt)
+
+**[α/Fe]** is the alpha-element enhancement - the abundance of O, Ne, Mg, Si, S, Ar, Ca, and Ti relative to iron compared to solar.
+A value of 0.4 means those elements are enhanced by 0.4 dex above solar relative to iron.
+The alpha-enhanced grid goes down to lower metallicity (-4.00 vs -2.50) because alpha-enhanced stars are usually old, metal-poor Pop II stars.
+
+`Castelli & Kurucz 2003 <https://arxiv.org/abs/astro-ph/0405087>`__
+
+`SVO model <https://svo2.cab.inta-csic.es/theory/newov2/index.php?models=Kurucz2003all>`__
+
+**Example:**
+
+.. code-block:: fortran
+
+   stellar_atm = 'data/colors_data/stellar_models/sg-SPHINX/'
+
+distance
+--------
+
+**Default:** ``3.0857d19`` (10 parsecs in cm)
+
+The distance to the star in centimetres, used to convert surface flux to observed flux.
+
+* **Default Behaviour:** At 10 parsecs (3.0857 × 10^19 cm) the output is **Absolute Magnitudes**.
+* **Custom Usage:** Set this to a specific source distance to calculate Apparent Magnitudes.
+
+**Example:**
+
+.. code-block:: fortran
+
+   distance = 5.1839d20
+
+
+make_csv
+--------
+
+**Default:** ``.false.``
+
+If set to ``.true.``, the module exports the full calculated SED at every profile interval.
+
+* **Destination:** Files are saved to the directory defined by ``colors_results_directory``.
+* **Format:** CSV files containing Wavelength vs. Flux.
+* **Use Case:** Useful for debugging or plotting the full spectrum of the star at a specific evolutionary age.
+
+**Example:**
+
+.. code-block:: fortran
+
+   make_csv = .true.
+
+
+sed_per_model
+-------------
+
+**Default:** ``.false.``
+
+Requires ``make_csv = .true.``. If set to ``.true.``, each SED output file is suffixed with the model number, preserving the full SED history rather than overwriting the previous file.
+
+.. warning::
+
+   This can produce very large numbers of files over a long run. Ensure adequate disk space before enabling.
+
+**Example:**
+
+.. code-block:: fortran
+
+   sed_per_model = .true.
+
+
+colors_results_directory
+------------------------
+
+**Default:** ``'SED'``
+
+The folder where CSV files (if ``make_csv = .true.``) and other outputs are saved.
+
+**Example:**
+
+.. code-block:: fortran
+
+   colors_results_directory = 'sed'
+
+
+mag_system
+----------
+
+**Default:** ``'Vega'``
+
+Defines the zero-point system for magnitude calculations. Options are:
+
+* ``'AB'``: Based on a flat spectral flux density of 3631 Jy.
+* ``'ST'``: Based on a flat spectral flux density per unit wavelength.
+* ``'Vega'``: Calibrated such that Vega has magnitude 0 in all bands.
+
+**Example:**
+
+.. code-block:: fortran
+
+   mag_system = 'AB'
+
+
+vega_sed
+--------
+
+**Default:** ``'data/colors_data/stellar_models/vega_flam.csv'``
+
+Required only if ``mag_system = 'Vega'``. Points to the reference SED file for Vega, used to compute photometric zero-points. Paths may be relative to ``$MESA_DIR``, relative to the working directory, or absolute.
+
+**Example:**
+
+.. code-block:: fortran
+
+   vega_sed = '/path/to/my/vega_SED.csv'
+
+
+Extra Inlist Controls
+---------------------
+
+The ``&colors`` namelist can be split across multiple files using the extra inlist mechanism. This works recursively—extra inlists can themselves read further extra inlists.
+
+``read_extra_colors_inlist(1..5)``
+   If ``.true.``, the module reads an additional ``&colors`` namelist from the file named by the corresponding ``extra_colors_inlist_name`` entry.
+
+``extra_colors_inlist_name(1..5)``
+   Filename to read when the corresponding ``read_extra_colors_inlist`` entry is ``.true.``.
+
+**Example:**
+
+.. code-block:: fortran
+
+   read_extra_colors_inlist(1) = .true.
+   extra_colors_inlist_name(1) = 'inlist_colors_extra'
+
+Defaults Reference
+==================
+
+.. code-block:: fortran
+
+   use_colors               = .false.
+   instrument               = 'data/colors_data/filters/Generic/Johnson'
+   stellar_atm              = 'data/colors_data/stellar_models/Kurucz2003all/'
+   vega_sed                 = 'data/colors_data/stellar_models/vega_flam.csv'
+   distance                 = 3.0857d19     ! 10 parsecs in cm -> Absolute Magnitudes
+   make_csv                 = .false.
+   sed_per_model            = .false.
+   colors_results_directory = 'SED'
+   mag_system               = 'Vega'
+
+   read_extra_colors_inlist(:) = .false.
+   extra_colors_inlist_name(:) = 'undefined'
+
+----
+
+Visual Summary of Data Flow
+===========================
+
+.. code-block:: text
+
+   +----------------+
+   |   MESA Model   |
+   | (Teff, logg, Z)|
+   +----------------+
+           |
+           v
+   +-------------------------------------------------------------------------+
+   |                        MESA COLORS MODULE                               |
+   | 1. Query Stellar Atmosphere Grid with input model                       |
+   | 2. Interpolate grid to construct specific SED                           |
+   | 3. Convolve SED with filters to generate band flux                      |
+   | 4. Apply distance flux dilution to generate bolometric flux -> Flux_bol |
+   | 5. Apply zero point (Vega/AB/ST) to generate magnitudes                 |
+   |                                    (Both bolometric and per filter)     |
+   +-------------------------------------------------------------------------+
+           |
+           v
+   +----------------------+
+   |    history.data      |
+   | age, Teff, ...       |
+   | Mag_bol, Flux_bol    |
+   | V, B, I, ...         |
+   +----------------------+
+
+
+----
+
+Python Helper Scripts
+=====================
+
+All Python helpers live in ``python_helpers/`` and are run from that directory.
+All paths default to ``../LOGS/`` and ``../SED/`` relative to that location, matching the standard test suite layout.
+
+plot_history_live.py
+--------------------
+
+**Purpose:** Live-updating four-panel diagnostic viewer for ``history.data``, designed to run *during* a MESA simulation.
+
+**What it shows:**
+
+* **Top-left**: Color–magnitude diagram (CMD) constructed automatically from whichever filters are present in the history file. Filter priority for color index selection follows: Gaia (Gbp−Grp), then Johnson (B−R or B−V), then Sloan (g−r), with a fallback to the first and last available filter.
+* **Top-right**: Classical HR diagram (Teff vs. log L).
+* **Bottom-left**: Color index as a function of stellar age.
+* **Bottom-right**: Light curves for all available filter bands simultaneously.
+
+All four panels are color-coded by MESA's ``phase_of_evolution`` integer if that column is present in the history file. If it is absent, points are colored by stellar age using a compressed inferno colormap that emphasises the most recent evolution.
+
+The script polls ``../LOGS/history.data`` every 0.1 seconds and updates the plot whenever the file changes. It will print a change notification for the first five updates, then go silent to avoid log spam. Close the window to exit.
+
+
+plot_history.py
+---------------
+
+**Purpose:** Single-shot (non-live) version of the history viewer. Reads the completed ``history.data`` once and renders the same four-panel figure. Intended for post-run analysis and as a shared library imported by ``plot_history_live.py``, ``movie_history.py``, and ``movie_cmd_3d.py``.
+
+Produces a static figure and then calls ``plt.show()``. The script also exports ``MesaView``, ``read_header_columns``, and ``setup_hr_diagram_params`` for use by the other scripts.
+
+**Note:** The first 5 model rows are skipped (``MesaView`` skip=5) to avoid noisy pre-MS relaxation artifacts at the very start of the run.
+
+plot_sed_live.py
+----------------
+
+**Purpose:** Live-updating SED viewer that monitors the ``SED/`` directory for CSV files written by the colors module (requires ``make_csv = .true.`` in ``inlist_colors``).
+
+**What it shows:** A single plot with a logarithmic wavelength axis showing:
+
+* The full stellar SED (black line, plotted once from the first file found).
+* The filter-convolved flux for each band (one colored line per filter).
+* The Vega reference SED if a ``VEGA_*`` file is present.
+* Colored background bands marking the X-ray, UV, optical, and IR regions of the electromagnetic spectrum.
+* A text box in the corner showing the stellar mass, metallicity, and distance parsed from ``inlist_colors``.
+
+The x-axis auto-scales to the wavelength range where the SED has flux above 1% of its peak; the y-axis scales to the range of convolved fluxes.
+
+Runs live, refreshing every 0.1 s. Close the window or press Ctrl-C to stop. Can also be configured to save a video instead of displaying live by setting ``save_video=True`` in the ``SEDChecker`` constructor.
+
+
+plot_sed.py
+-----------
+
+**Purpose:** Single-shot SED plot that reads all ``*SED.csv`` files in ``../SED/`` and overlays them in one figure. Simpler than ``plot_sed_live.py``—no live monitoring, no EM region shading, no inlist parsing.
+
+Displays the combined SED figure. The x-axis is cropped to 0–60000 Å by default; edit the ``xlim`` argument in ``main()`` to change this.
+
+
+plot_cmd_3d.py
+--------------
+
+**Purpose:** Interactive 3D scatter plot of the CMD with a user-selectable third axis. Useful for visualising how any history column correlates with the photometric evolution of the star.
+
+On launch, the script prints all available columns from ``history.data`` and prompts you to type the name of the column to use for the Z axis (default: ``Interp_rad``, the interpolation radius in the atmosphere grid). Press Enter to accept the default or type any other column name. A rotatable 3D matplotlib window then opens showing color index vs. magnitude vs. your chosen column.
+
+
+plot_zero_points.py
+-------------------
+
+**Purpose:** Runs MESA three times in sequence with ``mag_system`` set to ``'Vega'``, ``'AB'``, and ``'ST'`` respectively, then overlays the resulting CMDs in a single comparison figure. Useful for quantifying the offsets between magnitude systems for a given set of filters.
+
+The script must be run from within ``python_helpers/`` (it changes directory to ``../`` before calling ``./rn``). It temporarily modifies ``inlist_colors`` to set the magnitude system and to disable PGstar, restores the original file after each run, and saves each LOGS directory as ``LOGS_Vega``, ``LOGS_AB``, and ``LOGS_ST``. The comparison figure is saved to ``mag_system_comparison.png``.
+
+.. warning::
+
+   This script runs the full simulation three times. For large or slow models, consider reducing ``initial_mass`` or loosening ``varcontrol_target`` and ``mesh_delta_coeff`` inside the ``FAST_RUN_OVERRIDES`` dictionary at the top of the script before running.
+
+
+plot_newton_iter.py
+-------------------
+
+**Purpose:** Plots the per-Newton-iteration photometry data written to ``SED/iteration_colors.data`` by the colors module's solver-monitor hook. This file records the photometry at every Newton iteration within each timestep, capturing sub-timestep variability during convergence.
+
+The script supports both an **interactive mode** (a terminal UI with a filterable column picker) and a **batch mode** driven by command-line arguments. Both modes support arbitrary column expressions (e.g., ``B-V``, ``(V-U)/(B-V)``, ``Teff/1000``) in addition to named columns. When a ``history.data`` file is present, the history track is overlaid on the plot in grey for comparison. Plots are saved as both PDF and JPG.
+
+You will be prompted to select the plot type (2D scatter, 2D line, or 3D scatter), then the X, Y, (optionally Z), and color axes from a grid display. The picker supports substring filtering (``/text``), negative filtering (``!text``), and regex filtering (``//pattern``). You can also type a column name directly.
+
+
+movie_history.py
+----------------
+
+**Purpose:** Renders the same four-panel display as ``plot_history_live.py`` into an MP4 video, with one frame per model row. Points accumulate from left to right in time, so the full evolutionary track builds up across the video.
+
+Writes ``history.mp4`` in the current directory at 24 fps, 150 dpi. Requires ``ffmpeg`` to be installed and accessible on ``$PATH``. Progress is shown with a ``tqdm`` progress bar if that package is available.
+
+
+movie_newton_iter.py
+--------------------
+
+**Purpose:** Creates an animated MP4 showing the Newton iteration data accumulating point by point over time. Iterations are sorted by model number then iteration number, so the animation follows the physical sequence of the simulation. History file points are overlaid incrementally—a new history point appears each time a model's full set of iterations is complete. Outliers are removed via iterative sigma clipping before rendering. Axis limits expand smoothly as new data arrives.
+
+The script supports the same interactive and batch modes as ``plot_newton_iter.py``, and imports all shared functionality (terminal UI, data loading, expression parsing) directly from that module.
+
+You will be prompted for X, Y, and color axes, video duration, FPS, output filename, and sigma-clipping threshold.
+
+Requires ``ffmpeg``. For GIF output, ``pillow`` can be used instead by changing the writer in the source.
+
+
+movie_cmd_3d.py
+---------------
+
+**Purpose:** Creates a 3D rotation video that starts looking straight down the ``Interp_rad`` axis (showing a plain CMD) and rotates to an oblique 3D perspective over 10 seconds, with 1-second holds at each end.
+
+Writes ``cmd_interp_rad_rotation.mp4`` in the current directory at 30 fps. Requires ``ffmpeg``.
+
+
+run_batch.py
+------------
+
+**Purpose:** Runs MESA in batch over a list of parameter files, each of which defines a different stellar type (M dwarf, Pop III, OB star, etc.). After each run, the history file is renamed to avoid being overwritten by the next run.
+
+
+Edit ``param_options`` at the top of the script to list the ``extra_controls_inlist_name`` files you want to loop over, then run:
+
+
+The script: (1) comments out all parameter entries in ``inlist_1.0``, (2) uncomments one entry at a time, (3) runs ``./clean``, ``./mk``, and ``./rn`` in the MESA work directory, (4) renames the resulting ``history.data`` to ``history_<param_name>.data``, and (5) re-comments all entries at the end. If a run fails, a warning is printed and the loop continues with the next parameter set.
+
+**Note:** The MESA work directory is assumed to be one level above the location of ``run_batch.py`` (i.e., ``../``). The inlist to modify is ``inlist_1.0``. Adjust these paths at the top of the script if your layout differs.
+
+
+test_paths.py
+-------------
+
+**Purpose:** Validates that all path parameters in ``inlist_colors`` resolve correctly on the current system. Checks that ``instrument``, ``stellar_atm``, and ``vega_sed`` point to accessible directories and files, and that required sub-structure (``lookup_table.csv``, filter index file, ``*.dat`` curves) is present.
+
+
+test_timings.py
+---------------
+
+**Purpose:** Benchmarks the wall-clock overhead introduced by the colors module under different flag combinations. Runs the MESA model repeatedly with varying settings (e.g., ``make_csv``, ``sed_per_model``) and reports timing statistics, helping to characterise I/O vs. compute cost for a given atmosphere grid and filter set.
+
+----
+
+Data Preparation (SED_Tools)
+============================
+
+The ``colors`` module requires pre-processed stellar atmospheres and filter
+profiles organised in a specific directory structure. To automate this
+entire workflow, we provide the dedicated repository:
+
+**Repository:** `SED_Tools <https://github.com/nialljmiller/SED_Tools>`_
+
+SED_Tools downloads, validates, and converts raw spectral atmosphere grids and
+filter transmission curves from the following public archives:
+
+* `SVO Filter Profile Service <http://svo2.cab.inta-csic.es/theory/fps/>`_
+* `MAST BOSZ Stellar Atmosphere Library <https://archive.stsci.edu/prepds/bosz/>`_
+* `MSG / Townsend Atmosphere Grids <https://www.astro.wisc.edu/~townsend/msg/>`_
+
+These sources provide heterogeneous formats and file organisations. SED_Tools
+standardises them into the exact structure required by MESA:
+
+* ``lookup_table.csv``
+* Raw SED files (text and/or HDF5)
+* ``flux_cube.bin`` (binary cube for fast interpolation)
+* Filter index files and ``*.dat`` transmission curves
+
+SED_Tools produces:
+
+.. code-block:: text
+
+    data/
+    ├── stellar_models/<ModelName>/
+    │   ├── flux_cube.bin
+    │   ├── lookup_table.csv
+    │   ├── *.txt / *.h5
+    └── filters/<Facility>/<Instrument>/
+        ├── *.dat
+        └── <Instrument>
+
+These directories can be copied or symlinked directly into your MESA
+installation.
+
+A browsable online mirror of the processed SED_Tools output is also available:
+
+`SED Tools Web Interface (mirror) <https://nillmill.ddns.net/sed_tools/>`_
+
+This server provides a live view of:
+
+* All downloaded stellar atmosphere grids
+* All available filter facilities and instruments
+* File counts, disk usage, and metadata
+* Direct links to the directory structure used by MESA
+
+

--- a/star/test_suite/custom_colors_legacy/ck
+++ b/star/test_suite/custom_colors_legacy/ck
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# this provides the definition of check_one
+# check_one
+source "${MESA_DIR}/star/test_suite/test_suite_helpers"
+
+check_one

--- a/star/test_suite/custom_colors_legacy/clean
+++ b/star/test_suite/custom_colors_legacy/clean
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd make
+make clean

--- a/star/test_suite/custom_colors_legacy/custom_colors_history_columns.list
+++ b/star/test_suite/custom_colors_legacy/custom_colors_history_columns.list
@@ -1,0 +1,48 @@
+! history_columns.list -- determines the contents of star history logs
+! you can use a non-standard version by setting history_columns_file in your inlist
+
+! units are cgs unless otherwise noted.
+
+!----------------------------------------------------------------------------------------------
+
+!# general info about the model
+
+      model_number ! counting from the start of the run
+      num_zones ! number of zones in the model
+      phase_of_evolution
+
+   !## age
+
+      star_age ! elapsed simulated time in years since the start of the run
+
+   !## timestep
+      log_dt ! log10 time_step in years
+      
+   !## mass
+
+      star_mass ! in Msun units
+
+!----------------------------------------------------------------------------------------------
+
+!# Color output
+
+      ! Note the filter names are case sensitive and must match what is used in your color
+      ! data file
+      star_age
+      Teff
+      log_Teff
+      log_L
+      log_R
+      log_g
+      !Custom Av values are handled in the run_star_extras
+
+!----------------------------------------------------------------------------------------------
+
+!# debugging
+
+      num_retries ! total during the run
+
+   !## solver iterations
+
+      num_iters ! same as num_newton_iterations
+

--- a/star/test_suite/custom_colors_legacy/inlist_colors
+++ b/star/test_suite/custom_colors_legacy/inlist_colors
@@ -1,0 +1,126 @@
+! MESA inlist for stellar evolution with precomputed photometry tables
+! Uses the photo_precompute mode of the colors module, which reads
+! pre-computed bolometric correction tables rather than performing
+! on-the-fly SED convolution.
+
+! Niall Miller (2025)
+
+! =============================================================================
+! STAR_JOB NAMELIST - Controls model creation and global job settings
+! =============================================================================
+&star_job
+      ! Model creation settings
+      create_pre_main_sequence_model = .true.  ! Start from pre-MS rather than ZAMS
+
+      ! Termination conditions
+      save_model_when_terminate = .true.
+      save_model_filename = 'final.mod'
+
+      ! Custom output files
+      history_columns_file = 'custom_colors_history_columns.list'
+
+      ! Verbosity and debugging
+      show_log_description_at_start = .true.
+
+      ! Pre-MS model settings
+      pre_ms_relax_to_start_radiative_core = .false.
+      initial_model_relax_num_steps = 10
+      pre_ms_relax_num_steps = 10
+
+      pgstar_flag = .true.
+/
+
+! =============================================================================
+! EOS NAMELIST
+! =============================================================================
+&eos
+/
+
+! =============================================================================
+! KAP NAMELIST
+! =============================================================================
+&kap
+      Zbase = 0.02d0
+      kap_file_prefix = 'gs98'
+/
+
+! =============================================================================
+! COLORS NAMELIST - Precomputed photometry table mode
+! =============================================================================
+&colors
+      use_colors = .true.
+
+      ! Enable precomputed BC table mode.
+      ! When .true., the colors module reads pre-computed bolometric correction
+      ! tables directly rather than convolving SEDs with filter transmission curves.
+      photo_precompute = .true.
+
+      ! Distance for apparent magnitude conversion
+      distance = 3.0857d19         ! 1 pc in cm
+
+      ! Number of BC table files to load
+      color_num_files = 2
+
+      ! Lejeune, Cuisinier & Buser (1998) bolometric corrections
+      ! Covers Teff 2000-50000 K, log g -1 to 5.5, [Fe/H] -5 to +1
+      ! Contains: U B V R I J H K L M  (10 colors)
+      color_file_names(1) = 'lcb98cor.dat'
+      color_num_colors(1) = 11
+
+      ! Blackbody Johnson filter bolometric corrections
+      ! Contains: U B V R I  (5 colors)
+      color_file_names(2) = 'blackbody_johnson.dat'
+      color_num_colors(2) = 5
+
+/ ! end of colors namelist
+
+
+! =============================================================================
+! CONTROLS NAMELIST
+! =============================================================================
+&controls
+      initial_mass = 7.0d0
+      initial_z = 0.02d0
+
+      xa_central_lower_limit_species(1) = 'he4'
+      xa_central_lower_limit(1) = 1d-2
+
+      max_age = 1d12
+
+      history_interval = 1
+      profile_interval = 50
+
+      varcontrol_target = 1d-3
+      mesh_delta_coeff = 0.5
+/
+
+
+! =============================================================================
+! PGSTAR NAMELIST
+! =============================================================================
+&pgstar
+  pgstar_interval = 10
+
+  History_Track2_win_flag = .true.
+  History_Track2_xname = 'star_age'
+  History_Track2_yname = 'V'
+  History_Track2_title = 'V Light Curve'
+  History_Track2_xaxis_label = 'Age (yr)'
+  History_Track2_yaxis_label = 'V mag'
+
+  History_Track3_win_flag = .true.
+  History_Track3_xname = 'R'
+  History_Track3_yname = 'B'
+  History_Track3_title = 'B-R'
+  History_Track3_xaxis_label = 'R mag'
+  History_Track3_yaxis_label = 'B mag'
+  History_Track3_reverse_yaxis = .true.
+
+  History_Track4_win_flag = .true.
+  History_Track4_xname = 'U'
+  History_Track4_yname = 'I'
+  History_Track4_title = 'U-I'
+  History_Track4_xaxis_label = 'U mag'
+  History_Track4_yaxis_label = 'I mag'
+  History_Track4_reverse_yaxis = .true.
+/

--- a/star/test_suite/custom_colors_legacy/inlist_colors_header
+++ b/star/test_suite/custom_colors_legacy/inlist_colors_header
@@ -1,0 +1,34 @@
+&star_job
+   read_extra_star_job_inlist(1) = .true.
+   extra_star_job_inlist_name(1) = 'inlist_colors'
+/ ! end of star_job namelist
+
+
+&eos
+   read_extra_eos_inlist(1) = .true.
+   extra_eos_inlist_name(1) = 'inlist_colors'
+/ ! end of eos namelist
+
+
+&kap
+   read_extra_kap_inlist(1) = .true.
+   extra_kap_inlist_name(1) = 'inlist_colors'
+/ ! end of kap namelist
+
+
+&colors
+   read_extra_colors_inlist(1) = .true.
+   extra_colors_inlist_name(1) = 'inlist_colors'
+/ ! end of colors namelist
+
+
+&controls
+   read_extra_controls_inlist(1) = .true.
+   extra_controls_inlist_name(1)= 'inlist_colors'
+/ ! end of controls namelist
+
+
+&pgstar
+   read_extra_pgstar_inlist(1) = .true.
+   extra_pgstar_inlist_name(1) = 'inlist_colors'
+/ ! end of pgstar namelist

--- a/star/test_suite/custom_colors_legacy/make/makefile
+++ b/star/test_suite/custom_colors_legacy/make/makefile
@@ -1,0 +1,5 @@
+
+
+STAR = star
+
+include $(MESA_DIR)/star/work_standard_makefile

--- a/star/test_suite/custom_colors_legacy/mk
+++ b/star/test_suite/custom_colors_legacy/mk
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+function check_okay {
+	if [ $? -ne 0 ]
+	then
+		echo
+		echo "FAILED"
+		echo
+		exit 1
+	fi
+}
+
+cd make; make; check_okay

--- a/star/test_suite/custom_colors_legacy/python_helpers/check_legacy_mode.py
+++ b/star/test_suite/custom_colors_legacy/python_helpers/check_legacy_mode.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate that a MESA colors test run used legacy precomputed photometry.
+
+Expected layout when run from python_helpers/:
+    ../inlist_colors
+    ../LOGS/history.data
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+from pathlib import Path
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise SystemExit(f"ERROR: missing file: {path}")
+
+
+def parse_photo_precompute(inlist_text: str) -> bool | None:
+    match = re.search(r"^\s*photo_precompute\s*=\s*\.(true|false)\.\s*$",
+                      inlist_text, re.IGNORECASE | re.MULTILINE)
+    if match is None:
+        return None
+    return match.group(1).lower() == "true"
+
+
+def parse_history_table(history_text: str) -> tuple[list[str], list[list[float]]]:
+    lines = [line.rstrip() for line in history_text.splitlines() if line.strip()]
+
+    names_idx = None
+    for i, line in enumerate(lines):
+        if "model_number" in line.split():
+            names_idx = i
+            break
+
+    if names_idx is None:
+        raise SystemExit("ERROR: could not locate history column names line containing 'model_number'")
+
+    names = lines[names_idx].split()
+    rows: list[list[float]] = []
+
+    for line in lines[names_idx + 1 :]:
+        parts = line.split()
+        if len(parts) != len(names):
+            continue
+        try:
+            row = [float(x.replace("D", "E").replace("d", "e")) for x in parts]
+        except ValueError:
+            continue
+        rows.append(row)
+
+    if not rows:
+        raise SystemExit("ERROR: no numeric history rows found after the column-name line")
+
+    return names, rows
+
+
+def col_values(names: list[str], rows: list[list[float]], name: str) -> list[float]:
+    try:
+        idx = names.index(name)
+    except ValueError:
+        raise SystemExit(f"ERROR: required history column '{name}' not found")
+    return [row[idx] for row in rows]
+
+
+def is_all_close(values: list[float], target: float, tol: float = 1e-12) -> bool:
+    return all(math.isfinite(v) and abs(v - target) <= tol for v in values)
+
+
+def any_finite_non_sentinel(values: list[float], sentinel: float = -1.0) -> bool:
+    for v in values:
+        if math.isfinite(v) and abs(v - sentinel) > 1e-12:
+            return True
+    return False
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    inlist_path = root / "inlist_colors"
+    history_path = root / "LOGS" / "history.data"
+
+    inlist_text = read_text(inlist_path)
+    photo_precompute = parse_photo_precompute(inlist_text)
+    if photo_precompute is None:
+        print("FAIL: could not find 'photo_precompute' in inlist_colors")
+        return 1
+    if not photo_precompute:
+        print("FAIL: inlist_colors does not enable legacy mode (photo_precompute is not .true.)")
+        return 1
+
+    history_text = read_text(history_path)
+    names, rows = parse_history_table(history_text)
+
+    mag_bol = col_values(names, rows, "Mag_bol")
+    flux_bol = col_values(names, rows, "Flux_bol")
+    interp_rad = col_values(names, rows, "Interp_rad")
+
+    if not any_finite_non_sentinel(mag_bol):
+        print("FAIL: Mag_bol is missing or never populated with finite values")
+        return 1
+
+    if not is_all_close(flux_bol, -1.0):
+        print("FAIL: Flux_bol is not the expected legacy sentinel (-1) for all rows")
+        return 1
+
+    if not is_all_close(interp_rad, -1.0):
+        print("FAIL: Interp_rad is not the expected legacy sentinel (-1) for all rows")
+        return 1
+
+    try:
+        interp_idx = names.index("Interp_rad")
+    except ValueError:
+        print("FAIL: Interp_rad column missing")
+        return 1
+
+    phot_cols = names[interp_idx + 1 :]
+    if not phot_cols:
+        print("FAIL: no photometric columns found after Interp_rad")
+        return 1
+
+    populated_phot_cols = []
+    for name in phot_cols:
+        values = col_values(names, rows, name)
+        if any_finite_non_sentinel(values):
+            populated_phot_cols.append(name)
+
+    if not populated_phot_cols:
+        print("FAIL: no populated photometric columns were found")
+        return 1
+
+    print("PASS: legacy colors signature detected")
+    print("  - photo_precompute = .true.")
+    print("  - Mag_bol populated")
+    print("  - Flux_bol = -1 for all rows")
+    print("  - Interp_rad = -1 for all rows")
+    print(f"  - populated photometric columns found: {', '.join(populated_phot_cols[:8])}")
+    if len(populated_phot_cols) > 8:
+        print(f"    ... and {len(populated_phot_cols) - 8} more")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/star/test_suite/custom_colors_legacy/python_helpers/movie_history.py
+++ b/star/test_suite/custom_colors_legacy/python_helpers/movie_history.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Make a movie that visually matches the live HISTORY_check viewer.
+# One frame per row; each frame shows the full chain up to that row.
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.animation import FFMpegWriter
+from plot_history_live import HistoryChecker  # uses static_HISTORY_check under the hood
+
+do_tqdm = True
+try:
+    from tqdm import tqdm
+except ImportError:
+    do_tqdm = False
+
+
+# Reuse the live viewer so formatting/logic stays identical
+
+OUT = "history.mp4"
+FPS = 24
+DPI = 150
+
+# Build once from the user's checker and pull arrays
+checker = HistoryChecker(history_file="../LOGS/history.data", refresh_interval=0.1)
+checker.update_data()  # read md + compute columns/colors
+checker.setup_plot()  # set labels, axes styling, grids
+
+age = np.asarray(checker.Star_Age, float)
+Teff = np.asarray(checker.Teff, float)
+Log_L = np.asarray(checker.Log_L, float)
+hr_x = np.asarray(checker.hr_color, float)
+hr_y = np.asarray(checker.hr_mag, float)
+phase_colors = (
+    np.asarray(checker.phase_colors, object) if len(checker.phase_colors) else None
+)
+filters = list(checker.filter_columns)
+fig, axes = checker.fig, checker.axes
+
+if age.size == 0:
+    raise RuntimeError("history.data has zero rows")
+
+
+# Helper: padded limits
+def pad(lo, hi, frac=0.05):
+    if not np.isfinite(lo) or not np.isfinite(hi) or lo == hi:
+        return lo - 1, hi + 1
+    span = hi - lo
+    return lo - frac * span, hi + frac * span
+
+
+# Fix axis limits once so the camera doesn't jump
+age_lo, age_hi = pad(np.nanmin(age), np.nanmax(age))
+Teff_lo, Teff_hi = pad(np.nanmin(Teff), np.nanmax(Teff))
+LogL_lo, LogL_hi = pad(np.nanmin(Log_L), np.nanmax(Log_L))
+hrx_lo, hrx_hi = pad(np.nanmin(hr_x), np.nanmax(hr_x))
+hry_lo, hry_hi = pad(np.nanmin(hr_y), np.nanmax(hr_y))
+ci_lo, ci_hi = pad(np.nanmin(checker.color_index), np.nanmax(checker.color_index))
+
+# Preload all magnitude series + their assigned colors from the live viewer
+mag_series = []
+for i, f in enumerate(filters):
+    y = np.asarray(getattr(checker.md, f), float)
+    if y.size != age.size:
+        continue
+    color = checker.filter_colors[i] if i < len(checker.filter_colors) else "black"
+    mag_series.append((f, y, color))
+
+if mag_series:
+    m_all = np.vstack([s for _, s, _ in mag_series])
+    mag_lo, mag_hi = pad(np.nanmin(m_all), np.nanmax(m_all))
+else:
+    mag_lo, mag_hi = 0.0, 1.0
+
+writer = FFMpegWriter(fps=FPS, codec="libx264", extra_args=["-pix_fmt", "yuv420p"])
+
+with writer.saving(fig, OUT, dpi=DPI):
+    N = age.size
+
+    if do_tqdm:
+        iterator = tqdm(range(N))
+    else:
+        iterator = range(N)
+
+    for i in iterator:
+        sl = slice(0, i + 1)
+
+        # Clear and re-apply the exact same formatting
+        for ax in axes.flatten():
+            ax.cla()
+        checker.setup_plot()
+
+        # Colors for this frame (phase legend if available; else colormap colors are already in phase_colors)
+        C = (
+            phase_colors[sl]
+            if phase_colors is not None and len(phase_colors) == N
+            else None
+        )
+
+        # === Top-left: CMD/HR (color vs mag) ===
+        axes[0, 0].plot(
+            hr_x[sl], hr_y[sl], marker=",", linestyle="-", color="k", alpha=0.2
+        )
+        if C is not None:
+            axes[0, 0].scatter(
+                hr_x[sl], hr_y[sl], c=C, s=15, alpha=0.9, edgecolors="none"
+            )
+        else:
+            axes[0, 0].scatter(hr_x[sl], hr_y[sl], s=15, alpha=0.9, edgecolors="none")
+        axes[0, 0].set_xlim(hrx_lo, hrx_hi)
+        axes[0, 0].set_ylim(hry_hi, hry_lo)  # invert mags
+
+        # === Top-right: Teff vs Log L ===
+        axes[0, 1].plot(
+            Teff[sl], Log_L[sl], marker=",", linestyle="-", color="k", alpha=0.2
+        )
+        if C is not None:
+            axes[0, 1].scatter(
+                Teff[sl], Log_L[sl], c=C, s=15, alpha=0.9, edgecolors="none"
+            )
+        else:
+            axes[0, 1].scatter(Teff[sl], Log_L[sl], s=15, alpha=0.9, edgecolors="none")
+        axes[0, 1].set_xlim(Teff_hi, Teff_lo)  # Teff inverted x
+        axes[0, 1].set_ylim(LogL_lo, LogL_hi)
+
+        # === Bottom-left: Age vs color index ===
+        axes[1, 0].plot(
+            age[sl],
+            checker.color_index[sl],
+            marker=",",
+            linestyle="-",
+            color="k",
+            alpha=0.2,
+        )
+        if C is not None:
+            axes[1, 0].scatter(
+                age[sl],
+                checker.color_index[sl],
+                c=C,
+                s=15,
+                alpha=1.0,
+                edgecolors="none",
+            )
+        else:
+            axes[1, 0].scatter(
+                age[sl], checker.color_index[sl], s=15, alpha=1.0, edgecolors="none"
+            )
+        axes[1, 0].set_xlim(age_lo, age_hi)
+        axes[1, 0].set_ylim(ci_lo, ci_hi)
+
+        # === Bottom-right: Age vs all filter mags (full chain) ===
+        for label, series, color in mag_series:
+            axes[1, 1].plot(
+                age[sl],
+                series[sl],
+                marker="o",
+                linestyle="-",
+                markersize=3,
+                alpha=0.8,
+                label=label,
+                color=color,
+            )
+        axes[1, 1].set_xlim(age_lo, age_hi)
+        axes[1, 1].set_ylim(mag_hi, mag_lo)  # invert mags
+        if mag_series:
+            axes[1, 1].legend()
+
+        # Phase legend exactly like the live viewer (only when real phases are present)
+        if getattr(checker, "has_phase", False):
+            legend_elements = checker.create_phase_legend()
+            if len(legend_elements) > 0:
+                # keep the filter legend on bottom-right and add a centered phase legend
+                axes[1, 1].legend()
+                n_phases = len(legend_elements)
+                ncol = max(1, (n_phases + 1) // 1)
+                fig.legend(
+                    handles=legend_elements,
+                    loc="upper center",
+                    bbox_to_anchor=(0.5, 0.53),
+                    ncol=ncol,
+                    title_fontsize=10,
+                    fontsize=10,
+                    frameon=True,
+                    fancybox=True,
+                    shadow=True,
+                )
+
+        plt.subplots_adjust(top=0.92)
+        writer.grab_frame()
+
+print(f"Wrote {age.size} frames -> {OUT}")

--- a/star/test_suite/custom_colors_legacy/python_helpers/plot_cmd_3d.py
+++ b/star/test_suite/custom_colors_legacy/python_helpers/plot_cmd_3d.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import glob
+import textwrap
+
+import matplotlib.pyplot as plt
+import mesa_reader as mr
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+from plot_history import MesaView, read_header_columns, setup_hr_diagram_params
+
+
+def get_z_axis_selection(available_columns, default="Interp_rad"):
+    """
+    Prints available columns and prompts the user to select one for the Z-axis.
+    """
+    print("\n" + "=" * 60)
+    print("AVAILABLE COLUMNS FROM HISTORY DATA")
+    print("=" * 60)
+
+    # Sort and format the list of columns to be readable
+    sorted_cols = sorted(available_columns)
+    col_list_str = ", ".join(sorted_cols)
+
+    # Wrap text so it doesn't overflow the terminal
+    print(textwrap.fill(col_list_str, width=80))
+    print("-" * 60)
+
+    while True:
+        user_input = input(
+            f"\nEnter the Z-axis column name (default: {default}): "
+        ).strip()
+
+        # Handle Default (Enter key)
+        if user_input == "":
+            if default in available_columns:
+                print(f"Selected default: {default}")
+                return default
+            else:
+                print(
+                    f"Warning: Default '{default}' not found in file. Please select manually."
+                )
+                continue
+
+        # Handle Valid Selection
+        if user_input in available_columns:
+            print(f"Selected: {user_input}")
+            return user_input
+
+        # Handle Invalid Selection
+        print(f"Error: '{user_input}' is not a valid column. Please try again.")
+
+
+def make_3d_cmd(history_file="../LOGS/history.data"):
+    md = mr.MesaData(history_file)
+    md = MesaView(md, 5)
+
+    all_cols, filter_columns = read_header_columns(history_file)
+    hr_color, hr_mag, hr_xlabel, hr_ylabel, color_index = setup_hr_diagram_params(
+        md, filter_columns
+    )
+
+    # --- NEW INTERACTIVE SECTION ---
+    # Prompt user for Z-axis, using Interp_rad as default
+    z_col_name = get_z_axis_selection(all_cols, default="Interp_rad")
+
+    # Dynamically retrieve the data column from the MesaData object
+    # getattr(md, "name") is equivalent to md.name
+    try:
+        z_data = getattr(md, z_col_name)
+    except AttributeError:
+        print(f"Error: Could not retrieve data for {z_col_name}.")
+        return
+    # -------------------------------
+
+    fig = plt.figure(figsize=(10, 8))
+    ax = fig.add_subplot(111, projection="3d")
+
+    # Use the dynamically selected z_data
+    ax.scatter(hr_color, hr_mag, z_data, s=5)
+
+    ax.set_xlabel(hr_xlabel)
+    ax.set_ylabel(hr_ylabel)
+    ax.set_zlabel(z_col_name)  # Update label to match selection
+
+    ax.invert_yaxis()
+
+    plt.tight_layout()
+    plt.show()
+
+
+def main():
+    # Helper to find file if specific path not strictly enforced
+    files = glob.glob("../LOGS/history.data")
+    if not files:
+        print("Error: ../LOGS/history.data not found.")
+        return
+
+    history_file = files[0]
+    make_3d_cmd(history_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/star/test_suite/custom_colors_legacy/python_helpers/plot_history.py
+++ b/star/test_suite/custom_colors_legacy/python_helpers/plot_history.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3.8
+####################################################
+#
+# Author: M Joyce, Modified by N. Miller,
+#         Further modified to automatically use all filters
+#         by reading the header of the history file.
+#         Enhanced with MESA's built-in evolutionary phase identification.
+#
+####################################################
+import glob
+
+import matplotlib.pyplot as plt
+import mesa_reader as mr
+import numpy as np
+
+
+class MesaView:
+    def __init__(self, md, skip):
+        self._md = md
+        self._skip = skip
+
+    def __getattr__(self, name):
+        v = getattr(self._md, name)
+        # If it's a 1D array with same length as star_age, slice it
+        if isinstance(v, np.ndarray) and v.ndim == 1:
+            sa = getattr(self._md, "star_age", None)
+            if (
+                isinstance(sa, np.ndarray)
+                and sa.ndim == 1
+                and v.shape[0] == sa.shape[0]
+            ):
+                return v[self._skip :]
+        return v
+
+
+def get_mesa_phase_info(phase_code):
+    """
+    Map MESA's phase_of_evolution integer codes to phase names and colors.
+    Based on MESA's exact internal phase definitions from star_data_def.inc
+    """
+    # MESA phase codes (exact from source code)
+    phase_map = {
+        -1: ("Relax", "#C0C0C0"),  # Silver - Relaxation phase
+        1: ("Starting", "#E6E6FA"),  # Lavender - Starting phase
+        2: ("Pre-MS", "#FF69B4"),  # Hot pink - Pre-main sequence
+        3: ("ZAMS", "#00FF00"),  # Bright green - Zero-age main sequence
+        4: ("IAMS", "#0000FF"),  # Blue - Intermediate-age main sequence
+        5: ("TAMS", "#FF8C00"),  # Dark orange - Terminal-age main sequence
+        6: ("He-Burn", "#8A2BE2"),  # Blue violet - Helium burning (general)
+        7: ("ZACHeB", "#9932CC"),  # Dark orchid - Zero-age core helium burning
+        8: ("TACHeB", "#BA55D3"),  # Medium orchid - Terminal-age core helium burning
+        9: ("TP-AGB", "#8B0000"),  # Dark red - Thermally pulsing AGB
+        10: ("C-Burn", "#FF4500"),  # Orange red - Carbon burning
+        11: ("Ne-Burn", "#FF6347"),  # Tomato - Neon burning
+        12: ("O-Burn", "#FF8C00"),  # Dark orange - Oxygen burning
+        13: ("Si-Burn", "#FFA500"),  # Orange - Silicon burning
+        14: ("WDCS", "#708090"),  # Slate gray - White dwarf cooling sequence
+    }
+
+    return phase_map.get(phase_code, ("Unknown", "#808080"))
+
+
+def get_phase_info_from_mesa(md):
+    """Get evolutionary phase information using MESA's phase_of_evolution."""
+
+    # Check if phase_of_evolution exists in the data
+    if hasattr(md, "phase_of_evolution"):
+        phase_codes = md.phase_of_evolution
+    else:
+        print("Warning: phase_of_evolution not found in history file.")
+        print("Make sure to add 'phase_of_evolution' to your history_columns.list")
+        # Fallback to unknown phase
+        n_models = len(md.model_number)
+        phase_codes = np.full(n_models, -1)
+
+    phases = []
+    phase_colors = []
+
+    for code in phase_codes:
+        phase_name, color = get_mesa_phase_info(int(code))
+        phases.append(phase_name)
+        phase_colors.append(color)
+
+    return phases, phase_colors
+
+
+def read_header_columns(history_file):
+    """Read column headers from history file."""
+    header_line = None
+    with open(history_file, "r") as fp:
+        for line in fp:
+            if "model_number" in line:
+                header_line = line.strip()
+                break
+
+    if header_line is None:
+        print("Warning: Could not find header line with 'model_number'")
+        return [], []
+
+    # Split the header line on whitespace
+    all_cols = header_line.split()
+
+    # Find the index of Flux_bol
+    try:
+        flux_index = all_cols.index("Interp_rad")
+        filter_columns = all_cols[flux_index + 1 :]
+    except ValueError:
+        print("Warning: Could not find 'Flux_bol' column in header")
+        filter_columns = []
+
+    return all_cols, filter_columns
+
+
+def setup_hr_diagram_params(md, filter_columns):
+    """Set up parameters for HR diagram based on available filters."""
+
+    # Normalize filter names for case-insensitive matching
+    fc_lower = [f.lower() for f in filter_columns]
+
+    def has(name):
+        return name.lower() in fc_lower
+
+    def get(name):
+        # return actual filter name (case preserved) if present
+        for f in filter_columns:
+            if f.lower() == name.lower():
+                try:
+                    return getattr(md, f)
+                except AttributeError:
+                    return md.data(f)
+        return None
+
+    # --- Gaia-like (Gbp, Grp, G) ---
+    if has("gbp") and has("grp") and has("g"):
+        hr_color = get("gbp") - get("grp")
+        hr_mag = get("g")
+        hr_xlabel = "Gbp - Grp"
+        hr_ylabel = "G"
+        color_index = hr_color
+
+    # --- Johnson-like broadbands ---
+    elif has("v"):
+        # B-R if present
+        if has("b") and has("r"):
+            hr_color = get("b") - get("r")
+            hr_mag = get("v")
+            hr_xlabel = "B - R"
+            hr_ylabel = "V"
+            color_index = hr_color
+        # B-V if only B present
+        elif has("b"):
+            hr_color = get("b") - get("v")
+            hr_mag = get("v")
+            hr_xlabel = "B - V"
+            hr_ylabel = "V"
+            color_index = hr_color
+        # V-R if only R present
+        elif has("r"):
+            hr_color = get("v") - get("r")
+            hr_mag = get("v")
+            hr_xlabel = "V - R"
+            hr_ylabel = "V"
+            color_index = hr_color
+        else:
+            # no recognized pair with V
+            hr_color = None
+
+    # --- Sloan-like g-r if no V branch matched ---
+    elif has("g") and has("r"):
+        hr_color = get("g") - get("r")
+        hr_mag = get("g")
+        hr_xlabel = "g - r"
+        hr_ylabel = "g"
+        color_index = hr_color
+
+    else:
+        hr_color = None
+
+    # If we matched a branch with a valid hr_color
+    if hr_color is not None:
+        return hr_color, hr_mag, hr_xlabel, hr_ylabel, color_index
+
+    # --- FALLBACK: use first and last filter if nothing above matched ---
+    if len(filter_columns) >= 2:
+        f1 = filter_columns[0]
+        f2 = filter_columns[-1]
+        try:
+            col1 = getattr(md, f1)
+        except AttributeError:
+            col1 = md.data(f1)
+        try:
+            col2 = getattr(md, f2)
+        except AttributeError:
+            col2 = md.data(f2)
+
+        hr_color = col1 - col2
+        hr_mag = col1
+        hr_xlabel = f"{f1} - {f2}"
+        hr_ylabel = f1
+        color_index = hr_color
+
+    else:
+        # Not enough filters, fallback to flat arrays
+        print("Warning: Not enough filter columns to construct color index")
+        hr_color = np.zeros_like(md.Teff)
+        hr_mag = np.zeros_like(md.Teff)
+        hr_xlabel = "Color Index"
+        hr_ylabel = "Magnitude"
+        color_index = hr_color
+
+    return hr_color, hr_mag, hr_xlabel, hr_ylabel, color_index
+
+
+def create_phase_plots(history_file="../LOGS/history.data"):
+    """
+    Create plots with MESA's evolutionary phase color coding.
+    """
+    # Read the MESA data
+    md = mr.MesaData(history_file)
+    md = MesaView(md, 5)
+    # Basic stellar parameters
+    Teff = md.Teff
+    Log_L = md.log_L
+    # Log_g = md.log_g
+    # Log_R = md.log_R
+    Star_Age = md.star_age
+    # Mag_bol = md.Mag_bol
+    # Flux_bol = np.log10(md.Flux_bol)
+
+    # Read headers and get filter info
+    all_cols, filter_columns = read_header_columns(history_file)
+
+    # Set up HR diagram parameters
+    hr_color, hr_mag, hr_xlabel, hr_ylabel, color_index = setup_hr_diagram_params(
+        md, filter_columns
+    )
+
+    # Get evolutionary phase information using MESA's built-in phases
+    phases, phase_colors = get_phase_info_from_mesa(md)
+
+    # Print phase statistics
+    unique_phases, counts = np.unique(phases, return_counts=True)
+    print("\nEvolutionary phases found:")
+    for phase, count in zip(unique_phases, counts):
+        print(f"  {phase}: {count} models")
+
+    # Create the plots
+    fig, axes = plt.subplots(
+        2, 2, figsize=(14, 18), gridspec_kw={"hspace": 0.3, "wspace": 0.2}
+    )
+
+    # Top-left plot: HR Diagram (Color vs. Magnitude) with phase colors
+    axes[0, 0].scatter(
+        hr_color, hr_mag, c=phase_colors, s=20, alpha=0.7, edgecolors="none"
+    )
+
+    axes[0, 0].set_xlabel(hr_xlabel, fontsize=14)
+    axes[0, 0].set_ylabel(hr_ylabel, fontsize=14)
+    axes[0, 0].invert_yaxis()
+    axes[0, 0].xaxis.set_ticks_position("top")
+    axes[0, 0].xaxis.set_label_position("top")
+    axes[0, 0].grid(True, alpha=0.3)
+
+    # Top-right plot: Teff vs. Log_L with phase colors
+    axes[0, 1].scatter(Teff, Log_L, c=phase_colors, s=20, alpha=0.7, edgecolors="none")
+
+    axes[0, 1].set_xlabel("Teff (K)", fontsize=14)
+    axes[0, 1].set_ylabel("Log L/L☉", fontsize=14)
+    axes[0, 1].invert_xaxis()
+    axes[0, 1].yaxis.set_label_position("right")
+    axes[0, 1].yaxis.tick_right()
+    axes[0, 1].xaxis.set_ticks_position("top")
+    axes[0, 1].xaxis.set_label_position("top")
+    axes[0, 1].grid(True, alpha=0.3)
+
+    # Bottom-left plot: Age vs. Color Index with phase colors
+    axes[1, 0].scatter(
+        Star_Age, color_index, c=phase_colors, s=20, alpha=0.7, edgecolors="none"
+    )
+
+    axes[1, 0].set_xlabel("Age (years)", fontsize=14)
+    axes[1, 0].set_ylabel(f"Color ({hr_xlabel})", fontsize=14)
+    axes[1, 0].grid(True, alpha=0.3)
+
+    # Bottom-right plot: Age vs. All Filter Magnitudes
+    for filt in filter_columns:
+        try:
+            col_data = getattr(md, filt)
+        except AttributeError:
+            try:
+                col_data = md.data(filt)
+            except Exception:
+                print(f"Warning: Could not retrieve data for filter {filt}")
+                continue
+
+        axes[1, 1].plot(
+            Star_Age,
+            col_data,
+            marker="o",
+            linestyle="-",
+            label=filt,
+            markersize=3,
+            alpha=0.8,
+        )
+
+    axes[1, 1].set_xlabel("Age (years)", fontsize=14)
+    axes[1, 1].set_ylabel("Magnitude", fontsize=14)
+    axes[1, 1].invert_yaxis()
+    axes[1, 1].yaxis.set_label_position("right")
+    axes[1, 1].yaxis.tick_right()
+    axes[1, 1].grid(True, alpha=0.3)
+
+    # Create a custom legend for evolutionary phases (only show phases that appear)
+    unique_phases = []
+    unique_colors = []
+    for phase, color in zip(phases, phase_colors):
+        if phase not in unique_phases:
+            unique_phases.append(phase)
+            unique_colors.append(color)
+
+    # Add legend to the first subplot
+    legend_elements = [
+        plt.Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor=color,
+            markersize=8,
+            label=phase,
+            markeredgecolor="none",
+        )
+        for phase, color in zip(unique_phases, unique_colors)
+    ]
+
+    # Position legend outside the plot
+    axes[0, 0].legend(
+        handles=legend_elements,
+        loc="center left",
+        bbox_to_anchor=(1, 0.5),
+        title="Evolutionary Phase",
+    )
+
+    plt.tight_layout()
+    return fig, axes, phases, phase_colors
+
+
+def main():
+    # Locate the history.data file
+    try:
+        history_file = glob.glob("../LOGS/history.data")[0]
+    except IndexError:
+        history_file = "../LOGS/history.data"
+        print(f"Warning: No history.data file found, will check for {history_file}")
+
+    print("Using MESA's built-in phase_of_evolution for phase identification")
+    print("Make sure 'phase_of_evolution' is in your history_columns.list")
+    print("\nMESA Phase Definitions:")
+    print("  -1: Relax, 1: Starting, 2: Pre-MS, 3: ZAMS, 4: IAMS, 5: TAMS")
+    print("  6: He-Burn, 7: ZACHeB, 8: TACHeB, 9: TP-AGB")
+    print("  10: C-Burn, 11: Ne-Burn, 12: O-Burn, 13: Si-Burn, 14: WDCS")
+
+    fig, axes, phases, phase_colors = create_phase_plots(history_file)
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/star/test_suite/custom_colors_legacy/python_helpers/plot_history_live.py
+++ b/star/test_suite/custom_colors_legacy/python_helpers/plot_history_live.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+import glob
+import os
+
+# ---------------------------
+# Insert after imports (HISTORY_check.py)
+# ---------------------------
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import mesa_reader as mr
+import numpy as np
+from matplotlib.animation import FuncAnimation
+
+# Import functions from static version for consistency
+from plot_history import MesaView  # get_mesa_phase_info,
+from plot_history import read_header_columns, setup_hr_diagram_params
+
+
+NEWTON_ITER_PATHS = [
+    "../SED/iteration_colors.data",
+    "SED/iteration_colors.data",
+    "iteration_colors.data",
+]
+
+
+def age_colormap_colors(ages, cmap_name="inferno", recent_fraction=0.25, stretch=5.0):
+    """
+    Map ages -> RGBA colors with these properties:
+      - cmap_name: 'inferno'|'plasma'|'magma', etc.
+      - recent_fraction: fraction (0..1) of the top of the age range that
+                         receives most of the color variation (default 0.25).
+      - stretch: non-linear exponent applied to normalized ages to compress older ages.
+                 larger -> more compression of old ages (default 5.0).
+    Behavior:
+      - Colors update with the min/max of `ages` passed in each call.
+      - We first normalize ages to [0,1] using current min/max.
+      - Apply non-linear transform that compresses the lower (1-recent_fraction)
+        and expands the top `recent_fraction` so the most recent quarter is "hot".
+    """
+    ages = np.asarray(ages, dtype=float)
+    # handle degenerate case
+    if ages.size == 0:
+        return np.zeros((0, 4))
+
+    amin, amax = ages.min(), ages.max()
+    span = amax - amin if amax > amin else 1.0
+    nrm = (ages - amin) / span
+    # Nonlinear compressor that allocates most dynamic range to the top `recent_fraction`.
+    # We'll compress lower portion via a power transform, then rescale piecewise.
+    rf = float(np.clip(recent_fraction, 1e-6, 0.99))
+    # first apply power-law compression to whole range (older ages -> smaller)
+    nrm_pow = nrm**stretch
+
+    # Now remap such that nrm_pow in [0, 1-rf] -> [0, 0.05] (very dark ramp),
+    # and nrm_pow in [1-rf,1] -> [0.05,1.0] (main color variation).
+    cutoff = 1.0 - rf
+    below = nrm_pow <= cutoff
+    above = ~below
+    remapped = np.empty_like(nrm_pow)
+    if cutoff <= 0:
+        # degenerate: everything treated as recent
+        remapped = nrm_pow
+    else:
+        # compress the big older chunk into a small lower band [0, low_band]
+        low_band = 0.02  # almost-black band for the old bulk
+        # linear rescale below cutoff into [0, low_band]
+        if below.any():
+            remapped[below] = (nrm_pow[below] / cutoff) * low_band
+        # rescale above cutoff into [low_band, 1.0]
+        if above.any():
+            remapped[above] = low_band + (
+                (nrm_pow[above] - cutoff) / (1.0 - cutoff)
+            ) * (1.0 - low_band)
+
+    # Ensure in [0,1]
+    remapped = np.clip(remapped, 0.0, 1.0)
+
+    cmap = mpl.cm.get_cmap(cmap_name)
+    colors = cmap(remapped)  # RGBA Nx4
+    return colors
+
+
+def get_improved_mesa_phase_info(phase_code):
+    """
+    Map MESA's phase_of_evolution integer codes to phase names and more intuitive colors.
+    Colors follow stellar evolution logic: blue (hot/young) -> red (cool/evolved) -> white (remnants)
+    """
+    # Improved phase colors that make physical sense
+    phase_map = {
+        -1: ("Relax", "#808080"),  # Gray - Relaxation phase
+        1: ("Starting", "#E6E6FA"),  # Lavender - Starting phase
+        2: ("Pre-MS", "#9370DB"),  # Medium purple - Pre-main sequence (young)
+        3: ("ZAMS", "#4169E1"),  # Royal blue - Zero-age MS (hot, young MS)
+        4: ("IAMS", "#00CED1"),  # Dark turquoise - Intermediate-age MS
+        5: ("TAMS", "#FF6347"),  # Tomato - Terminal-age MS (cooler, evolved MS)
+        6: ("He-Burn", "#FF4500"),  # Orange red - Helium burning (post-MS)
+        7: ("ZACHeB", "#FF8C00"),  # Dark orange - Zero-age core helium burning
+        8: ("TACHeB", "#FFA500"),  # Orange - Terminal-age core helium burning
+        9: ("TP-AGB", "#DC143C"),  # Crimson - Thermally pulsing AGB (very evolved)
+        10: ("C-Burn", "#B22222"),  # Fire brick - Carbon burning (massive stars)
+        11: ("Ne-Burn", "#8B0000"),  # Dark red - Neon burning
+        12: ("O-Burn", "#800000"),  # Maroon - Oxygen burning
+        13: ("Si-Burn", "#654321"),  # Dark brown - Silicon burning (pre-collapse)
+        14: ("WDCS", "#F5F5F5"),  # White smoke - White dwarf cooling sequence
+    }
+
+    return phase_map.get(phase_code, ("Unknown", "#696969"))  # Dim gray for unknown
+
+
+def get_phase_info_from_mesa(md):
+    """Get evolutionary phase information using MESA's phase_of_evolution if present.
+    If missing, return None phase names and AGE-driven colors (inferno by default)."""
+    # If present, use original behavior (map codes to names/colors)
+    if hasattr(md, "phase_of_evolution"):
+        phase_codes = md.phase_of_evolution
+        phases = []
+        phase_colors = []
+        for code in phase_codes:
+            phase_name, color = get_improved_mesa_phase_info(int(code))
+            phases.append(phase_name)
+            phase_colors.append(color)
+        return phases, phase_colors
+
+    # fallback: color by age using inferno colormap, updated every call
+    # Warning message kept (but only once)
+    print("Warning: phase_of_evolution not found in history file.")
+    print("Make sure to add 'phase_of_evolution' to your history_columns.list")
+    ages = getattr(md, "star_age", None)
+    if ages is None:
+        # nothing to color
+        return [], []
+
+    # choose params: recent_fraction=0.25 compress older ages heavily (stretch=5)
+    colors = age_colormap_colors(
+        ages, cmap_name="jet", recent_fraction=0.25, stretch=5.0
+    )
+    # produce placeholder phase names (None or empty is fine)
+    phases = [None] * len(colors)
+    phase_colors = list(colors)
+    return phases, phase_colors
+
+
+def get_filter_colors(filter_names):
+    """Generate distinct colors for different filters."""
+    # Use a colormap that provides good contrast
+    cmap = plt.cm.Set1  # Good for distinct colors
+    colors = []
+    for i, filt in enumerate(filter_names):
+        color = cmap(i / max(len(filter_names), 1))
+        colors.append(color)
+    return colors
+
+
+class HistoryChecker:
+    def __init__(self, history_file="../LOGS/history.data", refresh_interval=0.01):
+        """
+        Initialize the History checker with auto-refresh capability and MESA phase color coding.
+
+        Args:
+            history_file: Path to the MESA history.data file
+            refresh_interval: Time in seconds between refresh attempts
+        """
+        self.history_file = history_file
+        self.refresh_interval = refresh_interval
+        self.last_modified = None
+
+        # Create the figure and axes
+        self.fig, self.axes = plt.subplots(
+            2, 2, figsize=(18, 16), gridspec_kw={"hspace": 0.01, "wspace": 0.01}
+        )
+
+        self.update_flag = 0
+        self._iter_warn_issued = False
+        # Initial setup
+        self.filter_columns = []
+        self.iter_col_names = None
+        self.iter_data = None
+        self.phases = []
+        self.phase_colors = []
+        self.filter_colors = []
+        self.update_data()
+        self.setup_plot()
+
+    def setup_plot(self):
+        """Set up the plot with formatting and labels (titles removed, labels enlarged, top x-axis added)."""
+        # Top-left plot: HR Diagram (Color vs. Magnitude)
+        self.axes[0, 0].set_xlabel(self.hr_xlabel, fontsize=16)
+        self.axes[0, 0].set_ylabel(self.hr_ylabel, fontsize=16)
+        self.axes[0, 0].invert_yaxis()
+        self.axes[0, 0].xaxis.set_ticks_position("top")
+        self.axes[0, 0].xaxis.set_label_position("top")
+        self.axes[0, 0].grid(True, alpha=0.3)
+
+        # Top-right plot: Teff vs. Log_L
+        self.axes[0, 1].set_xlabel("Teff (K)", fontsize=16)
+        self.axes[0, 1].set_ylabel("Log L/L☉", fontsize=16)
+        self.axes[0, 1].invert_xaxis()
+        self.axes[0, 1].yaxis.set_label_position("right")
+        self.axes[0, 1].yaxis.tick_right()
+        self.axes[0, 1].xaxis.set_ticks_position("top")
+        self.axes[0, 1].xaxis.set_label_position("top")
+        self.axes[0, 1].grid(True, alpha=0.3)
+
+        # Bottom-left plot: Age vs. Color Index
+        self.axes[1, 0].set_xlabel("Age (years)", fontsize=16)
+        self.axes[1, 0].set_ylabel(f"Color ({self.hr_xlabel})", fontsize=16)
+        self.axes[1, 0].grid(True, alpha=0.3)
+
+        # Bottom-right plot: Age vs. All Filter Magnitudes
+        self.axes[1, 1].set_xlabel("Age (years)", fontsize=16)
+        self.axes[1, 1].set_ylabel("Magnitude", fontsize=16)
+        self.axes[1, 1].invert_yaxis()
+        self.axes[1, 1].yaxis.set_label_position("right")
+        self.axes[1, 1].yaxis.tick_right()
+        self.axes[1, 1].grid(True, alpha=0.3)
+
+        plt.tight_layout()
+        plt.subplots_adjust(top=0.92)  # Adjust if needed for legend spacing
+
+    def check_for_changes(self):
+        """Check if history file has been modified since last check."""
+        if not os.path.exists(self.history_file):
+            print(f"Warning: History file {self.history_file} not found")
+            return False
+
+        current_mtime = os.path.getmtime(self.history_file)
+
+        if self.last_modified is None or current_mtime > self.last_modified:
+            self.last_modified = current_mtime
+            return True
+
+        return False
+
+    def update_data(self):
+        """Read data from history file and extract relevant columns."""
+        if not os.path.exists(self.history_file):
+            print(f"Warning: History file {self.history_file} not found")
+            return
+
+        try:
+            # Read the MESA data
+            self.md = mr.MesaData(self.history_file)
+            self.md = MesaView(self.md, 5)
+            # after: self.phases, self.phase_colors = get_phase_info_from_mesa(self.md)
+            self.has_phase = (
+                hasattr(self.md, "phase_of_evolution")
+                and np.unique(self.md.phase_of_evolution).size > 1
+            )
+
+            # Basic stellar parameters
+            self.Teff = self.md.Teff
+            self.Log_L = self.md.log_L
+            self.Log_g = self.md.log_g
+            self.Log_R = self.md.log_R
+            self.Star_Age = self.md.star_age
+            self.Mag_bol = self.md.Mag_bol
+            self.Flux_bol = np.log10(self.md.Flux_bol)
+
+            # Read header columns using imported function
+            self.all_cols, self.filter_columns = read_header_columns(self.history_file)
+
+            # Set up HR diagram parameters using imported function
+            (
+                self.hr_color,
+                self.hr_mag,
+                self.hr_xlabel,
+                self.hr_ylabel,
+                self.color_index,
+            ) = setup_hr_diagram_params(self.md, self.filter_columns)
+
+            # Get evolutionary phase information using MESA's built-in phases with improved colors
+            self.phases, self.phase_colors = get_phase_info_from_mesa(self.md)
+
+            # Get filter colors for the magnitude plot
+            self.filter_colors = get_filter_colors(self.filter_columns)
+
+        except Exception as e:
+            print(f"Error reading history data: {e}")
+
+        self.load_newton_iter_data()
+
+    def load_newton_iter_data(self):
+        """Try to load Newton iteration data from the Colors SED output.
+        Sets self.iter_col_names / self.iter_data, or None if unavailable.
+        Warns once to terminal if the file cannot be found."""
+        for path in NEWTON_ITER_PATHS:
+            if os.path.exists(path):
+                try:
+                    with open(path, "r") as f:
+                        header = f.readline().strip()
+                    if header.startswith("#"):
+                        header = header[1:].strip()
+                    col_names = header.split()
+                    data = np.loadtxt(path, comments="#")
+                    if data.ndim == 1:
+                        data = data.reshape(1, -1)
+                    self.iter_col_names = col_names
+                    self.iter_data = data
+                    return
+                except Exception as e:
+                    if not self._iter_warn_issued:
+                        print(f"Warning: found {path} but failed to load Newton iteration data: {e}")
+                        self._iter_warn_issued = True
+                    self.iter_col_names = None
+                    self.iter_data = None
+                    return
+        if not self._iter_warn_issued:
+            print("Warning: Newton iteration data not found "
+                  "(searched SED/iteration_colors.data). Skipping overlay.")
+            self._iter_warn_issued = True
+        self.iter_col_names = None
+        self.iter_data = None
+
+    def get_iter_col(self, name):
+        """Return a column array from the iteration data by column name, or None."""
+        if self.iter_col_names is None or self.iter_data is None:
+            return None
+        try:
+            idx = self.iter_col_names.index(name)
+            return self.iter_data[:, idx]
+        except (ValueError, IndexError):
+            return None
+
+    def overlay_newton_iters(self, ax, x_data, y_data, label="Newton iter"):
+        """Overlay Newton iteration points on an axis if both arrays are non-None."""
+        if x_data is None or y_data is None:
+            return
+        x = np.asarray(x_data, dtype=float)
+        y = np.asarray(y_data, dtype=float)
+        mask = np.isfinite(x) & np.isfinite(y)
+        if not np.any(mask):
+            return
+        ax.scatter(
+            x[mask], y[mask],
+            marker="x", s=40, linewidths=1.5,
+            color="orange", alpha=0.85, label=label, zorder=5,
+        )
+
+    def resolve_iter_color_index(self):
+        """Attempt to compute the same color index used for hr_color from iteration data.
+        Parses hr_xlabel (e.g. 'B-V') into two filter column names and subtracts them."""
+        xlabel = getattr(self, "hr_xlabel", "")
+        # Strip surrounding parens if present
+        xlabel = xlabel.strip("()")
+        if "-" not in xlabel:
+            return None
+        parts = xlabel.split("-", 1)
+        col_a = self.get_iter_col(parts[0].strip())
+        col_b = self.get_iter_col(parts[1].strip())
+        if col_a is None or col_b is None:
+            return None
+        return col_a - col_b
+
+    def resolve_iter_hr_mag(self):
+        """Attempt to get the hr magnitude column from iteration data using hr_ylabel."""
+        ylabel = getattr(self, "hr_ylabel", "")
+        # ylabel might be e.g. "V" or "Mv" — try direct lookup
+        col = self.get_iter_col(ylabel.strip())
+        if col is not None:
+            return col
+        # Also strip common magnitude prefixes
+        for prefix in ("M_", "Mv", "m_"):
+            stripped = ylabel.replace(prefix, "").strip()
+            col = self.get_iter_col(stripped)
+            if col is not None:
+                return col
+        return None
+
+    def create_phase_legend(self):
+        unique_phases, unique_colors = [], []
+        for phase, color in zip(self.phases, self.phase_colors):
+            if phase is None:  # ignore fallback age-color entries
+                continue
+            if phase not in unique_phases:
+                unique_phases.append(phase)
+                unique_colors.append(color)
+        return [
+            plt.Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="w",
+                markerfacecolor=color,
+                markersize=8,
+                label=phase,
+                markeredgecolor="none",
+            )
+            for phase, color in zip(unique_phases, unique_colors)
+        ]
+
+    def update_plot(self, frame):
+        """Update the plot with new data if the file has changed."""
+        if not self.check_for_changes():
+            return
+
+        if self.update_flag < 5:
+            print(f"Detected changes in {self.history_file}, updating plot...")
+            self.update_flag = self.update_flag + 1
+        elif self.update_flag == 5:
+            print(
+                f"... MESA is clearly running so no more updates about: {self.history_file}"
+            )
+            self.update_flag = self.update_flag + 1
+
+        # Update data
+        self.update_data()
+
+        # Clear all axes
+        for ax in self.axes.flatten():
+            ax.clear()
+
+        # Reset plot formatting
+        self.setup_plot()
+
+        # Top-left plot: HR Diagram with phase colors
+        if len(self.phases) > 0:
+            self.axes[0, 0].plot(
+                self.hr_color,
+                self.hr_mag,
+                marker=",",
+                linestyle="-",
+                color="k",
+                alpha=0.2,
+            )
+
+            self.axes[0, 0].scatter(
+                self.hr_color,
+                self.hr_mag,
+                c=self.phase_colors,
+                s=15,
+                alpha=0.9,
+                linestyle="-",
+                edgecolors="none",
+            )
+        else:
+            self.axes[0, 0].plot(self.hr_color, self.hr_mag, "go")
+
+        # Overlay Newton iteration data on HR diagram
+        self.overlay_newton_iters(
+            self.axes[0, 0],
+            self.resolve_iter_color_index(),
+            self.resolve_iter_hr_mag(),
+        )
+
+        # Top-right plot: Teff vs. Log_L with phase colors
+        if len(self.phases) > 0:
+            self.axes[0, 1].plot(
+                self.Teff,
+                self.Log_L,
+                marker=",",
+                linestyle="-",
+                color="k",
+                alpha=0.2,
+            )
+
+            self.axes[0, 1].scatter(
+                self.Teff,
+                self.Log_L,
+                c=self.phase_colors,
+                s=15,
+                alpha=0.9,
+                linestyle="-",
+                edgecolors="none",
+            )
+        else:
+            self.axes[0, 1].plot(self.Teff, self.Log_L, "go")
+
+        # Overlay Newton iteration data on Teff vs log_L
+        self.overlay_newton_iters(
+            self.axes[0, 1],
+            self.get_iter_col("Teff"),
+            self.get_iter_col("log_L"),
+        )
+
+        # Bottom-left plot: Age vs. Color Index with phase colors
+        if len(self.phases) > 0:
+            self.axes[1, 0].plot(
+                self.Star_Age,
+                self.color_index,
+                marker=",",
+                linestyle="-",
+                color="k",
+                alpha=0.2,
+            )
+
+            self.axes[1, 0].scatter(
+                self.Star_Age,
+                self.color_index,
+                c=self.phase_colors,
+                s=15,
+                alpha=1,
+                linestyle="-",
+                edgecolors="none",
+            )
+
+        else:
+            self.axes[1, 0].plot(self.Star_Age, self.color_index, "kx")
+
+        for i, filt in enumerate(self.filter_columns):
+            try:
+                col_data = getattr(self.md, filt)
+            except AttributeError:
+                try:
+                    col_data = self.md.data(filt)
+                except Exception:
+                    print(f"Warning: Could not retrieve data for filter {filt}")
+                    continue
+
+            col_data = np.asarray(col_data, dtype=float)
+            age = np.asarray(self.Star_Age, dtype=float)
+
+            # --- physical mask ---
+            mask = (
+                np.isfinite(col_data)
+                & np.isfinite(age)
+                & (col_data < 90.0)  # magnitude sanity bound
+                & (col_data > -50.0)  # avoid garbage negatives
+            )
+
+            if not np.any(mask):
+                # Entire column is non-physical → skip it
+                continue
+
+            color = self.filter_colors[i] if i < len(self.filter_colors) else "black"
+
+            self.axes[1, 1].plot(
+                age[mask],
+                col_data[mask],
+                marker="o",
+                linestyle="-",
+                label=filt,
+                color=color,
+                markersize=3,
+                alpha=0.8,
+            )
+
+        # Add evolutionary phase legend at the top of the figure
+        if len(self.phases) > 1:
+            # Add legend to filter plot
+            self.axes[1, 1].legend()
+
+        # --- legend block ---
+        if getattr(self, "has_phase", False):
+            legend_elements = self.create_phase_legend()
+            if len(legend_elements) > 0:
+                # optional: also keep the filter legend on bottom-right axes
+                self.axes[1, 1].legend()
+
+                n_phases = len(legend_elements)
+                ncol = max(1, (n_phases + 1) // 1)  # same as before; tweak if needed
+                self.fig.legend(
+                    handles=legend_elements,
+                    loc="upper center",
+                    bbox_to_anchor=(0.5, 0.53),
+                    ncol=ncol,
+                    title_fontsize=10,
+                    fontsize=10,
+                    frameon=True,
+                    fancybox=True,
+                    shadow=True,
+                )
+
+        # Adjust layout to make room for top legend
+        plt.tight_layout()
+        plt.subplots_adjust(top=0.92)
+
+        # Update the figure
+        self.fig.canvas.draw_idle()
+
+    def run(self):
+        """Start the auto-refreshing display."""
+        print(f"Monitoring history file: {self.history_file}")
+        print(f"Refresh interval: {self.refresh_interval} seconds")
+        print("Using MESA's built-in phase_of_evolution for color coding")
+        print("Make sure 'phase_of_evolution' is in your history_columns.list")
+        print("\nMESA Phase Definitions:")
+        print("  -1: Relax, 1: Starting, 2: Pre-MS, 3: ZAMS, 4: IAMS, 5: TAMS")
+        print("  6: He-Burn, 7: ZACHeB, 8: TACHeB, 9: TP-AGB")
+        print("  10: C-Burn, 11: Ne-Burn, 12: O-Burn, 13: Si-Burn, 14: WDCS")
+
+        # Initial plot
+        self.update_plot(0)
+
+        # Set up animation
+        self.animation = FuncAnimation(
+            self.fig,
+            self.update_plot,
+            interval=self.refresh_interval * 1000,  # Convert to milliseconds
+            cache_frame_data=False,
+        )
+
+        # Show the plot (this will block until window is closed)
+        plt.show()
+
+
+def main():
+    # Locate the history.data file
+    try:
+        history_file = glob.glob("../LOGS/history.data")[0]
+    except IndexError:
+        history_file = "../LOGS/history.data"  # Default path if not found
+        print(f"Warning: No history.data file found, will check for {history_file}")
+
+    checker = HistoryChecker(history_file=history_file, refresh_interval=0.1)
+    checker.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/star/test_suite/custom_colors_legacy/re
+++ b/star/test_suite/custom_colors_legacy/re
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+shopt -u expand_aliases 
+
+photo_directory=photos
+
+function most_recent_photo {
+    ls -tp "$photo_directory" | grep -v / | head -1
+}
+
+if [ $# -eq 0 ]
+then
+    photo=$(most_recent_photo)
+else
+    photo=$1
+fi
+
+if [ -z "$photo" ] || ! [ -f "$photo_directory/$photo" ]
+then
+    echo "specified photo ($photo) does not exist"
+    exit 1
+fi
+
+echo "restart from $photo"
+if ! cp "$photo_directory/$photo" restart_photo
+then
+    echo "failed to copy photo ($photo)"
+    exit 1
+fi
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+./star
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"

--- a/star/test_suite/custom_colors_legacy/rn
+++ b/star/test_suite/custom_colors_legacy/rn
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# this provides the definition of do_one (run one part of test)
+# do_one [inlist] [output model] [LOGS directory]
+source "${MESA_DIR}/star/test_suite/test_suite_helpers"
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+
+do_one inlist_colors_header
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+
+echo 'finished'

--- a/star/test_suite/custom_colors_legacy/rn1
+++ b/star/test_suite/custom_colors_legacy/rn1
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+rm -f restart_photo
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+./star
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"

--- a/star/test_suite/custom_colors_legacy/src/run.f90
+++ b/star/test_suite/custom_colors_legacy/src/run.f90
@@ -1,0 +1,15 @@
+      program run
+      use run_star_support, only: do_read_star_job
+      use run_star, only: do_run_star
+
+      implicit none
+
+      integer :: ierr
+
+      ierr = 0
+      call do_read_star_job('inlist', ierr)
+      if (ierr /= 0) stop 1
+
+      call do_run_star
+
+      end program run

--- a/star/test_suite/custom_colors_legacy/src/run_star_extras.f90
+++ b/star/test_suite/custom_colors_legacy/src/run_star_extras.f90
@@ -1,0 +1,256 @@
+! ***********************************************************************
+!
+!   Copyright (C) 2010-2025  Bill Paxton & The MESA Team
+!
+!   This program is free software: you can redistribute it and/or modify
+!   it under the terms of the GNU Lesser General Public License
+!   as published by the Free Software Foundation,
+!   either version 3 of the License, or (at your option) any later version.
+!
+!   This program is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+!   See the GNU Lesser General Public License for more details.
+!
+!   You should have received a copy of the GNU Lesser General Public License
+!   along with this program. If not, see <https://www.gnu.org/licenses/>.
+!
+! ***********************************************************************
+
+module run_star_extras
+
+   use star_lib
+   use star_def
+   use const_def
+   use math_lib
+
+   implicit none
+
+   ! these routines are called by the standard run_star check_model
+contains
+
+   subroutine extras_controls(id, ierr)
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      ! this is the place to set any procedure pointers you want to change
+      ! e.g., other_wind, other_mixing, other_energy  (see star_data.inc)
+
+      ! the extras functions in this file will not be called
+      ! unless you set their function pointers as done below.
+      ! otherwise we use a null_ version which does nothing (except warn).
+
+      s%extras_startup => extras_startup
+      s%extras_start_step => extras_start_step
+      s%extras_check_model => extras_check_model
+      s%extras_finish_step => extras_finish_step
+      s%extras_after_evolve => extras_after_evolve
+      s%how_many_extra_history_columns => how_many_extra_history_columns
+      s%data_for_extra_history_columns => data_for_extra_history_columns
+      s%how_many_extra_profile_columns => how_many_extra_profile_columns
+      s%data_for_extra_profile_columns => data_for_extra_profile_columns
+
+      s%how_many_extra_history_header_items => how_many_extra_history_header_items
+      s%data_for_extra_history_header_items => data_for_extra_history_header_items
+      s%how_many_extra_profile_header_items => how_many_extra_profile_header_items
+      s%data_for_extra_profile_header_items => data_for_extra_profile_header_items
+
+   end subroutine extras_controls
+
+   subroutine extras_startup(id, restart, ierr)
+      integer, intent(in) :: id
+      logical, intent(in) :: restart
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+   end subroutine extras_startup
+
+   integer function extras_start_step(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      extras_start_step = 0
+   end function extras_start_step
+
+   ! returns either keep_going, retry, or terminate.
+   integer function extras_check_model(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      extras_check_model = keep_going
+      if (.false. .and. s%star_mass_h1 < 0.35d0) then
+         ! stop when star hydrogen mass drops to specified level
+         extras_check_model = terminate
+         write (*, *) 'have reached desired hydrogen mass'
+         return
+      end if
+
+      ! if you want to check multiple conditions, it can be useful
+      ! to set a different termination code depending on which
+      ! condition was triggered.  MESA provides 9 customizable
+      ! termination codes, named t_xtra1 .. t_xtra9.  You can
+      ! customize the messages that will be printed upon exit by
+      ! setting the corresponding termination_code_str value.
+      ! termination_code_str(t_xtra1) = 'my termination condition'
+
+      ! by default, indicate where (in the code) MESA terminated
+      if (extras_check_model == terminate) s%termination_code = t_extras_check_model
+   end function extras_check_model
+
+   integer function how_many_extra_history_columns(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      how_many_extra_history_columns = 0
+   end function how_many_extra_history_columns
+
+   subroutine data_for_extra_history_columns(id, n, names, vals, ierr)
+      integer, intent(in) :: id, n
+      character(len=maxlen_history_column_name) :: names(n)
+      real(dp) :: vals(n)
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      ! note: do NOT add the extras names to history_columns.list
+      ! the history_columns.list is only for the built-in history column options.
+      ! it must not include the new column names you are adding here.
+
+   end subroutine data_for_extra_history_columns
+
+   integer function how_many_extra_profile_columns(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      how_many_extra_profile_columns = 0
+   end function how_many_extra_profile_columns
+
+   subroutine data_for_extra_profile_columns(id, n, nz, names, vals, ierr)
+      integer, intent(in) :: id, n, nz
+      character(len=maxlen_profile_column_name) :: names(n)
+      real(dp) :: vals(nz, n)
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      integer :: k
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      ! note: do NOT add the extra names to profile_columns.list
+      ! the profile_columns.list is only for the built-in profile column options.
+      ! it must not include the new column names you are adding here.
+
+      ! here is an example for adding a profile column
+      !if (n /= 1) stop 'data_for_extra_profile_columns'
+      !names(1) = 'beta'
+      !do k = 1, nz
+      !   vals(k,1) = s% Pgas(k)/s% P(k)
+      !end do
+
+   end subroutine data_for_extra_profile_columns
+
+   integer function how_many_extra_history_header_items(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      how_many_extra_history_header_items = 0
+   end function how_many_extra_history_header_items
+
+   subroutine data_for_extra_history_header_items(id, n, names, vals, ierr)
+      integer, intent(in) :: id, n
+      character(len=maxlen_history_column_name) :: names(n)
+      real(dp) :: vals(n)
+      type(star_info), pointer :: s
+      integer, intent(out) :: ierr
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      ! here is an example for adding an extra history header item
+      ! also set how_many_extra_history_header_items
+      ! names(1) = 'mixing_length_alpha'
+      ! vals(1) = s% mixing_length_alpha
+
+   end subroutine data_for_extra_history_header_items
+
+   integer function how_many_extra_profile_header_items(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      how_many_extra_profile_header_items = 0
+   end function how_many_extra_profile_header_items
+
+   subroutine data_for_extra_profile_header_items(id, n, names, vals, ierr)
+      integer, intent(in) :: id, n
+      character(len=maxlen_profile_column_name) :: names(n)
+      real(dp) :: vals(n)
+      type(star_info), pointer :: s
+      integer, intent(out) :: ierr
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+
+      ! here is an example for adding an extra profile header item
+      ! also set how_many_extra_profile_header_items
+      ! names(1) = 'mixing_length_alpha'
+      ! vals(1) = s% mixing_length_alpha
+
+   end subroutine data_for_extra_profile_header_items
+
+   ! returns either keep_going or terminate.
+   ! note: cannot request retry; extras_check_model can do that.
+   integer function extras_finish_step(id)
+      integer, intent(in) :: id
+      integer :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+      extras_finish_step = keep_going
+
+      ! to save a profile,
+      ! s% need_to_save_profiles_now = .true.
+      ! to update the star log,
+      ! s% need_to_update_history_now = .true.
+
+      ! see extras_check_model for information about custom termination codes
+      ! by default, indicate where (in the code) MESA terminated
+      if (extras_finish_step == terminate) s%termination_code = t_extras_finish_step
+   end function extras_finish_step
+
+   subroutine extras_after_evolve(id, ierr)
+      integer, intent(in) :: id
+      integer, intent(out) :: ierr
+      type(star_info), pointer :: s
+      ierr = 0
+      call star_ptr(id, s, ierr)
+      if (ierr /= 0) return
+   end subroutine extras_after_evolve
+
+end module run_star_extras


### PR DESCRIPTION
Closes #937 

Adds a `photo_precompute` option to the colors namelist that allows users to read pre-computed bolometric correction tables directly, bypassing the on-the-fly SED convolution introduced in the colors overhaul. This restores backwards compatibility for users who were relying on the old `color_file_names` / `color_num_colors` workflow from r24.08.1 and prior.

When `photo_precompute = .true.`, the module loads BC tables via the legacy `mod_colors` reader and interpolates over Teff, log g, and [Fe/H] using the existing tri-linear scheme. The on-the-fly atmosphere/filter pipeline is skipped entirely.

The precomputed BC tables shipped with MESA (`lcb98cor.dat`, `blackbody_johnson.dat`) are now located at `$MESA_DIR/data/colors_data/photo_precompute/`. Users can also supply their own tables in the same format by pointing `color_file_names` at a local path (SED_Tools is yet to handle these sorts of files).

A new test suite `custom_colors_legacy` demonstrates the mode using the LCB98 Johnson-Cousins tables for a 7 Msun evolution through the blue loop.

Note: as discussed in #937, interpolating pre-computed BC tables is not equivalent to interpolating spectra and then convolving. So the on-the-fly approach is more accurate and remains the default. This mode is provided for legacy compatibility and for cases where atmosphere models are unavailable.