### PR TITLE
Remove Tsurf_factor

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,8 @@ The build system scripts have been modernized. This has lead to the following ch
 
 For a more in-depth look at the new build system, see :doc:`developing/build-system`. If you change the build system in any way (e.g. skipping tests, building dynamic/shared libraries), it is highly recommended to have a look at this document.
 
+``Tsurf_factor`` was deprecated, and the associated controls and history column have been removed.
+
 .. _New Features main:
 
 New Features

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,7 +23,7 @@ The build system scripts have been modernized. This has lead to the following ch
 
 For a more in-depth look at the new build system, see :doc:`developing/build-system`. If you change the build system in any way (e.g. skipping tests, building dynamic/shared libraries), it is highly recommended to have a look at this document.
 
-``Tsurf_factor`` was deprecated, and the associated controls and history column have been removed.
+``Tsurf_factor`` and the associated controls and history column have been removed as they affected nothing. These controls were effectively deprecated after the removal of the black body boundary condition in 21.12.1.
 
 .. _New Features main:
 

--- a/linters/check_photos.py
+++ b/linters/check_photos.py
@@ -40,7 +40,6 @@ known_false_positives = {
     "max_years_for_timestep",
     "history_names_dict",
     "report_ierr",
-    "Tsurf_factor",
     "other_photo_read",
     "job",
     "tau_factor",

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4694,8 +4694,8 @@
       ! Tsurf_factor
       ! ~~~~~~~~~~~~
 
-      ! used when ``use_momentum_outer_BC``
-      ! ``T_surf`` is set to ``Tsurf_factor*T_black_body(L_surf,R_surf)``
+      ! Not used by the default outer BCs.
+      ! ``T_surf`` comes from atm or ``other_surface_PT``.
 
       ! ::
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4690,18 +4690,6 @@
     use_fixed_Psurf_outer_BC = .false.
     fixed_Psurf = 0
 
-
-      ! Tsurf_factor
-      ! ~~~~~~~~~~~~
-
-      ! Not used by the default outer BCs.
-      ! ``T_surf`` comes from atm or ``other_surface_PT``.
-
-      ! ::
-
-    Tsurf_factor = 1
-
-
       ! irradiation_flux
       ! ~~~~~~~~~~~~~~~~
       ! column_depth_for_irradiation

--- a/star/defaults/history_columns.list
+++ b/star/defaults/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/defaults/star_job.defaults
+++ b/star/defaults/star_job.defaults
@@ -1348,40 +1348,6 @@
     relax_opacity_factor = .false.
     relax_initial_opacity_factor = .false.
 
-
-      ! relax_to_this_Tsurf_factor
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! dlogTsurf_factor
-      ! ~~~~~~~~~~~~~~~~
-      ! relax_Tsurf_factor
-      ! ~~~~~~~~~~~~~~~~~~
-      ! relax_initial_Tsurf_factor
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! ::
-
-    relax_to_this_Tsurf_factor = -1
-    dlogTsurf_factor = 0.1d0
-    relax_Tsurf_factor = .false.
-    relax_initial_Tsurf_factor = .false.
-
-
-      ! set_to_this_Tsurf_factor
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~
-      ! set_Tsurf_factor
-      ! ~~~~~~~~~~~~~~~~
-      ! set_initial_Tsurf_factor
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! As for ``relax_to_this_Tsurf_factor``, but changes ``Tsurf_factor`` without reconverging.
-
-      ! ::
-
-    set_to_this_Tsurf_factor = -1
-    set_Tsurf_factor = .false.
-    set_initial_Tsurf_factor = .false.
-
-
       ! relax_mass_change
       ! ~~~~~~~~~~~~~~~~~
       ! relax_initial_mass_change

--- a/star/dev_cases_TDC_Pulsation/dev_TDC_Cepheid_6M/history_columns.list
+++ b/star/dev_cases_TDC_Pulsation/dev_TDC_Cepheid_6M/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/dev_cases_test_TDC/dev_TDC_through_ppisn/history_columns.list
+++ b/star/dev_cases_test_TDC/dev_TDC_through_ppisn/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/job/run_star_support.f90
+++ b/star/job/run_star_support.f90
@@ -1092,29 +1092,6 @@
          end if
       end subroutine relax_tau_factor
 
-
-      subroutine relax_Tsurf_factor(s)
-         type (star_info), pointer :: s
-         real(dp) :: next
-         include 'formats'
-         write(*,*) 'relax_to_this_Tsurf_factor < s% Tsurf_factor', &
-            s% job% relax_to_this_Tsurf_factor < s% Tsurf_factor
-         write(*,1) 'relax_to_this_Tsurf_factor', s% job% relax_to_this_Tsurf_factor
-         write(*,1) 's% Tsurf_factor', s% Tsurf_factor
-         if (s% job% relax_to_this_Tsurf_factor < s% Tsurf_factor) then
-            next = exp10(safe_log10(s% Tsurf_factor) - s% job% dlogTsurf_factor)
-            if (next < s% job% relax_to_this_Tsurf_factor) &
-               next = s% job% relax_to_this_Tsurf_factor
-         else
-            next = exp10(safe_log10(s% Tsurf_factor) + s% job% dlogTsurf_factor)
-            if (next > s% job% relax_to_this_Tsurf_factor) &
-               next = s% job% relax_to_this_Tsurf_factor
-         end if
-         s% Tsurf_factor = next
-         write(*,1) 'relax_Tsurf_factor', next, s% job% relax_to_this_Tsurf_factor
-      end subroutine relax_Tsurf_factor
-
-
       subroutine check_if_want_to_stop_warnings(s)
          use utils_lib
          type (star_info), pointer :: s
@@ -1953,12 +1930,6 @@
             s% tau_factor = s% job% set_to_this_tau_factor
          end if
 
-         if (s% job% set_Tsurf_factor .or. &
-               (s% job% set_initial_Tsurf_factor .and. .not. restart)) then
-            write(*,1) 'set_Tsurf_factor', s% job% set_to_this_Tsurf_factor
-            s% Tsurf_factor = s% job% set_to_this_Tsurf_factor
-         end if
-
          if (s% job% set_initial_age .and. .not. restart) then
             write(*,1) 'set_initial_age', s% job% initial_age  ! in years
             call star_set_age(id, s% job% initial_age, ierr)
@@ -2530,14 +2501,6 @@
             call star_relax_L_center( &
                id, s% job% new_L_center, s% job% dlgL_per_step, s% job% relax_L_center_dt, ierr)
             if (failed('star_relax_L_center',ierr)) return
-         end if
-
-         if (s% job% relax_Tsurf_factor .or. &
-               (s% job% relax_initial_Tsurf_factor .and. .not. restart)) then
-            write(*,1) 'relax_Tsurf_factor', s% job% relax_to_this_Tsurf_factor
-            call star_relax_Tsurf_factor( &
-               id, s% job% relax_to_this_Tsurf_factor, s% job% dlogTsurf_factor, ierr)
-            if (failed('star_relax_Tsurf_factor',ierr)) return
          end if
 
          if (s% job% relax_tau_factor .or. &

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -501,7 +501,7 @@
     atm_irradiated_kap_v, atm_irradiated_kap_v_div_kap_th, atm_irradiated_P_surf, &
     atm_irradiated_max_iters, &
 
-    use_compression_outer_BC, use_momentum_outer_BC, Tsurf_factor, use_zero_Pgas_outer_BC, &
+    use_compression_outer_BC, use_momentum_outer_BC, use_zero_Pgas_outer_BC, &
     fixed_Psurf, use_fixed_Psurf_outer_BC, fixed_vsurf, use_fixed_vsurf_outer_BC, use_RSP_L_eqn_outer_BC, &
 
     atm_build_tau_outer, atm_build_dlogtau, atm_build_errtol, &
@@ -1292,7 +1292,6 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  s% use_compression_outer_BC = use_compression_outer_BC
  s% use_momentum_outer_BC = use_momentum_outer_BC
- s% Tsurf_factor = Tsurf_factor
  s% use_zero_Pgas_outer_BC = use_zero_Pgas_outer_BC
  s% fixed_vsurf = fixed_vsurf
  s% use_fixed_vsurf_outer_BC = use_fixed_vsurf_outer_BC
@@ -3012,7 +3011,6 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  use_compression_outer_BC = s% use_compression_outer_BC
  use_momentum_outer_BC = s% use_momentum_outer_BC
- Tsurf_factor = s% Tsurf_factor
  use_zero_Pgas_outer_BC = s% use_zero_Pgas_outer_BC
  fixed_vsurf = s% fixed_vsurf
  use_fixed_vsurf_outer_BC = s% use_fixed_vsurf_outer_BC

--- a/star/private/history.f90
+++ b/star/private/history.f90
@@ -1461,8 +1461,6 @@ contains
          case(h_species)
             int_val = s% species
             is_int_val = .true.
-         case(h_Tsurf_factor)
-            val = s% Tsurf_factor
          case(h_tau_factor)
             val = s% tau_factor
          case(h_tau_surface)

--- a/star/private/init.f90
+++ b/star/private/init.f90
@@ -507,7 +507,6 @@
          s% model_number_for_last_retry = 0
          s% dt_limit_ratio = 0
          s% force_tau_factor = 0
-         s% force_Tsurf_factor = 0
          s% force_opacity_factor = 0
 
          s% generations = 0

--- a/star/private/init_model.f90
+++ b/star/private/init_model.f90
@@ -279,7 +279,7 @@
                dprop, initial_z, initial_y, &
                dprop, iprop, dprop, dprop, &
                dprop, dprop, dprop, dprop, &
-               dprop, dprop, dprop, dprop, dprop, dprop, &
+               dprop, dprop, dprop, dprop, dprop, &
                dprop, dprop, dprop, dprop, iprop, ierr)
             if (ierr /= 0) then
                write(*,2) 'year_month_day_when_created', year_month_day_when_created
@@ -379,7 +379,7 @@
                net_name, iprop, nz_in, iprop, m_in, &
                dprop, dprop, dprop, iprop, &
                dprop, dprop, dprop, dprop, dprop, &
-               dprop, dprop, dprop, dprop, dprop, dprop, &
+               dprop, dprop, dprop, dprop, dprop, &
                dprop, dprop, dprop, dprop, dprop, iprop, ierr)
             if (ierr /= 0 .or. m_in < 0 .or. nz_in < 0) then
                write(*,*) 'missing required properties'

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -86,7 +86,7 @@
             s% astero_revised_max_yr_dt, &
             s% cumulative_energy_error, s% cumulative_extra_heating, &
             s% have_initial_energy_integrals, s% total_energy_initial, &
