### PR TITLE
add banded solver, TDC Y-face seed, skip cox if include_mlt_corr is F

### DIFF
--- a/star/defaults/controls_dev.defaults
+++ b/star/defaults/controls_dev.defaults
@@ -13,6 +13,27 @@
 
       compare_TDC_to_MLT = .false.
 
+      ! use_TDC_Y_face_seeded_newton
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! If true, use the start-of-step TDC Y_face on the first solver
+      ! iteration, and the previous solver iteration's TDC Y_face thereafter,
+      ! to try a small local positive-Y bracket before the full bracketing path.
+      ! The seed is only used during structural solver iterations.
+      !
+      ! ::
+
+      use_TDC_Y_face_seeded_newton = .false.
+
+      ! Hydro matrix solver options
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! hydro_matrix_solver selects the mesa-star hydro matrix solve.
+      ! Options are 'bcyclic' for the existing block cyclic reduction solver
+      ! and 'banded' for an RSP-like DGBTRF/DGBTRS banded solve.
+      !
+      ! ::
+
+      hydro_matrix_solver = 'bcyclic'
+
       ! RSP2 parameters
       ! ~~~~~~~~~~~~~~~
 

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -361,6 +361,8 @@
     P_theta_for_velocity_time_centering, L_theta_for_velocity_time_centering, &
     max_logT_for_include_P_and_L_in_velocity_time_centering, &
     steps_before_use_TDC, use_P_d_1_div_rho_form_of_work_when_time_centering_velocity, compare_TDC_to_MLT, &
+    use_TDC_Y_face_seeded_newton, &
+    hydro_matrix_solver, &
     remesh_for_TDC_pulsations_log_core_zoning, velocity_logT_lower_bound, &
     max_dt_yrs_for_velocity_logT_lower_bound, velocity_tau_lower_bound, velocity_q_upper_bound, &
     use_drag_energy, drag_coefficient, min_q_for_drag, &
@@ -2100,6 +2102,8 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% use_rsp_form_of_scale_height = use_rsp_form_of_scale_height
  s% include_mlt_in_velocity_time_centering = include_mlt_in_velocity_time_centering
  s% compare_TDC_to_MLT = compare_TDC_to_MLT
+ s% use_TDC_Y_face_seeded_newton = use_TDC_Y_face_seeded_newton
+ s% hydro_matrix_solver = hydro_matrix_solver
  s% TDC_hydro_use_mass_interp_face_values = TDC_hydro_use_mass_interp_face_values
  s% TDC_hydro_nz = TDC_hydro_nz
  s% TDC_hydro_nz_outer = TDC_hydro_nz_outer
@@ -3810,6 +3814,8 @@ solver_test_partials_sink_name = s% solver_test_partials_sink_name
  use_rsp_form_of_scale_height = s% use_rsp_form_of_scale_height
  include_mlt_in_velocity_time_centering = s% include_mlt_in_velocity_time_centering
  compare_TDC_to_MLT = s% compare_TDC_to_MLT
+ use_TDC_Y_face_seeded_newton = s% use_TDC_Y_face_seeded_newton
+ hydro_matrix_solver = s% hydro_matrix_solver
  TDC_hydro_use_mass_interp_face_values = s% TDC_hydro_use_mass_interp_face_values
  TDC_hydro_nz = s% TDC_hydro_nz
  TDC_hydro_nz_outer = s% TDC_hydro_nz_outer

--- a/star/private/star_solver.f90
+++ b/star/private/star_solver.f90
@@ -114,7 +114,7 @@
          real(dp), dimension(:,:), pointer :: dxsave=>null(), ddxsave=>null(), B=>null(), grad_f=>null(), soln=>null()
          real(dp), dimension(:), pointer :: dxsave1=>null(), ddxsave1=>null(), B1=>null(), grad_f1=>null(), &
             row_scale_factors1=>null(), col_scale_factors1=>null(), soln1=>null(), &
-            save_ublk1=>null(), save_dblk1=>null(), save_lblk1=>null()
+            save_ublk1=>null(), save_dblk1=>null(), save_lblk1=>null(), band1=>null()
          real(dp), dimension(:,:), pointer :: rhs=>null()
          integer, dimension(:), pointer :: ipiv1=>null()
          real(dp), dimension(:,:), pointer :: ddx=>null(), xder=>null()
@@ -137,7 +137,8 @@
             min_corr_coeff, max_corr_min, max_resid_min, max_abs_correction
          integer :: nz, iter, max_tries, tiny_corr_cnt, i, &
             force_iter_value, iter_for_resid_tol2, iter_for_resid_tol3, &
-            max_corr_k, max_corr_j, max_resid_k, max_resid_j
+            max_corr_k, max_corr_j, max_resid_k, max_resid_j, &
+            band_kl, band_ku, band_ldab, band_diag
          integer(i8) :: time0
          character (len=strlen) :: err_msg
          logical :: first_try, dbg_msg, passed_tol_tests, &
@@ -151,6 +152,7 @@
          real(dp), pointer, dimension(:) :: equ1=>null()
          real(dp), pointer, dimension(:,:) :: equ=>null()  ! (nvar,nz)
          real(dp), pointer, dimension(:,:) :: AF=>null()  ! (ldAF,neq)
+         real(dp), pointer, dimension(:,:) :: band=>null()  ! (band_ldab,neq)
          real(dp), pointer, dimension(:,:,:) :: ublk=>null(), dblk=>null(), lblk=>null()  ! (nvar,nvar,nz)
          real(dp), dimension(:,:,:), pointer :: lblkF=>null(), dblkF=>null(), ublkF=>null()  ! (nvar,nvar,nz)
 
@@ -1022,8 +1024,17 @@
                !$OMP END PARALLEL DO SIMD
             end if
 
