### PR TITLE
fix scalar multiply

### DIFF
--- a/num/public/accurate_sum_auto_diff_star_order1.f90
+++ b/num/public/accurate_sum_auto_diff_star_order1.f90
@@ -135,8 +135,8 @@ contains
       type(accurate_auto_diff_real_star_order1), intent(in) :: op1
       real(dp), intent(in) :: op2
 
-      ret%sum = op1%sum*op1
-      ret%compensator = op1%compensator*op1
+      ret%sum = op1%sum*op2
+      ret%compensator = op1%compensator*op2
 
    end function mult_acc_rdp
 


### PR DESCRIPTION
This PR fixes a typo in the accurate auto-diff multiply code.

When MESA did:

```fortran
accurate_ad_value * scalar
```

the code accidentally multiplied by the accurate auto-diff value again, instead
of multiplying by the scalar.

So it was effectively doing:

```fortran
value * value
```

when it should have done:

```fortran
value * scalar
```

The fix changes the multiply routine, so it uses the scalar. This makes
`accurate_ad * scalar` behave the same way as `scalar * accurate_ad`.

This could have affected the hydro routines that use accurate auto-diff sums,
like `get1_energy_eqn`, `get1_momentum_eqn`, `do1_dudt_eqn`, and
`do1_turbulent_energy_eqn`. But those routines avoided this bug because they
either convert back to normal auto-diff before scaling, or use
the safe multiply direction. That small syntax difference prevented this bug from
breaking anything, because `scalar * accurate_ad_value` worked, while 
`accurate_ad_value * scalar` was the broken operator overload.