-            s% force_tau_factor, s% force_Tsurf_factor, s% force_opacity_factor, &
+            s% force_tau_factor, s% force_opacity_factor, &
             s% crystal_core_boundary_mass
 
          if (failed('initial_y')) return
@@ -96,12 +96,6 @@
                s% tau_factor /= s% job% set_to_this_tau_factor) then
             s% tau_factor = s% force_tau_factor
             write(*,1) 'set tau_factor to photo value', s% tau_factor
-         end if
-
-         if (s% force_Tsurf_factor > 0 .and. s% Tsurf_factor /= s% force_Tsurf_factor .and. &
-               s% Tsurf_factor /= s% job% set_to_this_Tsurf_factor) then
-            s% Tsurf_factor = s% force_Tsurf_factor
-            write(*,1) 'set Tsurf_factor to photo value', s% Tsurf_factor
          end if
 
          if (s% force_opacity_factor > 0 .and. s% opacity_factor /= s% force_opacity_factor .and. &

--- a/star/private/photo_out.f90
+++ b/star/private/photo_out.f90
@@ -68,7 +68,7 @@
             s% astero_revised_max_yr_dt, &
             s% cumulative_energy_error, s% cumulative_extra_heating, &
             s% have_initial_energy_integrals, s% total_energy_initial, &
-            s% force_tau_factor, s% force_Tsurf_factor, s% force_opacity_factor, &
+            s% force_tau_factor, s% force_opacity_factor, &
             s% crystal_core_boundary_mass
 
          write(iounit) s% net_name

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -221,7 +221,7 @@
             year_month_day_when_created, nz, species, nvar, count
          logical :: do_read_prev, no_L
          real(dp) :: initial_mass, initial_z, initial_y, &
-            tau_factor, Tsurf_factor, opacity_factor, mixing_length_alpha
+            tau_factor, opacity_factor, mixing_length_alpha
          character (len=strlen) :: buffer, string
          character (len=net_name_len) :: net_name
          character(len=iso_name_length), pointer :: names(:)  ! (species)
@@ -274,7 +274,6 @@
          s% xmstar = -1
 
          tau_factor = s% tau_factor
-         Tsurf_factor = s% Tsurf_factor
          mixing_length_alpha = s% mixing_length_alpha
          opacity_factor = s% opacity_factor
 
@@ -283,7 +282,7 @@
             initial_mass, initial_z, initial_y, mixing_length_alpha, &
             s% model_number, s% star_age, tau_factor, s% Teff, &
             s% power_nuc_burn, s% power_h_burn, s% power_he_burn, s% power_z_burn, s% power_photo, &
-            Tsurf_factor, opacity_factor, s% crystal_core_boundary_mass, &
+            opacity_factor, s% crystal_core_boundary_mass, &
             s% xmstar, s% R_center, s% L_center, s% v_center, &
             s% cumulative_energy_error, s% num_retries, ierr)
 