-            call factor_mtx(ierr)
-            if (ierr == 0) call solve_mtx(ierr)
+            select case (trim(s% hydro_matrix_solver))
+            case ('', 'bcyclic')
+               call factor_mtx(ierr)
+               if (ierr == 0) call solve_mtx(ierr)
+            case ('banded')
+               call solve_banded_mtx(ierr)
+            case default
+               write(*,*) 'bad value for hydro_matrix_solver: ' // &
+                  trim(s% hydro_matrix_solver)
+               ierr = -1
+            end select
 
             if (s% use_DGESVX_in_bcyclic) then
                !$OMP PARALLEL DO SIMD
@@ -1064,6 +1075,88 @@
                B1, soln1, row_scale_factors1, col_scale_factors1, equed1, &
                iter, ierr)
          end subroutine solve_mtx
+
+
+         subroutine solve_banded_mtx(ierr)
+            integer, intent(out) :: ierr
+            integer :: info, k, i_equ, i_var, irow, jcol, row0, col0, iband
+            include 'formats'
+
+            ierr = 0
+            if (.not. associated(band)) then
+               write(*,*) 'band storage is not allocated for hydro_matrix_solver=banded'
+               ierr = -1
+               return
+            end if
+
+            band(1:band_ldab,1:neq) = 0d0
+            soln1(1:neq) = B1(1:neq)
+
+            do k = 1, nz
+               row0 = nvar*(k-1)
+               do i_equ = 1, nvar
+                  irow = row0 + i_equ
+
+                  do i_var = 1, nvar
+                     jcol = row0 + i_var
+                     iband = band_diag + irow - jcol
+                     if (iband < 1 .or. iband > band_ldab) then
+                        write(*,*) 'hydro banded matrix entry outside band', &
+                           irow, jcol, iband, band_ldab
+                        ierr = -1
+                        return
+                     end if
+                     band(iband,jcol) = dblk(i_equ,i_var,k)
+                  end do
+
+                  if (k > 1) then
+                     col0 = nvar*(k-2)
+                     do i_var = 1, nvar
+                        jcol = col0 + i_var
+                        iband = band_diag + irow - jcol
+                        if (iband < 1 .or. iband > band_ldab) then
+                           write(*,*) 'hydro banded matrix entry outside band', &
+                              irow, jcol, iband, band_ldab
+                           ierr = -1
+                           return
+                        end if
+                        band(iband,jcol) = lblk(i_equ,i_var,k)
+                     end do
+                  end if
+
+                  if (k < nz) then
+                     col0 = nvar*k
+                     do i_var = 1, nvar
+                        jcol = col0 + i_var
+                        iband = band_diag + irow - jcol
+                        if (iband < 1 .or. iband > band_ldab) then
+                           write(*,*) 'hydro banded matrix entry outside band', &
+                              irow, jcol, iband, band_ldab
+                           ierr = -1
+                           return
+                        end if
+                        band(iband,jcol) = ublk(i_equ,i_var,k)
+                     end do
+                  end if
+               end do
+            end do
+
+            call DGBTRF(neq, neq, band_kl, band_ku, band, band_ldab, ipiv1, info)
+            if (info /= 0) then
+               write(*,2) 'hydro banded DGBTRF failed', info
+               ierr = info
+               return
+            end if
+
+            call DGBTRS('N', neq, band_kl, band_ku, 1, band, band_ldab, &
+               ipiv1, soln1, neq, info)
+            if (info /= 0) then
+               write(*,2) 'hydro banded DGBTRS failed', info
+               ierr = info
+               return
+            end if
+
+         end subroutine solve_banded_mtx
 
 
          subroutine test_cell_partials(s, k, save_dx, save_equ, ierr)
@@ -1826,6 +1919,15 @@
             allocate(save_dblk1(1:nvar*neq))
             allocate(save_lblk1(1:nvar*neq))
 
+            band_kl = 2*nvar
+            band_ku = 2*nvar
+            band_ldab = 2*band_kl + band_ku + 1
+            band_diag = band_kl + band_ku + 1
+            if (trim(s% hydro_matrix_solver) == 'banded') then
+               allocate(band1(1:band_ldab*neq))
+               band(1:band_ldab,1:neq) => band1(1:band_ldab*neq)
+            end if
+
             if (s% fill_arrays_with_NaNs) then
                call fill_with_NaNs(dxsave1)
                call fill_with_NaNs(ddxsave1)
@@ -1839,6 +1941,7 @@
                call fill_with_NaNs(save_ublk1)
                call fill_with_NaNs(save_dblk1)
                call fill_with_NaNs(save_lblk1)
+               if (associated(band1)) call fill_with_NaNs(band1)
             end if
 
             dxsave(1:nvar,1:nz) => dxsave1(1:neq)
@@ -1890,6 +1993,7 @@
             if(associated(save_ublk1)) deallocate(save_ublk1)
             if(associated(save_dblk1)) deallocate(save_dblk1)
             if(associated(save_lblk1)) deallocate(save_lblk1)
+            if(associated(band1)) deallocate(band1)
             if(associated(ipiv1)) deallocate(ipiv1)
 
             if(associated(ublk1)) deallocate(ublk1)
@@ -1902,8 +2006,9 @@
 
             nullify(equ, equ1, dxsave1,dxsave, ddxsave, B1, &
                      soln1, grad_f1, rhs, xder, ddx, row_scale_factors1,&
-                     col_scale_factors1, save_ublk1, save_dblk1, save_lblk1,&
+                     col_scale_factors1, save_ublk1, save_dblk1, save_lblk1, band1,&
                      B, soln, grad_f,ipiv1, ublk1, dblk1, lblk1, ublkF1,dblkF1, lblkF1)
+            nullify(band)
 
          end subroutine cleanup
 

--- a/star/private/star_solver.f90
+++ b/star/private/star_solver.f90
@@ -1025,9 +1025,9 @@
             end if
 
             select case (trim(s% hydro_matrix_solver))
-            case ('', 'bcyclic')
-               call factor_mtx(ierr)
-               if (ierr == 0) call solve_mtx(ierr)
+            case ('bcyclic')
+               call factor_bcyclic_mtx(ierr)
+               if (ierr == 0) call solve_bcyclic_mtx(ierr)
             case ('banded')
                call solve_banded_mtx(ierr)
             case default
