### PR TITLE
fix sdk caching for github actions

### DIFF
--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -59,7 +59,9 @@ runs:
         path: |
           mesasdk-x86_64-linux-${{inputs.sdk}}.tar.gz
           mesasdk-aarch64-macos-${{inputs.sdk}}.pkg
-        key: ${{ runner.os }}-${{inputs.sdk}}-${{ env.DYNAMIC }}
+        # If this key changes, run the workflow once to seed the new caches and
+        # again to verify cache-hit behavior.
+        key: ${{ runner.os }}-${{inputs.sdk}}${{ env.DYNAMIC && format('-{0}', env.DYNAMIC) || '' }}
 
     - name: Get SDK ${{ runner.os }} '26.3.2'
       if: ${{ (steps.cache.outputs.cache-hit != 'true') && (  inputs.sdk == '26.3.2') && (runner.os == 'Linux') }}

--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -58,7 +58,7 @@ runs:
       with:
         path: |
           mesasdk-x86_64-linux-${{inputs.sdk}}.tar.gz
-        key: ${{ runner.os }}-${{inputs.sdk}}
+        key: ${{ runner.os }}-${{inputs.sdk}}-${{ env.DYNAMIC }}
 
     - name: Get SDK ${{ runner.os }} '26.3.2'
       if: ${{ (steps.cache.outputs.cache-hit != 'true') && (  inputs.sdk == '26.3.2') && (runner.os == 'Linux') }}

--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -58,6 +58,7 @@ runs:
       with:
         path: |
           mesasdk-x86_64-linux-${{inputs.sdk}}.tar.gz
+          mesasdk-aarch64-macos-${{inputs.sdk}}.pkg
         key: ${{ runner.os }}-${{inputs.sdk}}-${{ env.DYNAMIC }}
 
     - name: Get SDK ${{ runner.os }} '26.3.2'


### PR DESCRIPTION
1.  Both linux sdk github actions were writing to the same sdk. For now, I've changed the actions such that they generate and use their own sdk cache.
2. The mac os sdk was not being cached. A path for caching has been added.