### PR TITLE
Superadiabatic reduction (linear) timescale limiter

### DIFF
--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -2746,11 +2746,8 @@
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
       ! Optional convective-turnover-time limiter for the throttle.
-      ! When ``.true.``, multiplies the throttle excess
-      ! ``(Gamma_factor - 1)`` by
-      !
-      ! ``f_tau = 1 - exp(-dt / tau_conv)``
-      !
+      ! When ``.true.``, relaxes the throttle using a fraction
+      ! ``f_tau`` set by ``superad_reduction_turnover_limit_function``,
       ! where ``tau_conv = scale_height(k) / mlt_vc_old(k)`` is the
       ! local convective turnover time computed from the previous
       ! step's converged convective velocity. This reflects the
@@ -2775,6 +2772,19 @@
       ! ::
 
       superad_reduction_use_turnover_limit = .false.
+
+      ! superad_reduction_turnover_limit_function
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Functional form for the turnover-time relaxation fraction. Allowed
+      ! values are:
+      !
+      ! - ``'exponential'``: ``f_tau = 1 - exp(-dt/tau_conv)``
+      ! - ``'linear'``: ``f_tau = min(dt/tau_conv, 1)``
+
+      ! ::
+
+      superad_reduction_turnover_limit_function = 'exponential'
 
       ! superad_reduction_turnover_vc_floor_frac
       ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -136,7 +136,8 @@
    gradT_excess_min_center_he4, gradT_excess_max_logT, gradT_excess_min_log_tau_full_on, gradT_excess_max_log_tau_full_off, &
     use_superad_reduction, superad_reduction_gamma_limit, superad_reduction_gamma_limit_scale, D_mix_zero_region_top_q, &
     superad_reduction_gamma_inv_scale, superad_reduction_diff_grads_limit, superad_reduction_limit, &
-    superad_reduction_use_turnover_limit, superad_reduction_turnover_vc_floor_frac, &
+    superad_reduction_use_turnover_limit, superad_reduction_turnover_limit_function, &
+    superad_reduction_turnover_vc_floor_frac, &
     make_gradr_sticky_in_solver_iters, min_logT_for_make_gradr_sticky_in_solver_iters, &
     max_logT_for_mlt, thermohaline_coeff, thermohaline_option, mixing_length_alpha, remove_small_D_limit, &
     alt_scale_height_flag, Henyey_MLT_y_param, Henyey_MLT_nu_param, no_MLT_below_shock, mlt_make_surface_no_mixing, &
@@ -1080,6 +1081,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% superad_reduction_diff_grads_limit = superad_reduction_diff_grads_limit
  s% superad_reduction_limit = superad_reduction_limit
  s% superad_reduction_use_turnover_limit = superad_reduction_use_turnover_limit
+ s% superad_reduction_turnover_limit_function = superad_reduction_turnover_limit_function
  s% superad_reduction_turnover_vc_floor_frac = superad_reduction_turnover_vc_floor_frac
 
  s% max_logT_for_mlt = max_logT_for_mlt
@@ -2805,6 +2807,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  superad_reduction_diff_grads_limit = s% superad_reduction_diff_grads_limit
  superad_reduction_limit = s% superad_reduction_limit
  superad_reduction_use_turnover_limit = s% superad_reduction_use_turnover_limit
+ superad_reduction_turnover_limit_function = s% superad_reduction_turnover_limit_function
  superad_reduction_turnover_vc_floor_frac = s% superad_reduction_turnover_vc_floor_frac
 
  max_logT_for_mlt = s% max_logT_for_mlt

--- a/star/private/turb_support.f90
+++ b/star/private/turb_support.f90
@@ -561,7 +561,12 @@ contains
                               * s% csound_face(k)
                vc_old_local = max(s% mlt_vc_old(k), vc_old_floor, 1d-30)
                tau_conv = scale_height / vc_old_local
-               f_turnover = 1d0 - exp(-s% dt / tau_conv)
+               select case (trim(s% superad_reduction_turnover_limit_function))
+               case ('linear')
+                  f_turnover = min(s% dt / tau_conv, 1d0)
+               case default
+                  f_turnover = 1d0 - exp(-s% dt / tau_conv)
+               end select
                Gamma_factor = Gamma_factor_old_local + &
                               f_turnover * (Gamma_factor - Gamma_factor_old_local)
             end if

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -307,6 +307,7 @@
             superad_reduction_diff_grads_limit, &
             superad_reduction_limit
          logical :: superad_reduction_use_turnover_limit
+         character(len=strlen) :: superad_reduction_turnover_limit_function
          real(dp) :: superad_reduction_turnover_vc_floor_frac
 
       ! mixing parameters


### PR DESCRIPTION
Very similar to #1006, with the same motivation, only the activation function of the limiter is linear, rather than an exponential logistic-like supression.