@@ -1057,30 +1057,29 @@
          end function solve_equ
 
 
-         subroutine factor_mtx(ierr)
+         subroutine factor_bcyclic_mtx(ierr)
             use star_bcyclic, only: bcyclic_factor
             integer, intent(out) :: ierr
             call bcyclic_factor( &
                s, nvar, nz, lblk1, dblk1, ublk1, lblkF1, dblkF1, ublkF1, ipiv_blk1, &
                B1, row_scale_factors1, col_scale_factors1, &
                equed1, iter, ierr)
-         end subroutine factor_mtx
+         end subroutine factor_bcyclic_mtx
 
 
-         subroutine solve_mtx(ierr)
+         subroutine solve_bcyclic_mtx(ierr)
             use star_bcyclic, only: bcyclic_solve
             integer, intent(out) :: ierr
             call bcyclic_solve( &
                s, nvar, nz, lblk1, dblk1, ublk1, lblkF1, dblkF1, ublkF1, ipiv_blk1, &
                B1, soln1, row_scale_factors1, col_scale_factors1, equed1, &
                iter, ierr)
-         end subroutine solve_mtx
+         end subroutine solve_bcyclic_mtx
 
 
          subroutine solve_banded_mtx(ierr)
             integer, intent(out) :: ierr
             integer :: info, k, i_equ, i_var, irow, jcol, row0, col0, iband
-            include 'formats'
 
             ierr = 0
             if (.not. associated(band)) then
@@ -1143,7 +1142,7 @@
 
             call DGBTRF(neq, neq, band_kl, band_ku, band, band_ldab, ipiv1, info)
             if (info /= 0) then
-               write(*,2) 'hydro banded DGBTRF failed', info
+               write(*,*) 'hydro banded DGBTRF failed', info
                ierr = info
                return
             end if
@@ -1151,7 +1150,7 @@
             call DGBTRS('N', neq, band_kl, band_ku, 1, band, band_ldab, &
                ipiv1, soln1, neq, info)
             if (info /= 0) then
-               write(*,2) 'hydro banded DGBTRS failed', info
+               write(*,*) 'hydro banded DGBTRS failed', info
                ierr = info
                return
             end if
@@ -2007,8 +2006,7 @@
             nullify(equ, equ1, dxsave1,dxsave, ddxsave, B1, &
                      soln1, grad_f1, rhs, xder, ddx, row_scale_factors1,&
                      col_scale_factors1, save_ublk1, save_dblk1, save_lblk1, band1,&
-                     B, soln, grad_f,ipiv1, ublk1, dblk1, lblk1, ublkF1,dblkF1, lblkF1)
-            nullify(band)
+                     B, soln, grad_f,ipiv1, ublk1, dblk1, lblk1, ublkF1,dblkF1, lblkF1, band)
 
          end subroutine cleanup
 

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -305,6 +305,7 @@
             s% u_face_start(k) = 0d0  ! s% u_face_ad(k)%val
             s% P_face_start(k) = -1d0  ! mark as unset s% P_face_ad(k)%val
             s% L_start(k) = s% L(k)
+            s% Y_face_start(k) = s% Y_face(k)
             s% omega_start(k) = s% omega(k)
             s% ye_start(k) = s% ye(k)
             s% j_rot_start(k) = s% j_rot(k)

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -339,8 +339,8 @@ contains
             mixing_type, scale, chiT, chiRho, gradr, r, Ptot, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, s%tdc_num_iters(k), max_conv_vel, &
             Eq_div_w, grav, &
-            s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr, &
-            Y_face_guess)
+            s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, &
+            Y_face_guess, ierr)
          s% dvc_dt_TDC(k) = (conv_vel%val - conv_vel_start) / s%dt
 
             if (ierr /= 0) then
@@ -361,8 +361,8 @@ contains
                   mixing_type, scale, chiT, chiRho, gradr_scaled, r, Ptot, T, rho, dV, Cp, opacity, &
                   scale_height, gradL, grada, conv_vel, D, Y_face, gradT, s%tdc_num_iters(k), max_conv_vel, &
                   Eq_div_w, grav, &
-                  s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr, &
-                  Y_face_guess)
+                  s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, &
+                  Y_face_guess, ierr)
                s% dvc_dt_TDC(k) = (conv_vel%val - conv_vel_start) / s%dt
                if (ierr /= 0) then
                   if (s% report_ierr) write(*,*) 'ierr from set_TDC when using superad_reduction'

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -216,13 +216,13 @@ contains
       integer, intent(out) :: ierr
 
       type(auto_diff_real_star_order1) :: Pr, Pg, grav, Lambda, gradL, beta
-      real(dp) :: conv_vel_start, scale, max_conv_vel
+      real(dp) :: conv_vel_start, scale, max_conv_vel, Y_face_guess
 
       ! these are used by use_superad_reduction
       real(dp) :: Gamma_limit, scale_value1, scale_value2, diff_grads_limit, reduction_limit, lambda_limit
       type(auto_diff_real_star_order1) :: Lrad_div_Ledd, Gamma_inv_threshold, Gamma_factor, alfa0, &
          diff_grads_factor, Gamma_term, exp_limit, grad_scale, gradr_scaled, Eq_div_w, check_Eq, mlt_Pturb, Ptot
-      logical ::  test_partials, using_TDC
+      logical ::  test_partials, using_TDC, have_Y_face_guess
       logical, parameter :: report = .false.
       include 'formats'
 
@@ -325,13 +325,25 @@ contains
             scale = max(abs(s% L_start(k)), 1d-3*maxval(s% L_start(1:s% nz)))
          end if
 
