### PR TITLE
add optional flag to disable mlt_fallback in TDC adjust_mass

### DIFF
--- a/star/defaults/controls_dev.defaults
+++ b/star/defaults/controls_dev.defaults
@@ -189,6 +189,19 @@
     TDC_use_density_form_for_eddy_viscosity = .false.
 
 
+      ! TDC_adjust_mass_fallback_to_mlt
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! If TDC_adjust_mass_fallback_to_mlt = .true., cells touched by
+      ! adjust_mass use MLT instead of TDC. This matches the previous behavior.
+      ! If false, TDC remains enabled in those cells and uses the TDC
+      ! convective velocity for the zone.
+
+      ! ::
+
+    TDC_adjust_mass_fallback_to_mlt = .true.
+
+
       ! use_TDC_enthalpy_flux_limiter
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -108,7 +108,7 @@
     TDC_alpha_D, TDC_alpha_R, TDC_alpha_Pt, TDC_alpha_M, &
     TDC_alpha_C, TDC_alpha_S, &
     TDC_alpha_M_use_explicit_mlt_vc_in_momentum_equation, &
-    TDC_use_density_form_for_eddy_viscosity, &
+    TDC_use_density_form_for_eddy_viscosity, TDC_adjust_mass_fallback_to_mlt, &
     TDC_num_innermost_cells_forced_nonturbulent, TDC_num_outermost_cells_forced_nonturbulent, &
     include_mlt_Pturb_in_thermodynamic_gradients, &
     include_mlt_corr_to_TDC, use_TDC_enthalpy_flux_limiter, TDC_include_eturb_in_energy_equation, &
@@ -2092,6 +2092,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% TDC_alpha_S = TDC_alpha_S
  s% TDC_alpha_M_use_explicit_mlt_vc_in_momentum_equation = TDC_alpha_M_use_explicit_mlt_vc_in_momentum_equation
  s% TDC_use_density_form_for_eddy_viscosity = TDC_use_density_form_for_eddy_viscosity
+ s% TDC_adjust_mass_fallback_to_mlt = TDC_adjust_mass_fallback_to_mlt
  s% TDC_num_innermost_cells_forced_nonturbulent = TDC_num_innermost_cells_forced_nonturbulent
  s% TDC_num_outermost_cells_forced_nonturbulent = TDC_num_outermost_cells_forced_nonturbulent
  s% include_mlt_Pturb_in_thermodynamic_gradients = include_mlt_Pturb_in_thermodynamic_gradients
@@ -3803,6 +3804,7 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  TDC_alpha_S = s% TDC_alpha_S
  TDC_alpha_M_use_explicit_mlt_vc_in_momentum_equation = s% TDC_alpha_M_use_explicit_mlt_vc_in_momentum_equation
  TDC_use_density_form_for_eddy_viscosity = s% TDC_use_density_form_for_eddy_viscosity
+ TDC_adjust_mass_fallback_to_mlt = s% TDC_adjust_mass_fallback_to_mlt
  TDC_num_innermost_cells_forced_nonturbulent = s% TDC_num_innermost_cells_forced_nonturbulent
  TDC_num_outermost_cells_forced_nonturbulent = s% TDC_num_outermost_cells_forced_nonturbulent
  include_mlt_Pturb_in_thermodynamic_gradients = s% include_mlt_Pturb_in_thermodynamic_gradients

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -38,9 +38,8 @@ contains
 
    !> Determines if it is safe (physically) to use TDC instead of MLT.
    !!
-   !! Currently we only know we have to fall back to MLT in cells that get touched
-   !! by adjust_mass, because there the convection speeds at the start of the
-   !! step can be badly out of whack.
+   !! By default, fall back to MLT in cells that get touched by adjust_mass.
+   !! This can be disabled to let those cells use TDC.
    !!
    !! @param s star pointer
    !! @param k face index
@@ -50,7 +49,7 @@ contains
       integer, intent(in) :: k
 
       fallback = .false.
-      if (abs(s%mstar_dot) > 1d-99 .and. k < s% k_const_mass) then
+      if (s% TDC_adjust_mass_fallback_to_mlt .and. abs(s%mstar_dot) > 1d-99 .and. k < s% k_const_mass) then
          fallback = .true.
       end if
    end function check_if_must_fall_back_to_MLT

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -38,8 +38,10 @@ contains
 
    !> Determines if it is safe (physically) to use TDC instead of MLT.
    !!
-   !! By default, fall back to MLT in cells that get touched by adjust_mass.
-   !! This can be disabled to let those cells use TDC.
+   !! Currently we only know we have to fall back to MLT in cells that get touched
+   !! by adjust_mass, because there the convection speeds at the start of the
+   !! step can be badly out of whack. This can be disabled with TDC_adjust_mass_fallback_to_mlt
+   !! to let those cells use TDC.
    !!
    !! @param s star pointer
    !! @param k face index

--- a/star_data/private/star_controls_dev.inc
+++ b/star_data/private/star_controls_dev.inc
@@ -2,6 +2,7 @@
          logical :: compare_TDC_to_MLT 
 
          logical :: TDC_use_density_form_for_eddy_viscosity
+         logical :: TDC_adjust_mass_fallback_to_mlt
          logical :: include_mlt_Pturb_in_thermodynamic_gradients
          logical :: use_TDC_enthalpy_flux_limiter
          logical :: include_mlt_in_velocity_time_centering


### PR DESCRIPTION
This pr introduces a dev control which affects TDC. It allows zones touched by adjust mass to use TDC inste. I think this can be more consistent the falling back to mlt, and this control is needed to evolve TDC pulsation models with mass loss as well.

In my testing, pulsation models with mass loss generate noisy features and convection in the surface layers touched by adjust_mass, because of the mlt fallback. Not falling back fixes this issue. 