### PR TITLE
approx21: fix he4 dydt spurious a2

### DIFF
--- a/net/private/net_approx21.f90
+++ b/net/private/net_approx21.f90
@@ -1110,7 +1110,7 @@
    ! cno cycles
          a1 = y(io16) * y(ih1) * rate(iropg)
 
-         qray(ihe4) =  qray(ihe4) + a1 + a2
+         qray(ihe4) =  qray(ihe4) + a1
 
          if (.not. deriva) then
             a1 = y(in14) * y(ih1) * rate(ifa) * rate(irnpg)


### PR DESCRIPTION
There was a small bug in the derivative for he4 in approx21. `a2 = y(ihe3) * y(ihe4) * rate(irhe3ag)` is added twice on accident. This is just a derivative, so at most it would mildly affect convergence on the pre-ms when there is he3 available? Otherwise I think this is a relatively inconsequential bug.