+         have_Y_face_guess = s% use_TDC_Y_face_seeded_newton .and. s% doing_solver_iterations
+         if (have_Y_face_guess) then
+            if (s% solver_iter == 0) then
+               Y_face_guess = s% Y_face_start(k)
+            else
+               Y_face_guess = s% Y_face(k)
+            end if
+         else
+            Y_face_guess = 0d0
+         end if
+
          call set_TDC(&
             conv_vel_start, mixing_length_alpha, s%TDC_alpha_D, s%TDC_alpha_R, s%TDC_alpha_Pt, &
             s%dt, cgrav, m, report, &
             mixing_type, scale, chiT, chiRho, gradr, r, Ptot, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, s%tdc_num_iters(k), max_conv_vel, &
             Eq_div_w, grav, &
-            s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr)
+            s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr, &
+            have_Y_face_guess, Y_face_guess)
          s% dvc_dt_TDC(k) = (conv_vel%val - conv_vel_start) / s%dt
 
             if (ierr /= 0) then
@@ -352,7 +364,8 @@ contains
                   mixing_type, scale, chiT, chiRho, gradr_scaled, r, Ptot, T, rho, dV, Cp, opacity, &
                   scale_height, gradL, grada, conv_vel, D, Y_face, gradT, s%tdc_num_iters(k), max_conv_vel, &
                   Eq_div_w, grav, &
-                  s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr)
+                  s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr, &
+                  have_Y_face_guess, Y_face_guess)
                s% dvc_dt_TDC(k) = (conv_vel%val - conv_vel_start) / s%dt
                if (ierr /= 0) then
                   if (s% report_ierr) write(*,*) 'ierr from set_TDC when using superad_reduction'

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -327,12 +327,9 @@ contains
 
          have_Y_face_guess = s% use_TDC_Y_face_seeded_newton .and. s% doing_solver_iterations
          if (have_Y_face_guess) then
-            if (s% solver_iter == 0) then
-               Y_face_guess = s% Y_face_start(k)
-            else
-               Y_face_guess = s% Y_face(k)
-            end if
+            Y_face_guess = s% Y_face(k)
          else
+            ! Non-positive Y_face_guess values are ignored by the TDC seeded bracket.
             Y_face_guess = 0d0
          end if
 
@@ -343,7 +340,7 @@ contains
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, s%tdc_num_iters(k), max_conv_vel, &
             Eq_div_w, grav, &
             s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr, &
-            have_Y_face_guess, Y_face_guess)
+            Y_face_guess)
          s% dvc_dt_TDC(k) = (conv_vel%val - conv_vel_start) / s%dt
 
             if (ierr /= 0) then
@@ -365,7 +362,7 @@ contains
                   scale_height, gradL, grada, conv_vel, D, Y_face, gradT, s%tdc_num_iters(k), max_conv_vel, &
                   Eq_div_w, grav, &
                   s% include_mlt_corr_to_TDC, s% TDC_alpha_C, s% TDC_alpha_S, s% use_TDC_enthalpy_flux_limiter, energy, ierr, &
-                  have_Y_face_guess, Y_face_guess)
+                  Y_face_guess)
                s% dvc_dt_TDC(k) = (conv_vel%val - conv_vel_start) / s%dt
                if (ierr /= 0) then
                   if (s% report_ierr) write(*,*) 'ierr from set_TDC when using superad_reduction'

--- a/star_data/private/star_controls_dev.inc
+++ b/star_data/private/star_controls_dev.inc
@@ -1,5 +1,7 @@
          
          logical :: compare_TDC_to_MLT 
+         logical :: use_TDC_Y_face_seeded_newton
+         character(32) :: hydro_matrix_solver
 
          logical :: TDC_use_density_form_for_eddy_viscosity
          logical :: include_mlt_Pturb_in_thermodynamic_gradients

--- a/turb/private/tdc.f90
+++ b/turb/private/tdc.f90
@@ -48,7 +48,7 @@ contains
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
    !! @param Y_face_guess Candidate superadiabaticity for the local solve. Non-positive values disable seeding.
-   subroutine get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, Y_face_guess)
+   subroutine get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, Y_face_guess, ierr)
       type(tdc_info), intent(in) :: info
       real(dp), intent(in) :: scale
       type(auto_diff_real_tdc), intent(in) :: Zlb, Zub
@@ -97,8 +97,8 @@ contains
       ! Start down the chain of logic...
       if (Y_is_positive) then
          ! If Y > 0 then Q(Y) is monotone and we can jump straight to the search.
-         call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr, &
-            Y_face_guess)
+         call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, &
+            Y_face_guess, ierr)
          if (ierr /= 0) return
          Y = convert(Y_face)
          if (info%report) write(*,*) 'Y is positive, Y=',Y_face%val
@@ -183,7 +183,7 @@ contains
                      ! Do a search over [lower_bound, Z1]. If we find a root, that's the root closest to zero so call it done.
                      if (info%report) write(*,*) 'Searching from Y=',-exp(Zlb%val),'to Y=',-exp(Z1%val)
                      call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Z1, Y_face, Af, tdc_num_iters, &
-                        ierr, 0d0)
+                        0d0, ierr)
                      Y = convert(Y_face)
                      if (info%report) write(*,*) 'ierr',ierr, tdc_num_iters
                      if (ierr /= 0) then
@@ -191,7 +191,7 @@ contains
                         ! Do a search over [Z1, Z0]. If we find a root, that's the root closest to zero so call it done.
                         ! Note that if we get to this stage there is (mathematically) guaranteed to be a root, modulo precision issues.
                         call bracket_plus_Newton_search(info, scale, Y_is_positive, Z1, Z0, Y_face, Af, tdc_num_iters, &
-                           ierr, 0d0)
+                           0d0, ierr)
                         Y = convert(Y_face)
                      end if
                      if (info%report) write(*,*) 'Y=',Y%val
@@ -201,7 +201,7 @@ contains
                   call compute_Q(info, Y0, Q, Af)
                   if (Q > 0) then  ! Means there's a root in [Y0,0] so we bracket search from [lower_bound,Z0]
                      call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Z0, Y_face, Af, tdc_num_iters, &
-                        ierr, 0d0)
+                        0d0, ierr)
                      Y = convert(Y_face)
                      if (info%report) write(*,*) 'Q(Y0) > 0, bisected and found Y=',Y%val
                   else  ! Means there's no root in [Y0,0] so the only root is radY.