@@ -312,16 +311,6 @@
             write(*,'(A)')
             s% tau_factor = tau_factor
             s% force_tau_factor = tau_factor
-         end if
-
-         if (abs(Tsurf_factor - s% Tsurf_factor) > Tsurf_factor*1d-9 .and. &
-               s% Tsurf_factor /= s% job% set_to_this_Tsurf_factor) then
-            ! don't change if just set by inlist
-            write(*,'(A)')
-            write(*,1) 'WARNING: changing to saved Tsurf_factor =', Tsurf_factor
-            write(*,'(A)')
-            s% Tsurf_factor = Tsurf_factor
-            s% force_Tsurf_factor = Tsurf_factor
          end if
 
          if (abs(opacity_factor - s% opacity_factor) > opacity_factor*1d-9 .and. &
@@ -679,7 +668,7 @@
             num_retries, year_month_day_when_created
          real(dp) :: m_div_msun, initial_z, &
             mixing_length_alpha, star_age, &
-            Teff, tau_factor, Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            Teff, tau_factor, opacity_factor, crystal_core_boundary_mass, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
             xmstar, R_center, L_center, v_center, cumulative_energy_error
          call do_read_saved_model_properties(fname, &
@@ -687,7 +676,7 @@
             m_div_msun, initial_z, mixing_length_alpha, &
             model_number, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, &
             cumulative_energy_error, num_retries, ierr)
       end subroutine do_read_saved_model_number
@@ -698,7 +687,7 @@
             m_div_msun, initial_z, mixing_length_alpha, &
             model_number, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, &
             cumulative_energy_error, num_retries, ierr)
          use utils_lib
@@ -709,7 +698,7 @@
          real(dp), intent(inout) :: m_div_msun, initial_z, &
             mixing_length_alpha, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, cumulative_energy_error
          integer, intent(out) :: ierr
          integer :: iounit
