### PR TITLE
adjust documentation on momentum outer BC

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4694,8 +4694,8 @@
       ! Tsurf_factor
       ! ~~~~~~~~~~~~
 
-      ! used when ``use_momentum_outer_BC``
-      ! ``T_surf`` is set to ``Tsurf_factor*T_black_body(L_surf,R_surf)``
+      ! Not used by the default outer BCs.
+      ! ``T_surf`` comes from atm or ``other_surface_PT``.
 
       ! ::
 


### PR DESCRIPTION
Abha Vishwakarma made a mailinglist post highlighting this comment in the MESA documentation which is incorrect/outdated. I've amended the docs here.