@@ -234,8 +234,8 @@ contains
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
    !! @param Y_face_guess Candidate superadiabaticity for the local solve. Non-positive values disable seeding.
-   subroutine bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr, &
-         Y_face_guess)
+   subroutine bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, &
+         Y_face_guess, ierr)
       type(tdc_info), intent(in) :: info
       logical, intent(in) :: Y_is_positive
       real(dp), intent(in) :: scale

--- a/turb/private/tdc.f90
+++ b/turb/private/tdc.f90
@@ -47,12 +47,17 @@ contains
    !! @param Y_face The superadiabaticity (dlnT/dlnP - grada, output).
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
-   subroutine get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr)
+   !! @param have_Y_face_guess If true, use Y_face_guess to try a small local positive-Y bracket.
+   !! @param Y_face_guess Candidate superadiabaticity for the local solve.
+   subroutine get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, &
+         have_Y_face_guess, Y_face_guess)
       type(tdc_info), intent(in) :: info
       real(dp), intent(in) :: scale
       type(auto_diff_real_tdc), intent(in) :: Zlb, Zub
       type(auto_diff_real_star_order1),intent(out) :: conv_vel, Y_face
       integer, intent(out) :: tdc_num_iters, ierr
+      logical, intent(in), optional :: have_Y_face_guess
+      real(dp), intent(in), optional :: Y_face_guess
 
       logical :: Y_is_positive
       type(auto_diff_real_tdc) :: Af, Y, Y0, Y1, Z0, Z1, radY
@@ -95,9 +100,10 @@ contains
       ! Start down the chain of logic...
       if (Y_is_positive) then
          ! If Y > 0 then Q(Y) is monotone and we can jump straight to the search.
-         call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr)
-         Y = convert(Y_face)
+         call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr, &
+            have_Y_face_guess, Y_face_guess)
          if (ierr /= 0) return
+         Y = convert(Y_face)
          if (info%report) write(*,*) 'Y is positive, Y=',Y_face%val
       else
          if (info%report) write(*,*) 'Y is negative.'
@@ -227,7 +233,10 @@ contains
    !! @param Y_face The superadiabaticity (dlnT/dlnP - grada, output).
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
-   subroutine bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr)
+   !! @param have_Y_face_guess If true, use Y_face_guess to try a small local positive-Y bracket.
+   !! @param Y_face_guess Candidate superadiabaticity for the local solve.
+   subroutine bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr, &
+         have_Y_face_guess, Y_face_guess)
       type(tdc_info), intent(in) :: info
       logical, intent(in) :: Y_is_positive
       real(dp), intent(in) :: scale
@@ -236,6 +245,8 @@ contains
       type(auto_diff_real_tdc), intent(out) :: Af
       integer, intent(out) :: tdc_num_iters
       integer, intent(out) :: ierr
+      logical, intent(in), optional :: have_Y_face_guess
+      real(dp), intent(in), optional :: Y_face_guess
 
       type(auto_diff_real_tdc) :: Y, Z, Q, Qc, Z_new, correction, lower_bound_Z, upper_bound_Z
       type(auto_diff_real_tdc) :: dQdZ
@@ -252,6 +263,9 @@ contains
       ! We start by bisecting to find a narrow interval around the root.
       lower_bound_Z = Zlb
       upper_bound_Z = Zub
+
+      call try_seeded_positive_Y_bracket(info, Y_is_positive, Zlb, Zub, lower_bound_Z, upper_bound_Z, &
+         have_Y_face_guess, Y_face_guess)
 
       ! Perform bisection search.
       call Q_bisection_search(info, Y_is_positive, lower_bound_Z, upper_bound_Z, Z, ierr)
@@ -274,6 +288,10 @@ contains
       do iter = 1, max_iter
          Y = set_Y(Y_is_positive, Z)
          call compute_Q(info, Y, Q, Af)
+         if (is_bad(Q%val)) then
+            ierr = 1
+            exit
+         end if
 
          if (abs(Q%val)/scale <= residual_tolerance .and. have_derivatives) then
             ! Can't exit on the first iteration, otherwise we have no derivative information.
@@ -329,7 +347,9 @@ contains
 
             call compute_Q(info, Y, Qc, Af)
 
-            if (abs(Qc) < abs(Q)) then
+            if (is_bad(Qc%val)) then
+               correction = 0.5d0 * correction
+            else if (abs(Qc) < abs(Q)) then
                exit
             else
                correction = 0.5d0 * correction
@@ -377,5 +397,44 @@ contains
       Y_face = unconvert(Y)
       tdc_num_iters = iter
    end subroutine bracket_plus_Newton_search
+
+
+   subroutine try_seeded_positive_Y_bracket(info, Y_is_positive, Zlb, Zub, lower_bound_Z, upper_bound_Z, &
+         have_Y_face_guess, Y_face_guess)
+      type(tdc_info), intent(in) :: info
+      logical, intent(in) :: Y_is_positive
+      type(auto_diff_real_tdc), intent(in) :: Zlb, Zub
+      type(auto_diff_real_tdc), intent(inout) :: lower_bound_Z, upper_bound_Z
+      logical, intent(in), optional :: have_Y_face_guess
+      real(dp), intent(in), optional :: Y_face_guess
+
+      type(auto_diff_real_tdc) :: Af, Q_lb, Q_ub, Y, Z_seed, Z_seed_lb, Z_seed_ub
+      ! Try a local bracket within a factor exp(seed_bracket_half_width) of the seed.
+      real(dp), parameter :: seed_bracket_half_width = 3d0
+
+      if (.not. Y_is_positive) return
+      if (.not. present(have_Y_face_guess)) return
+      if (.not. present(Y_face_guess)) return
+      if (.not. have_Y_face_guess) return
+      if (is_bad(Y_face_guess) .or. Y_face_guess <= 0d0) return
+
+      Z_seed = log(Y_face_guess)
+      if (is_bad(Z_seed%val)) return
+      if (Z_seed%val < Zlb%val .or. Z_seed%val > Zub%val) return
+
+      Z_seed_lb = max(Zlb%val, Z_seed%val - seed_bracket_half_width)
+      Z_seed_ub = min(Zub%val, Z_seed%val + seed_bracket_half_width)
+
+      Y = set_Y(Y_is_positive, Z_seed_lb)
+      call compute_Q(info, Y, Q_lb, Af)
+      Y = set_Y(Y_is_positive, Z_seed_ub)
+      call compute_Q(info, Y, Q_ub, Af)
+
+      if (is_bad(Q_lb%val) .or. is_bad(Q_ub%val)) return
+      if (Q_lb * Q_ub > 0d0) return
+
+      lower_bound_Z = Z_seed_lb
+      upper_bound_Z = Z_seed_ub
+   end subroutine try_seeded_positive_Y_bracket
 
 end module tdc

