### PR TITLE
Minor Changes to Neutrino Cooling Rate

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -37,7 +37,7 @@ Bug Fixes
 
 The plasma neutrino cooling rate was using an hardcoded prefactor calculated with a Weinberg angle of 0.2319, while all other neutrino cooling processes used calculated prefactors taking the Weinberg angle as input, with default value 0.22290.
 Thus, modifying the value of the Weinberg angle resulted in changes to neutrino cooling processes except for the plasma neutrinos.
-This was the case in all previous MESA versions, and was found and fixed by user Garv Chauhan. Plasma neutrinos now use the same Weinberg angle as all other processes and changing its value will affect the corresponding cooling rate.
+This was the case in all previous MESA versions, and was found and fixed by user Garv Chauhan, see `gh-998 https://github.com/MESAHub/mesa/pull/998`_. Plasma neutrinos now use the same Weinberg angle as all other processes and changing its value will affect the corresponding cooling rate.
 The change in default Weinberg angle results in small numerical differences for stars where plasma neutrino cooling is significant.
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,12 @@ MESA no longer stops when reactions for which special rates are set are not in t
 Bug Fixes
 ---------
 
+The plasma neutrino cooling rate was using an hardcoded prefactor calculated with a Weinberg angle of 0.2319, while all other neutrino cooling processes used calculated prefactors taking the Weinberg angle as input, with default value 0.22290.
+Thus, modifying the value of the Weinberg angle resulted in changes to neutrino cooling processes except for the plasma neutrinos.
+This was the case in all previous MESA versions, and was found and fixed by user Garv Chauhan. Plasma neutrinos now use the same Weinberg angle as all other processes and changing its value will affect the corresponding cooling rate.
+The change in default Weinberg angle results in small numerical differences for stars where plasma neutrino cooling is significant.
+
+
 The parameter ``report_max_infall_inside_fe_core`` was ignored in versions r25.12.1 and r26.4.1 and always had it's default value. See `gh-981 https://github.com/MESAHub/mesa/pull/981`_.
 
 ``fe_core_infall_limit`` now obeys ``when_to_stop_rtol`` and ``when_to_stop_atol`` again (broken since r11532).

--- a/neu/private/mod_neu.f90
+++ b/neu/private/mod_neu.f90
@@ -35,6 +35,7 @@
       real(dp), parameter :: cvp   = 1.0d0 - cv
       real(dp), parameter :: ca    = 0.5d0
       real(dp), parameter :: cap   = 1.0d0 - ca
+      real(dp), parameter :: tfac0 = cv*cv + (num_neu_fam-1.0d0) * (cvp*cvp)
       real(dp), parameter :: tfac1 = cv*cv + ca*ca + (num_neu_fam-1.0d0) * (cvp*cvp+cap*cap)
       real(dp), parameter :: tfac2 = cv*cv - ca*ca + (num_neu_fam-1.0d0) * (cvp*cvp - cap*cap)
       real(dp), parameter :: tfac3 = tfac2/tfac1
@@ -237,13 +238,13 @@
          temp = T
       end if
 
-      if (T <= 0) then
+      if (temp <= 0) then
          info = -1
          return
       end if
 
       if (logT == arg_not_provided) then
-         logtemp = log10(T)
+         logtemp = log10(temp)
       else
          logtemp = logT
       end if
@@ -263,13 +264,13 @@
          den = Rho
       end if
 
-      if (Rho <= 0) then
+      if (den <= 0) then
          info = -1
          return
       end if
 
       if (logRho == arg_not_provided) then
-         logden = log10(Rho)
+         logden = log10(den)
       else
          logden = logRho
       end if
@@ -1579,8 +1580,8 @@
          splasdz = a2*splasdz + a3*gl2dz*a1
 
 