@@ -735,7 +724,7 @@
             m_div_msun, initial_z, initial_y, mixing_length_alpha, &
             model_number, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, &
             cumulative_energy_error, num_retries, ierr)
          close(iounit)
@@ -751,14 +740,14 @@
          real(dp) :: m_div_msun, initial_z, initial_y, &
             mixing_length_alpha, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, cumulative_energy_error
          call read_properties(iounit, &
             net_name, species, n_shells, year_month_day_when_created, &
             m_div_msun, initial_z, initial_y, mixing_length_alpha, &
             model_number, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, &
             cumulative_energy_error, num_retries, ierr)
       end subroutine do_read_net_name
@@ -773,7 +762,7 @@
             num_retries, year_month_day_when_created
          real(dp) :: m_div_msun, initial_z, &
             mixing_length_alpha, cumulative_energy_error, &
-            Teff, tau_factor, Tsurf_factor, &
+            Teff, tau_factor, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
             opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center
@@ -782,7 +771,7 @@
             m_div_msun, initial_z, mixing_length_alpha, &
             model_number, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, &
             cumulative_energy_error, num_retries, ierr)
       end subroutine do_read_saved_model_age
@@ -793,7 +782,7 @@
             m_div_msun, initial_z, initial_y, mixing_length_alpha, &
             model_number, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, &
             cumulative_energy_error, num_retries, ierr)
          integer, intent(in) :: iounit
@@ -803,7 +792,7 @@
          real(dp), intent(inout) :: m_div_msun, initial_z, initial_y, &
             mixing_length_alpha, star_age, tau_factor, Teff, &
             power_nuc_burn, power_h_burn, power_he_burn, power_z_burn, power_photo, &
-            Tsurf_factor, opacity_factor, crystal_core_boundary_mass, &
+            opacity_factor, crystal_core_boundary_mass, &
             xmstar, R_center, L_center, v_center, cumulative_energy_error
          integer, intent(out) :: ierr
          character (len=132) :: line
@@ -829,7 +818,6 @@
             if (match_keyword('power_he_burn', line, power_he_burn)) cycle
             if (match_keyword('power_z_burn', line, power_z_burn)) cycle
             if (match_keyword('power_photo', line, power_photo)) cycle
-            if (match_keyword('Tsurf_factor', line, Tsurf_factor)) cycle
             if (match_keyword('opacity_factor', line, opacity_factor)) cycle
             if (match_keyword('crystal_core_boundary_mass', line, crystal_core_boundary_mass)) cycle
             if (match_keyword('xmstar', line, xmstar)) cycle

--- a/star/private/relax.f90
+++ b/star/private/relax.f90
@@ -48,7 +48,6 @@
       public :: do_relax_y
       public :: do_relax_tau_factor
       public :: do_relax_opacity_factor
-      public :: do_relax_tsurf_factor
       public :: do_relax_uniform_omega
       public :: do_relax_irradiation
       public :: do_relax_mass_change
@@ -1614,131 +1613,6 @@
          s% max_timestep = secyer*s% time_step
 
       end function relax_opacity_factor_check_model