--- a/turb/private/tdc.f90
+++ b/turb/private/tdc.f90
@@ -47,17 +47,14 @@ contains
    !! @param Y_face The superadiabaticity (dlnT/dlnP - grada, output).
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
-   !! @param have_Y_face_guess If true, use Y_face_guess to try a small local positive-Y bracket.
-   !! @param Y_face_guess Candidate superadiabaticity for the local solve.
-   subroutine get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, &
-         have_Y_face_guess, Y_face_guess)
+   !! @param Y_face_guess Candidate superadiabaticity for the local solve. Non-positive values disable seeding.
+   subroutine get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, Y_face_guess)
       type(tdc_info), intent(in) :: info
       real(dp), intent(in) :: scale
       type(auto_diff_real_tdc), intent(in) :: Zlb, Zub
       type(auto_diff_real_star_order1),intent(out) :: conv_vel, Y_face
       integer, intent(out) :: tdc_num_iters, ierr
-      logical, intent(in), optional :: have_Y_face_guess
-      real(dp), intent(in), optional :: Y_face_guess
+      real(dp), intent(in) :: Y_face_guess
 
       logical :: Y_is_positive
       type(auto_diff_real_tdc) :: Af, Y, Y0, Y1, Z0, Z1, radY
@@ -101,7 +98,7 @@ contains
       if (Y_is_positive) then
          ! If Y > 0 then Q(Y) is monotone and we can jump straight to the search.
          call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr, &
-            have_Y_face_guess, Y_face_guess)
+            Y_face_guess)
          if (ierr /= 0) return
          Y = convert(Y_face)
          if (info%report) write(*,*) 'Y is positive, Y=',Y_face%val
@@ -185,14 +182,16 @@ contains
                      if (info%report) write(*,*) 'Root has Q>0. Q(Y1)=',Q%val
                      ! Do a search over [lower_bound, Z1]. If we find a root, that's the root closest to zero so call it done.
                      if (info%report) write(*,*) 'Searching from Y=',-exp(Zlb%val),'to Y=',-exp(Z1%val)
-                     call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Z1, Y_face, Af, tdc_num_iters, ierr)
+                     call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Z1, Y_face, Af, tdc_num_iters, &
+                        ierr, 0d0)
                      Y = convert(Y_face)
                      if (info%report) write(*,*) 'ierr',ierr, tdc_num_iters
                      if (ierr /= 0) then
                         if (info%report) write(*,*) 'No root found. Searching from Y=',-exp(Z1%val),'to Y=',-exp(Z0%val)
                         ! Do a search over [Z1, Z0]. If we find a root, that's the root closest to zero so call it done.
                         ! Note that if we get to this stage there is (mathematically) guaranteed to be a root, modulo precision issues.
-                        call bracket_plus_Newton_search(info, scale, Y_is_positive, Z1, Z0, Y_face, Af, tdc_num_iters, ierr)
+                        call bracket_plus_Newton_search(info, scale, Y_is_positive, Z1, Z0, Y_face, Af, tdc_num_iters, &
+                           ierr, 0d0)
                         Y = convert(Y_face)
                      end if
                      if (info%report) write(*,*) 'Y=',Y%val
@@ -201,7 +200,8 @@ contains
                   if (info%report) write(*,*) 'Bisected dQdZ, no root found.'
                   call compute_Q(info, Y0, Q, Af)
                   if (Q > 0) then  ! Means there's a root in [Y0,0] so we bracket search from [lower_bound,Z0]
-                     call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Z0, Y_face, Af, tdc_num_iters, ierr)
+                     call bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Z0, Y_face, Af, tdc_num_iters, &
+                        ierr, 0d0)
                      Y = convert(Y_face)
                      if (info%report) write(*,*) 'Q(Y0) > 0, bisected and found Y=',Y%val
                   else  ! Means there's no root in [Y0,0] so the only root is radY.
@@ -233,10 +233,9 @@ contains
    !! @param Y_face The superadiabaticity (dlnT/dlnP - grada, output).
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
-   !! @param have_Y_face_guess If true, use Y_face_guess to try a small local positive-Y bracket.
-   !! @param Y_face_guess Candidate superadiabaticity for the local solve.
+   !! @param Y_face_guess Candidate superadiabaticity for the local solve. Non-positive values disable seeding.
    subroutine bracket_plus_Newton_search(info, scale, Y_is_positive, Zlb, Zub, Y_face, Af, tdc_num_iters, ierr, &
-         have_Y_face_guess, Y_face_guess)
+         Y_face_guess)
       type(tdc_info), intent(in) :: info
       logical, intent(in) :: Y_is_positive
       real(dp), intent(in) :: scale
@@ -245,8 +244,7 @@ contains
       type(auto_diff_real_tdc), intent(out) :: Af
       integer, intent(out) :: tdc_num_iters
       integer, intent(out) :: ierr
-      logical, intent(in), optional :: have_Y_face_guess
-      real(dp), intent(in), optional :: Y_face_guess
+      real(dp), intent(in) :: Y_face_guess
 
       type(auto_diff_real_tdc) :: Y, Z, Q, Qc, Z_new, correction, lower_bound_Z, upper_bound_Z
       type(auto_diff_real_tdc) :: dQdZ
@@ -264,8 +262,7 @@ contains
       lower_bound_Z = Zlb
       upper_bound_Z = Zub
 