-         a2      = 0.93153d0 * 3.0d21 * input% xl9
-         a3      = 0.93153d0 * 3.0d21 * 9.0d0*input% xl8*input% xldt
+         a2      = tfac0 * 3.0d21 * input% xl9
+         a3      = tfac0 * 3.0d21 * 9.0d0*input% xl8*input% xldt
 
          a1      = splas
          splas   = a2*a1


### PR DESCRIPTION
I have been working on a project (along with Mathieu Renzo and Cecilia Lunardini) involving the effect of Beyond-the-Standard-Model neutrino physics on stellar evolution. This requires changing the existing neutrino cooling implementation in MESA. To achieve this, I used the flag (s% other_neu) in run_star_extras.f90. My modified neutrino cooling rate is based directly on the standard MESA neutrino cooling rate implemented in mod_neu.f90 at the main GitHub page for MESA (https://github.com/MESAHub/mesa/tree/main/neu/private).

I want to report two issues that I found during this time :

1. Hardcoded Constant in the Plasma-Neutrino process : In mod_neu.f90, all cooling rates are organized in the form of a thermal integral times some function of pre-defined factors labeled as t1,t2,t3,t4,t5,t6 (see lines 38-43). These pre-defined factors are determined by a combination of cv, cvp and ca, cap (vector and axial-vector couplings, see lines 34-37). Vector coupling is a function of weinberg_theta angle (line 34). Most of the cooling processes (photo-neutrino, pair-neutrino, bremsstrahlung-neutrino, recombination-neutrino) use these pre-defined factors defined globally. Therefore, changing the weinberg_theta or any of the (cv, cvp, ca, cap), will affect all these neutrino cooling rates. 

However, I found that the dependence on (cv, cvp) for the plasma-neutrino process is explicitly hard-coded : value of 0.93153d0 (lines 1582,1583). The expression for this pre-factor is in equation(4.1) of Itoh1996. If evaluated for weinberg_theta used in Itoh1996 (see eqns 2.2-2.4) and set n=2, we get exactly 0.93153. Therefore, if any global change is done for weinberg_theta and/or num_neu_fam, the change is not reflected in the plasma-neutrino process. Moreover, in const_def.f90, definition of weinberg_theta = 0.22290d0 (line 111). While plasma-neutrino process (the hard-coded constant) uses Itoh et. al.'s value of weinberg_theta = 0.2319.

Fix is to define a new factor (around line 37-38)--> real(dp), parameter :: tfac0 = cv*cv + (num_neu_fam-1.0d0) * (cvp*cvp)

Original line 1582 : a2 = 0.93153d0 * 3.0d21 * input% xl9
Original line 1583 : a3 = 0.93153d0 * 3.0d21 * 9.0d0*input% xl8*input% xldt

Fix for line 1582 : a2 = tfac0 * 3.0d21 * input% xl9
Fix for line 1582 : a3 = tfac0 * 3.0d21 * 9.0d0*input% xl8*input% xldt

2. Test conditions are for T/Rho instead for temp/den : This major issue pertains to variable assignment and test conditions defined in the code block (lines 230-280). The code correctly allows either T or logT, and either Rho or logRho, but later it tests if (T <= 0) and if (Rho <= 0). If MESA calls the hook with T = arg_not_provided and only logT supplied, or similarly for density, those checks will fire on the sentinel value and wrongly abort the routine. Those checks should use temp and den instead (line 240 and line 266).

Original line 240 : if (T <= 0d0) then
Fix for line 240 : if (temp <= 0d0) then

Original line 246 :  logtemp = log10(T)
Fix for line 246 :  logtemp = log10(temp)

The original lines are wrong because when MESA passes T = arg_not_provided and only supplies logT instead. In that case, T is a sentinel, not the actual temperature. Similarly for density,

Original line 266 :  if (Rho <= 0) then
Fix for line 266 :  if (den <= 0d0) then

Original line 272 :  logden = log10(Rho)
Fix for line 272 :   logden = log10(den)

The code after the above-mentioned changes does show some differences compared to the older results, but they seem quite minimal. 