-
-
-      subroutine do_relax_Tsurf_factor(id, new_Tsurf_factor, dlogTsurf_factor, ierr)
-         integer, intent(in) :: id
-         real(dp), intent(in) :: new_Tsurf_factor, dlogTsurf_factor
-         integer, intent(out) :: ierr
-         integer, parameter ::  lipar=1, lrpar=2
-         integer :: max_model_number
-         real(dp) :: Tsurf_factor
-         type (star_info), pointer :: s
-         integer, target :: ipar_ary(lipar)
-         integer, pointer :: ipar(:)
-         real(dp), target :: rpar_ary(lrpar)
-         real(dp), pointer :: rpar(:)
-         rpar => rpar_ary
-         ipar => ipar_ary
-         include 'formats'
-         ierr = 0
-         if (new_Tsurf_factor <= 0) then
-            ierr = -1
-            write(*,*) 'invalid new_Tsurf_factor', new_Tsurf_factor
-            return
-         end if
-         call get_star_ptr(id, s, ierr)
-         if (ierr /= 0) return
-         Tsurf_factor = s% Tsurf_factor
-         if (abs(new_Tsurf_factor - Tsurf_factor) <= 1d-6) then
-            s% Tsurf_factor = new_Tsurf_factor
-            return
-         end if
-         write(*,'(A)')
-         write(*,1) 'current Tsurf_factor', Tsurf_factor
-         write(*,1) 'relax to new Tsurf_factor', new_Tsurf_factor
-         write(*,'(A)')
-         write(*,1) 'dlogTsurf_factor', dlogTsurf_factor
-         write(*,'(A)')
-         rpar(1) = new_Tsurf_factor
-         rpar(2) = dlogTsurf_factor
-         max_model_number = s% max_model_number
-         s% max_model_number = -1111
-         call do_internal_evolve( &
-               id, before_evolve_relax_Tsurf_factor, &
-               relax_Tsurf_factor_adjust_model, relax_Tsurf_factor_check_model, &
-               null_finish_model, .true., lipar, ipar, lrpar, rpar, ierr)
-         s% max_model_number = max_model_number
-         if (ierr /= 0) then
-            write(*,'(A)')
-            write(*,1) 'ERROR: failed doing relax Tsurf_factor', new_Tsurf_factor
-            write(*,'(A)')
-            call mesa_error(__FILE__,__LINE__,'do_relax_Tsurf_factor')
-         end if
-
-         if (new_Tsurf_factor == 1d0) then
-            s% force_Tsurf_factor = 0d0
-         else
-            s% force_Tsurf_factor = s% Tsurf_factor
-         end if
-
-         call error_check('relax tsurf factor',ierr)
-
-      end subroutine do_relax_Tsurf_factor
-
-
-      subroutine before_evolve_relax_Tsurf_factor(s, id, lipar, ipar, lrpar, rpar, ierr)
-         type (star_info), pointer :: s
-         integer, intent(in) :: id, lipar, lrpar
-         integer, intent(inout), pointer :: ipar(:)  ! (lipar)
-         real(dp), intent(inout), pointer :: rpar(:)  ! (lrpar)
-         integer, intent(out) :: ierr
-         ierr = 0
-         call turn_off_winds(s)
-         s% max_model_number = -111
-      end subroutine before_evolve_relax_Tsurf_factor
-
-      integer function relax_Tsurf_factor_adjust_model(s, id, lipar, ipar, lrpar, rpar)
-         type (star_info), pointer :: s
-         integer, intent(in) :: id, lipar, lrpar
-         integer, intent(inout), pointer :: ipar(:)  ! (lipar)
-         real(dp), intent(inout), pointer :: rpar(:)  ! (lrpar)
-         relax_Tsurf_factor_adjust_model = keep_going
-      end function relax_Tsurf_factor_adjust_model
-
-      integer function relax_Tsurf_factor_check_model(s, id, lipar, ipar, lrpar, rpar)
-         use do_one_utils, only:do_bare_bones_check_model
-         type (star_info), pointer :: s
-         integer, intent(in) :: id, lipar, lrpar
-         integer, intent(inout), pointer :: ipar(:)  ! (lipar)
-         real(dp), intent(inout), pointer :: rpar(:)  ! (lrpar)
-         real(dp) :: new_Tsurf_factor, dlogTsurf_factor, current_Tsurf_factor, next
-         logical, parameter :: dbg = .false.
-
-         include 'formats'
-
-         relax_Tsurf_factor_check_model = do_bare_bones_check_model(id)
-         if (relax_Tsurf_factor_check_model /= keep_going) return
-
-         new_Tsurf_factor = rpar(1)
-         dlogTsurf_factor = rpar(2)
-         current_Tsurf_factor = s% Tsurf_factor
-
-         if (mod(s% model_number, s% terminal_interval) == 0) &
-            write(*,1) 'Tsurf_factor target current', new_Tsurf_factor, current_Tsurf_factor
-
-         if (abs(current_Tsurf_factor-new_Tsurf_factor) < 1d-15) then
-            s% Tsurf_factor = new_Tsurf_factor
-            s% termination_code = t_relax_finished_okay
-            relax_Tsurf_factor_check_model = terminate
-            return
-         end if
-
-         if (new_Tsurf_factor < current_Tsurf_factor) then
-            next = exp10(safe_log10(current_Tsurf_factor) - dlogTsurf_factor)
-            if (next < new_Tsurf_factor) next = new_Tsurf_factor
-         else
-            next = exp10(safe_log10(current_Tsurf_factor) + dlogTsurf_factor)
-            if (next > new_Tsurf_factor) next = new_Tsurf_factor
-         end if
-
-         if (dbg) write(*,1) 'next Tsurf_factor', next, log10(next)
-
-         s% Tsurf_factor = next
-         s% max_timestep = secyer*s% time_step
-
-      end function relax_Tsurf_factor_check_model
-
 
       subroutine do_relax_irradiation(id, &
             min_steps, new_irrad_flux, new_irrad_col_depth, relax_irradiation_max_yrs_dt, ierr)

--- a/star/private/remove_shells.f90
+++ b/star/private/remove_shells.f90
@@ -1002,7 +1002,7 @@
          integer, intent(out) :: ierr
          type (star_info), pointer :: s, c, prv
          type (star_info), target :: copy_info
-         real(dp) :: tau_surf_new, tau_factor_new, Lmid, Rmid, T, P, T_black_body
+         real(dp) :: tau_surf_new, tau_factor_new, Lmid, Rmid, T, P
          integer :: k, k_old, nz, nz_old, skip
 
          logical, parameter :: dbg = .false., restart = .false.
@@ -1121,14 +1121,6 @@
          if (dbg) write(*,2) 's% dm(nz)/Msun', nz, s% dm(nz)/Msun
          if (dbg) write(*,2) 's% m(nz)/msun', nz, s% m(nz)/Msun
 
-         if (Lmid > 0d0) then
-            T_black_body = pow(Lmid/(pi4*rmid*rmid*boltz_sigma), 0.25d0)
-            s% Tsurf_factor = T/T_black_body
-         else
-            s% Tsurf_factor = 1d0
-         end if
-         s% force_Tsurf_factor = s% Tsurf_factor
-
          if (s% use_momentum_outer_bc) then
             s% tau_factor = tau_factor_new
             s% force_tau_factor = s% tau_factor
@@ -1143,8 +1135,7 @@
             return
          end if
 