-      call try_seeded_positive_Y_bracket(info, Y_is_positive, Zlb, Zub, lower_bound_Z, upper_bound_Z, &
-         have_Y_face_guess, Y_face_guess)
+      call try_seeded_positive_Y_bracket(info, Y_is_positive, Zlb, Zub, lower_bound_Z, upper_bound_Z, Y_face_guess)
 
       ! Perform bisection search.
       call Q_bisection_search(info, Y_is_positive, lower_bound_Z, upper_bound_Z, Z, ierr)
@@ -399,23 +396,18 @@ contains
    end subroutine bracket_plus_Newton_search
 
 
-   subroutine try_seeded_positive_Y_bracket(info, Y_is_positive, Zlb, Zub, lower_bound_Z, upper_bound_Z, &
-         have_Y_face_guess, Y_face_guess)
+   subroutine try_seeded_positive_Y_bracket(info, Y_is_positive, Zlb, Zub, lower_bound_Z, upper_bound_Z, Y_face_guess)
       type(tdc_info), intent(in) :: info
       logical, intent(in) :: Y_is_positive
       type(auto_diff_real_tdc), intent(in) :: Zlb, Zub
       type(auto_diff_real_tdc), intent(inout) :: lower_bound_Z, upper_bound_Z
-      logical, intent(in), optional :: have_Y_face_guess
-      real(dp), intent(in), optional :: Y_face_guess
+      real(dp), intent(in) :: Y_face_guess
 
       type(auto_diff_real_tdc) :: Af, Q_lb, Q_ub, Y, Z_seed, Z_seed_lb, Z_seed_ub
       ! Try a local bracket within a factor exp(seed_bracket_half_width) of the seed.
       real(dp), parameter :: seed_bracket_half_width = 3d0
 
       if (.not. Y_is_positive) return
-      if (.not. present(have_Y_face_guess)) return
-      if (.not. present(Y_face_guess)) return
-      if (.not. have_Y_face_guess) return
       if (is_bad(Y_face_guess) .or. Y_face_guess <= 0d0) return
 
       Z_seed = log(Y_face_guess)

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -117,7 +117,7 @@ module turb
             mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, &
             max_conv_vel, Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, &
-            TDC_alpha_S, use_TDC_enthalpy_flux_limiter, energy, ierr, Y_face_guess)
+            TDC_alpha_S, use_TDC_enthalpy_flux_limiter, energy, Y_face_guess, ierr)
       use tdc
       use tdc_support
       real(dp), intent(in) :: conv_vel_start, mixing_length_alpha, TDC_alpha_D, TDC_alpha_R, TDC_alpha_Pt
@@ -186,7 +186,7 @@ module turb
       ! Get solution
       Zub = upper_bound_Z
       Zlb = lower_bound_Z
-      call get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, Y_face_guess)
+      call get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, Y_face_guess, ierr)
 
       ! Cap conv_vel at max_conv_vel_div_csound*cs
       if (conv_vel%val > max_conv_vel) then

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -111,12 +111,14 @@ module turb
    !! @param gradT The temperature gradient dlnT/dlnP (output).
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
+   !! @param have_Y_face_guess If true, use Y_face_guess to try a small local positive-Y bracket.
+   !! @param Y_face_guess Candidate superadiabaticity for the local solve.
    subroutine set_TDC( &
             conv_vel_start, mixing_length_alpha, TDC_alpha_D, TDC_alpha_R, TDC_alpha_Pt, dt, cgrav, m, report, &
             mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, &
             max_conv_vel, Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, &
-            TDC_alpha_S, use_TDC_enthalpy_flux_limiter, energy, ierr)
+            TDC_alpha_S, use_TDC_enthalpy_flux_limiter, energy, ierr, have_Y_face_guess, Y_face_guess)
       use tdc
       use tdc_support
       real(dp), intent(in) :: conv_vel_start, mixing_length_alpha, TDC_alpha_D, TDC_alpha_R, TDC_alpha_Pt
@@ -124,6 +126,8 @@ module turb
       type(auto_diff_real_star_order1), intent(in) :: &
          chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, scale_height, gradL, grada, Eq_div_w, grav, energy
       logical, intent(in) :: report, include_mlt_corr_to_TDC, use_TDC_enthalpy_flux_limiter
+      logical, intent(in), optional :: have_Y_face_guess
+      real(dp), intent(in), optional :: Y_face_guess
       type(auto_diff_real_star_order1),intent(out) :: conv_vel, Y_face, gradT, D
       integer, intent(out) :: tdc_num_iters, mixing_type, ierr
       type(tdc_info) :: info
@@ -135,14 +139,23 @@ module turb
       type(auto_diff_real_tdc) :: Zub, Zlb
       include 'formats'
 
-      ! Do a call to MLT
       !grav = cgrav * m / pow2(r)
       L = 64d0 * pi * boltz_sigma * pow4(T) * grav * pow2(r) * gradr / (3d0 * P * opacity)
-      Lambda = mixing_length_alpha * scale_height
-      call set_MLT('Cox', mixing_length_alpha, 0d0, 0d0, &
-                     chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
-                     gradr, grada, gradL, &
-                     Gamma, gradT, Y_face, conv_vel, D, mixing_type,1d99, ierr)
+      if (include_mlt_corr_to_TDC) then
+         Lambda = mixing_length_alpha * scale_height
+         call set_MLT('Cox', mixing_length_alpha, 0d0, 0d0, &
+                        chiT, chiRho, Cp, grav, Lambda, rho, P, T, opacity, &
+                        gradr, grada, gradL, &
+                        Gamma, gradT, Y_face, conv_vel, D, mixing_type,1d99, ierr)
+      else
+         Gamma = 0d0
+         gradT = gradr
+         Y_face = gradT - gradL
+         conv_vel = 0d0
+         D = 0d0
+         mixing_type = no_mixing
+         ierr = 0
+      end if
 
 
       ! Pack TDC info
@@ -175,7 +188,8 @@ module turb
       ! Get solution
       Zub = upper_bound_Z
       Zlb = lower_bound_Z
