### PR TITLE
do not stop on missing special reactions

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,7 @@ For a more in-depth look at the new build system, see :doc:`developing/build-sys
 New Features
 ------------
 
+MESA no longer stops when reactions for which special rates are set are not in the nuclear network, only a warning is printed. This is intended to make it easier to test various network sizes without having to also change the list of special reactions.
 
 .. _Bug Fixes main:
 

--- a/star/job/run_star_support.f90
+++ b/star/job/run_star_support.f90
@@ -1482,12 +1482,10 @@
          type (star_info), pointer :: s
          integer :: j, i, ir
          integer, pointer :: net_reaction_ptr(:)
-         logical :: error
 
          include 'formats'
 
          ierr = 0
-         error = .false.
          call star_ptr(id, s, ierr)
          if (ierr /= 0) return
 
@@ -1514,7 +1512,6 @@
                write(*,*) 'Failed to find reaction_for_special_factor ' // &
                trim(s% job% reaction_for_special_factor(i)), &
                j, s% job% special_rate_factor(i)
-               error = .true.
                cycle
             end if
             s% rate_factors(j) = s% job% special_rate_factor(i)
@@ -1522,8 +1519,6 @@
                   trim(s% job% reaction_for_special_factor(i)), &
                   j, s% job% special_rate_factor(i)
          end do
-
-         if(error) call mesa_error(__FILE__,__LINE__)
 
       end subroutine set_rate_factors
 


### PR DESCRIPTION
The case this intends to support is testing various nuclear reaction networks with custom rates. If you have an expansive set of custom reaction rates, you no longer have to remove the rates that are not present in the network you are currently testing.