### PR TITLE
changelog: remove warning that python is required

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,8 +2,6 @@
 Changelog
 *********
 
-.. warning:: As of r24.08.1, building MESA now requires Python (3.5 or newer) be installed.
-
 .. note:: This section describes changes present in the development version of MESA (``main`` branch) relative to the most recent release.
 
 


### PR DESCRIPTION
It has been long enough since the release that required python