-         if (dbg) write(*,1) 'do_remove_surface tau_factor, Tsurf_factor', &
-            s% tau_factor, s% Tsurf_factor
+         if (dbg) write(*,1) 'do_remove_surface tau_factor', s% tau_factor
 
          if (dbg) call mesa_error(__FILE__,__LINE__,'do_remove_surface')
 

--- a/star/private/star_history_def.f90
+++ b/star/private/star_history_def.f90
@@ -37,8 +37,7 @@
       integer, parameter :: h_time_step = h_log_abs_mdot + 1
       integer, parameter :: h_e_thermal = h_time_step + 1
       integer, parameter :: h_species = h_e_thermal + 1
-      integer, parameter :: h_Tsurf_factor = h_species + 1
-      integer, parameter :: h_tau_factor = h_Tsurf_factor + 1
+      integer, parameter :: h_tau_factor = h_species + 1
       integer, parameter :: h_log_tau_center = h_tau_factor + 1
       integer, parameter :: h_tau_surface = h_log_tau_center + 1
       integer, parameter :: h_num_zones = h_tau_surface + 1
@@ -703,7 +702,6 @@
          history_column_name(h_time_step_sec) = 'time_step_sec'
          history_column_name(h_e_thermal) = 'e_thermal'
          history_column_name(h_num_zones) = 'num_zones'
-         history_column_name(h_Tsurf_factor) = 'Tsurf_factor'
          history_column_name(h_log_tau_center) = 'log_tau_center'
          history_column_name(h_tau_factor) = 'tau_factor'
          history_column_name(h_tau_surface) = 'tau_surface'

--- a/star/private/star_job_ctrls_io.f90
+++ b/star/private/star_job_ctrls_io.f90
@@ -262,14 +262,6 @@
          adjust_tau_factor_to_surf_density, &
          base_for_adjust_tau_factor_to_surf_density, &
 
-         relax_Tsurf_factor, &
-         relax_initial_Tsurf_factor, &
-         set_Tsurf_factor, &
-         set_initial_Tsurf_factor, &
-         relax_to_this_Tsurf_factor, &
-         set_to_this_Tsurf_factor, &
-         dlogTsurf_factor, &
-
          relax_irradiation, &
          relax_initial_irradiation, &
          set_irradiation, &
@@ -853,14 +845,6 @@
          s% job% relax_opacity_factor = relax_opacity_factor
          s% job% relax_initial_opacity_factor = relax_initial_opacity_factor
 
-         s% job% relax_Tsurf_factor = relax_Tsurf_factor
-         s% job% relax_initial_Tsurf_factor = relax_initial_Tsurf_factor
-         s% job% set_Tsurf_factor = set_Tsurf_factor
-         s% job% set_initial_Tsurf_factor = set_initial_Tsurf_factor
-         s% job% relax_to_this_Tsurf_factor = relax_to_this_Tsurf_factor
-         s% job% set_to_this_Tsurf_factor = set_to_this_Tsurf_factor
-         s% job% dlogTsurf_factor = dlogTsurf_factor
-
          s% job% relax_irradiation = relax_irradiation
          s% job% relax_initial_irradiation = relax_initial_irradiation
          s% job% set_irradiation = set_irradiation
@@ -1399,14 +1383,6 @@
          d_opacity_factor = s% job% d_opacity_factor
          relax_opacity_factor = s% job% relax_opacity_factor
          relax_initial_opacity_factor = s% job% relax_initial_opacity_factor
-
-         relax_Tsurf_factor = s% job% relax_Tsurf_factor
-         relax_initial_Tsurf_factor = s% job% relax_initial_Tsurf_factor
-         set_Tsurf_factor = s% job% set_Tsurf_factor
-         set_initial_Tsurf_factor = s% job% set_initial_Tsurf_factor
-         relax_to_this_Tsurf_factor = s% job% relax_to_this_Tsurf_factor
-         set_to_this_Tsurf_factor = s% job% set_to_this_Tsurf_factor
-         dlogTsurf_factor = s% job% dlogTsurf_factor
 
          relax_irradiation = s% job% relax_irradiation
          relax_initial_irradiation = s% job% relax_initial_irradiation

--- a/star/private/write_model.f90
+++ b/star/private/write_model.f90
@@ -150,9 +150,6 @@
          if (s% tau_factor /= 1) then
             write(iounit, 1) 'tau_factor', s% tau_factor
          end if
-         if (s% Tsurf_factor /= 1) then
-            write(iounit, 1) 'Tsurf_factor', s% Tsurf_factor
-         end if
          if (s% opacity_factor /= 1) then
             write(iounit, 1) 'opacity_factor', s% opacity_factor
          end if

--- a/star/public/star_lib.f90
+++ b/star/public/star_lib.f90
@@ -1518,18 +1518,6 @@
          call do_relax_opacity_factor(id, new_opacity_factor, dopacity_factor, ierr)
       end subroutine star_relax_opacity_factor
 