-      call get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr)
+      call get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, &
+         have_Y_face_guess, Y_face_guess)
 
       ! Cap conv_vel at max_conv_vel_div_csound*cs
       if (conv_vel%val > max_conv_vel) then

--- a/turb/public/turb.f90
+++ b/turb/public/turb.f90
@@ -111,14 +111,13 @@ module turb
    !! @param gradT The temperature gradient dlnT/dlnP (output).
    !! @param tdc_num_iters Number of iterations taken in the TDC solver.
    !! @param ierr Tracks errors (output).
-   !! @param have_Y_face_guess If true, use Y_face_guess to try a small local positive-Y bracket.
-   !! @param Y_face_guess Candidate superadiabaticity for the local solve.
+   !! @param Y_face_guess Candidate superadiabaticity for the local solve. Non-positive values disable seeding.
    subroutine set_TDC( &
             conv_vel_start, mixing_length_alpha, TDC_alpha_D, TDC_alpha_R, TDC_alpha_Pt, dt, cgrav, m, report, &
             mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, &
             max_conv_vel, Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, &
-            TDC_alpha_S, use_TDC_enthalpy_flux_limiter, energy, ierr, have_Y_face_guess, Y_face_guess)
+            TDC_alpha_S, use_TDC_enthalpy_flux_limiter, energy, ierr, Y_face_guess)
       use tdc
       use tdc_support
       real(dp), intent(in) :: conv_vel_start, mixing_length_alpha, TDC_alpha_D, TDC_alpha_R, TDC_alpha_Pt
@@ -126,8 +125,7 @@ module turb
       type(auto_diff_real_star_order1), intent(in) :: &
          chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, scale_height, gradL, grada, Eq_div_w, grav, energy
       logical, intent(in) :: report, include_mlt_corr_to_TDC, use_TDC_enthalpy_flux_limiter
-      logical, intent(in), optional :: have_Y_face_guess
-      real(dp), intent(in), optional :: Y_face_guess
+      real(dp), intent(in) :: Y_face_guess
       type(auto_diff_real_star_order1),intent(out) :: conv_vel, Y_face, gradT, D
       integer, intent(out) :: tdc_num_iters, mixing_type, ierr
       type(tdc_info) :: info
@@ -188,8 +186,7 @@ module turb
       ! Get solution
       Zub = upper_bound_Z
       Zlb = lower_bound_Z
-      call get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, &
-         have_Y_face_guess, Y_face_guess)
+      call get_TDC_solution(info, scale, Zlb, Zub, conv_vel, Y_face, tdc_num_iters, ierr, Y_face_guess)
 
       ! Cap conv_vel at max_conv_vel_div_csound*cs
       if (conv_vel%val > max_conv_vel) then

--- a/turb/test/src/test_turb.f90
+++ b/turb/test/src/test_turb.f90
@@ -151,7 +151,7 @@ contains
          mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
          scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, max_conv_vel, &
          Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, TDC_alpha_S, use_TDC_enthalpy_flux_limiter, &
-         energy, ierr)
+         energy, ierr, 0d0)
 
 
       write (*, 1) 'TDC: Y, conv_vel_start, conv_vel, dt   ', Y_face%val, conv_vel_start, conv_vel%val, dt
@@ -225,7 +225,7 @@ contains
             mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, max_conv_vel, &
             Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, TDC_alpha_S, use_TDC_enthalpy_flux_limiter, &
-            energy, ierr)
+            energy, ierr, 0d0)
 
 
          write (*, 1) 'dt, gradT, conv_vel_start, conv_vel', dt, gradT%val, conv_vel_start, conv_vel%val

--- a/turb/test/src/test_turb.f90
+++ b/turb/test/src/test_turb.f90
@@ -151,7 +151,7 @@ contains
          mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
          scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, max_conv_vel, &
          Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, TDC_alpha_S, use_TDC_enthalpy_flux_limiter, &
-         energy, ierr, 0d0)
+         energy, 0d0, ierr)
 
 
       write (*, 1) 'TDC: Y, conv_vel_start, conv_vel, dt   ', Y_face%val, conv_vel_start, conv_vel%val, dt
@@ -225,7 +225,7 @@ contains
             mixing_type, scale, chiT, chiRho, gradr, r, P, T, rho, dV, Cp, opacity, &
             scale_height, gradL, grada, conv_vel, D, Y_face, gradT, tdc_num_iters, max_conv_vel, &
             Eq_div_w, grav, include_mlt_corr_to_TDC, TDC_alpha_C, TDC_alpha_S, use_TDC_enthalpy_flux_limiter, &
-            energy, ierr, 0d0)
+            energy, 0d0, ierr)
 
 
          write (*, 1) 'dt, gradT, conv_vel_start, conv_vel', dt, gradT%val, conv_vel_start, conv_vel%val


### PR DESCRIPTION
This pr adds:

1.  a matrix solver option with `hydro_matrix_solver = 'banded'` support and solver plumbing. This is the same banded solver RSP uses, just repurposed for star. It is significantly faster than bcyclic for pulsation models, or really anything that is on a smaller mesh. Bcyclic can parallelize more and remains a better all purpose generalized solver for MESA.

2. `use_TDC_Y_face_seeded_newton` plus the Y-face start/previous-iteration seed path.
Small supporting TDC plumbing. `use_TDC_Y_face_seeded_newton` let's TDC skip the bisection logic and newton iterate to get a solution faster if the solution hasn't moved very far. This is helpful for zones where convection is not changing very much and another full root bisection can be wasteful. This control in my testing reduced the number of iterations in most TDC zones in half. This should be tested further, but this option should reduce the time spent in TDC ~ 1/2 . I have seen 5-10% speed up in some models during testing, but the speed up only becomes important when the timestep is limited by tdc/mlt and not eos/kap or other evolve step related overhead.

3. along with 2, when `include_mlt_corr_to_TDC = .false.`, we now skip the call to Cox inside TDC, since we don't need mlt Gamma. This is one less extra mlt call inside tdc per zone per iteration.