### PR TITLE
fixed incorrect metal mass fraction array for Freedman lowT opacity tables

### DIFF
--- a/kap/preprocessor/src/freedman.f90
+++ b/kap/preprocessor/src/freedman.f90
@@ -43,19 +43,19 @@ contains
       integer :: iz
       iz = floor(Z*1d5 + 0.1d0)
       select case (iz)
-      case (1000)
+      case (700)
          fname = trim(data_dir)//'/m0.3.txt'
-      case (2000)
+      case (1500)
          fname = trim(data_dir)//'/p0.0.txt'
-      case (4000)
+      case (2900)
          fname = trim(data_dir)//'/p0.3.txt'
-      case (10000)
+      case (7000)
          fname = trim(data_dir)//'/p0.7.txt'
-      case (20000)
+      case (13000)
          fname = trim(data_dir)//'/p1.0.txt'
-      case (63000)
+      case (32100)
          fname = trim(data_dir)//'/p1.5.txt'
-      case (100000)
+      case (42900)
          fname = trim(data_dir)//'/p1.7.txt'
       case default
          write (*, *) 'get_Freedman_fname: unexpected Z value for Freedman data', Z

--- a/kap/public/kap_def.f90
+++ b/kap/public/kap_def.f90
@@ -618,7 +618,7 @@ contains
           kap_lowT_Xs(1:num_kap_lowT_Xs(i), i) = [ 0.00d0 ]
           num_kap_lowT_Zs(i) = 7
           kap_lowT_Zs(1:num_kap_lowT_Zs(i), i) = &
-             [ 0.01d0, 0.02d0, 0.04d0, 0.100d0, 0.200d0, 0.63d0, 1.00d0 ]
+             [ 0.007d0, 0.015d0, 0.029d0, 0.07d0,  0.13d0,  0.321d0, 0.429d0 ]
           num_kap_lowT_Xs_for_this_Z(1:num_kap_lowT_Zs(i), i) = num_kap_lowT_Xs(i)
        case DEFAULT
           num_kap_lowT_Xs(i) = 10


### PR DESCRIPTION
Updated $MESA_DIR/kap/public/kap_def.f90 and $MESA_DIR/kap/preprocessor/src/freedman.f90 to reflect the below:
------------
Louis Siebenaler (cc'd) and I noticed a problem with the preprocessing & evaluation of the Freedman11 low-temperature opacity tables. Specifically, the "Z" values associated with each table, as e.g. enumerated in $MESA_DIR/kap/public/kap_def.f90,
num_kap_lowT_Zs(i) = 7
kap_lowT_Zs(1:num_kap_lowT_Zs(i), i) = [ 0.01d0, 0.02d0, 0.04d0, 0.100d0, 0.200d0, 0.63d0, 1.00d0 ]

are not metal mass fractions. Rather, they are related to number fractions; for example, a Freedman [M/H] value of -0.3 corresponds to a metal number fraction of 10**(-0.3)*solar = 0.5*solar; [M/H]=0 corresponds to a solar number fraction, etc. It appears that there was a decision made to equate the solar metal number fraction with a metal *mass* fraction of 0.02 and scale the other values in the array accordingly.

The metal mass fraction array should instead look something like this (with small variations possible depending on which protosolar abundance table you work with; the below values are based on Lodders 2003 table 2):
[M/H] = [-0.3, 0.0, 0.3, 0.7, 1.0, 1.5, 1.7]
Z = [0.0075, 0.0148, 0.029,  0.0698, 0.1303, 0.3215, 0.4288]