-
-      subroutine star_relax_Tsurf_factor(id, new_Tsurf_factor, dlogTsurf_factor, ierr)
-         use relax, only: do_relax_Tsurf_factor
-         integer, intent(in) :: id
-         real(dp), intent(in) :: new_Tsurf_factor
-         real(dp), intent(in) :: dlogTsurf_factor
-            ! change log10(Tsurf_factor) by at most this amount per step
-         integer, intent(out) :: ierr
-         call do_relax_Tsurf_factor(id, new_Tsurf_factor, dlogTsurf_factor, ierr)
-      end subroutine star_relax_Tsurf_factor
-
-
       ! kind_of_relax = 0 => target = new_omega
       ! kind_of_relax = 1 => target = new_omega_div_omega_crit
       ! kind_of_relax = 2 => target = new_surface_rotation_v

--- a/star/test_suite/1.5M_with_diffusion/history_columns.list
+++ b/star/test_suite/1.5M_with_diffusion/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/12M_pre_ms_to_core_collapse/history_columns.list
+++ b/star/test_suite/12M_pre_ms_to_core_collapse/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/15M_dynamo/history_columns.list
+++ b/star/test_suite/15M_dynamo/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/16M_conv_premix/history_columns.list
+++ b/star/test_suite/16M_conv_premix/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/16M_predictive_mix/history_columns.list
+++ b/star/test_suite/16M_predictive_mix/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/1M_pre_ms_to_wd/history_columns.list
+++ b/star/test_suite/1M_pre_ms_to_wd/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/1M_thermohaline/history_columns.list
+++ b/star/test_suite/1M_thermohaline/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/20M_pre_ms_to_core_collapse/history_columns.list
+++ b/star/test_suite/20M_pre_ms_to_core_collapse/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/20M_z2m2_high_rotation/history_columns.list
+++ b/star/test_suite/20M_z2m2_high_rotation/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/5M_cepheid_blue_loop/history_columns.list
+++ b/star/test_suite/5M_cepheid_blue_loop/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/7M_prems_to_AGB/history_columns.list
+++ b/star/test_suite/7M_prems_to_AGB/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/accreted_material_j/history_columns.list
+++ b/star/test_suite/accreted_material_j/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/adjust_net/history_columns.list
+++ b/star/test_suite/adjust_net/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/c13_pocket/history_columns.list
+++ b/star/test_suite/c13_pocket/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/carbon_kh/history_columns.list
+++ b/star/test_suite/carbon_kh/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/cburn_inward/history_columns.list
+++ b/star/test_suite/cburn_inward/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/ccsn_IIp/history_columns.list
+++ b/star/test_suite/ccsn_IIp/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/conserve_angular_momentum/history_columns.list
+++ b/star/test_suite/conserve_angular_momentum/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/conv_core_cpm/history_columns.list
+++ b/star/test_suite/conv_core_cpm/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/custom_rates/history_columns.list
+++ b/star/test_suite/custom_rates/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/diffusion_smoothness/history_columns.list
+++ b/star/test_suite/diffusion_smoothness/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/gyre_in_mesa_rsg/history_columns.list
+++ b/star/test_suite/gyre_in_mesa_rsg/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/gyre_in_mesa_wd/history_columns.list
+++ b/star/test_suite/gyre_in_mesa_wd/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/hb_2M/history_columns.list
+++ b/star/test_suite/hb_2M/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/high_mass/history_columns.list
+++ b/star/test_suite/high_mass/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/high_rot_darkening/history_columns.list
+++ b/star/test_suite/high_rot_darkening/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/high_z/history_columns.list
+++ b/star/test_suite/high_z/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/hot_cool_wind/history_columns.list
+++ b/star/test_suite/hot_cool_wind/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/hse_riemann/history_columns.list
+++ b/star/test_suite/hse_riemann/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/irradiated_planet/history_columns.list
+++ b/star/test_suite/irradiated_planet/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/magnetic_braking/history_columns.list
+++ b/star/test_suite/magnetic_braking/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_brown_dwarf/history_columns.list
+++ b/star/test_suite/make_brown_dwarf/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_co_wd/history_columns.list
+++ b/star/test_suite/make_co_wd/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_env/history_columns.list
+++ b/star/test_suite/make_env/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_he_wd/history_columns.list
+++ b/star/test_suite/make_he_wd/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_metals/history_columns.list
+++ b/star/test_suite/make_metals/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_o_ne_wd/history_columns.list
+++ b/star/test_suite/make_o_ne_wd/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_planets/history_columns.list
+++ b/star/test_suite/make_planets/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_pre_ccsn_13bvn/history_columns.list
+++ b/star/test_suite/make_pre_ccsn_13bvn/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_sdb/history_columns.list
+++ b/star/test_suite/make_sdb/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/make_zams/history_columns.list
+++ b/star/test_suite/make_zams/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/ns_c/history_columns.list
+++ b/star/test_suite/ns_c/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/ns_h/history_columns.list
+++ b/star/test_suite/ns_h/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/ns_he/history_columns.list
+++ b/star/test_suite/ns_he/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/other_physics_hooks/history_columns.list
+++ b/star/test_suite/other_physics_hooks/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/pisn/history_columns.list
+++ b/star/test_suite/pisn/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/ppisn/history_columns.list
+++ b/star/test_suite/ppisn/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/radiative_levitation/history_columns.list
+++ b/star/test_suite/radiative_levitation/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_BEP/history_columns.list
+++ b/star/test_suite/rsp_BEP/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_BLAP/history_columns.list
+++ b/star/test_suite/rsp_BLAP/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_Cepheid/history_columns.list
+++ b/star/test_suite/rsp_Cepheid/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_Cepheid_6M/history_columns.list
+++ b/star/test_suite/rsp_Cepheid_6M/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_Delta_Scuti/history_columns.list
+++ b/star/test_suite/rsp_Delta_Scuti/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_RR_Lyrae/history_columns.list
+++ b/star/test_suite/rsp_RR_Lyrae/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_Type_II_Cepheid/history_columns.list
+++ b/star/test_suite/rsp_Type_II_Cepheid/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_gyre/history_columns.list
+++ b/star/test_suite/rsp_gyre/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/rsp_save_and_load_file/history_columns.list
+++ b/star/test_suite/rsp_save_and_load_file/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/semiconvection/history_columns.list
+++ b/star/test_suite/semiconvection/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/simplex_solar_calibration/history_columns.list
+++ b/star/test_suite/simplex_solar_calibration/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/split_burn_big_net/history_columns.list
+++ b/star/test_suite/split_burn_big_net/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/timing/history_columns.list
+++ b/star/test_suite/timing/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/twin_studies/history_columns.list
+++ b/star/test_suite/twin_studies/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/tzo/history_columns.list
+++ b/star/test_suite/tzo/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_acc_small_dm/history_columns.list
+++ b/star/test_suite/wd_acc_small_dm/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_aic/history_columns.list
+++ b/star/test_suite/wd_aic/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_c_core_ignition/history_columns.list
+++ b/star/test_suite/wd_c_core_ignition/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_cool_0.6M/history_columns.list
+++ b/star/test_suite/wd_cool_0.6M/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_diffusion/history_columns.list
+++ b/star/test_suite/wd_diffusion/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_he_shell_ignition/history_columns.list
+++ b/star/test_suite/wd_he_shell_ignition/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_nova_burst/history_columns.list
+++ b/star/test_suite/wd_nova_burst/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/wd_stable_h_burn/history_columns.list
+++ b/star/test_suite/wd_stable_h_burn/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star/test_suite/zams_to_cc_80/history_columns.list
+++ b/star/test_suite/zams_to_cc_80/history_columns.list
@@ -79,7 +79,6 @@
       log_abs_mdot ! log10(abs(star_mdot)) (in msolar per year)
 
    !## imposed surface conditions
-      !Tsurf_factor
       !tau_factor
       !tau_surface
 

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -431,8 +431,6 @@
          real(dp) :: fixed_Psurf
          logical :: use_RSP_L_eqn_outer_BC
 
-         real(dp) :: Tsurf_factor
-
       ! create atmosphere
 
          real(dp) :: atm_build_tau_outer

--- a/star_data/private/star_job_controls.inc
+++ b/star_data/private/star_job_controls.inc
@@ -165,11 +165,6 @@
       logical :: adjust_tau_factor_to_surf_density
       real(dp) :: base_for_adjust_tau_factor_to_surf_density
 
-      logical :: relax_Tsurf_factor, relax_initial_Tsurf_factor
-      logical :: set_Tsurf_factor, set_initial_Tsurf_factor
-      real(dp) :: relax_to_this_Tsurf_factor, set_to_this_Tsurf_factor
-      real(dp) :: dlogTsurf_factor
-
       logical :: relax_irradiation, relax_initial_irradiation
       logical :: set_irradiation, set_initial_irradiation
       integer :: relax_irradiation_min_steps
@@ -365,4 +360,3 @@
       ! When to run cleanup to deallocate unneeded data
       logical :: report_garbage_collection
       integer :: num_steps_for_garbage_collection
-

--- a/star_data/public/star_data_def.inc
+++ b/star_data/public/star_data_def.inc
@@ -1,7 +1,7 @@
 
       character(len=24) :: version_number ! mesa version from file $MESA_DIR/data/version_number
 
-      integer, parameter :: star_def_version = 17
+      integer, parameter :: star_def_version = 18
 
       integer, parameter :: nz_alloc_extra = 200
 

--- a/star_data/public/star_data_step_input.inc
+++ b/star_data/public/star_data_step_input.inc
@@ -161,7 +161,7 @@
          real(dp) :: Teff, dt_limit_ratio
          real(dp) :: cumulative_energy_error, cumulative_extra_heating
          real(dp) :: total_energy_initial, tau_factor, tau_base
-         real(dp) :: force_tau_factor, force_Tsurf_factor, force_opacity_factor
+         real(dp) :: force_tau_factor, force_opacity_factor
          real(dp) :: revised_max_yr_dt, astero_revised_max_yr_dt
          real(dp) :: gradT_excess_alpha_old
          real(dp) :: crystal_core_boundary_mass
@@ -204,5 +204,4 @@
 
          integer :: i_equ_w_div_wc ! equation for w_div_wc
          integer :: i_dj_rot_dt ! equation for specific angular momentum
-
 


### PR DESCRIPTION
See the discussion in https://github.com/MESAHub/mesa/pull/971. Tsurf_factor is deprecated. This pr removes Tsurf factor, its associated controls/references, and makes note of this in the changelog.