### PR TITLE
update make_pre_ccn_13bvn

### DIFF
--- a/star/test_suite/make_pre_ccsn_13bvn/README.rst
+++ b/star/test_suite/make_pre_ccsn_13bvn/README.rst
@@ -12,8 +12,7 @@ Physical checks
 
 Tests the functionality of velocity drag for v_flag for damping large surfaces velocities from He shell (N-alpha) flashes during advanced burning.
 Tests energy conservation for regions where v_drag is applied.
-Tests the use of OP_split_burn as split burn <4d9 leads to large temperature swings and single zone burning in the core, and split burn >4.5d9 needs smaller timesteps.
-This case illustrates strong coupling between burning and hydro: OP_split_burn lower and higher thresholds can only be exceeded with very tight timesteps.
+Tests MESA's solver by evolving to core-collapse with fully implicit coupling between burning and hydrodynamics.
 
 Inlists
 =======
@@ -28,9 +27,9 @@ This test case has five parts.
 
 * Part 4 (``inlist_after_remove``) replaces the remaining hydrogen in the envelope with helium.
 
-* Part 5 (``inlist_to_post_si_burn``) evolves the model until log_center_T = 9.60d0, after Si-core burning. op_split_burn_min_T = 4.2d9
+* Part 5 (``inlist_to_post_si_burn``) evolves the model until log_center_T = 9.60d0, after Si-core burning.
 
-* Part 6 (``inlist_to_cc``) evolves the model until core collapse (300 km/s infall).  reduced to op_split_burn_min_T = 1d9 for speed
+* Part 6 (``inlist_to_cc``) evolves the model until core collapse (300 km/s infall). 
 
 
 Last-Updated: 24Dec2023 by EbF

--- a/star/test_suite/make_pre_ccsn_13bvn/README.rst
+++ b/star/test_suite/make_pre_ccsn_13bvn/README.rst
@@ -32,4 +32,4 @@ This test case has five parts.
 * Part 6 (``inlist_to_cc``) evolves the model until core collapse (300 km/s infall). 
 
 
-Last-Updated: 24Dec2023 by EbF
+Last-Updated: 01June2026 by EbF

--- a/star/test_suite/make_pre_ccsn_13bvn/README.rst
+++ b/star/test_suite/make_pre_ccsn_13bvn/README.rst
@@ -29,7 +29,7 @@ This test case has five parts.
 
 * Part 5 (``inlist_to_post_si_burn``) evolves the model until log_center_T = 9.60d0, after Si-core burning.
 
-* Part 6 (``inlist_to_cc``) evolves the model until core collapse (300 km/s infall). 
+* Part 6 (``inlist_to_cc``) evolves the model until core collapse (300 km/s infall).
 
 
 Last-Updated: 01June2026 by EbF

--- a/star/test_suite/make_pre_ccsn_13bvn/inlist_after_remove
+++ b/star/test_suite/make_pre_ccsn_13bvn/inlist_after_remove
@@ -31,6 +31,7 @@
       x_integer_ctrl(1) = 4 ! inlist_part
 
 ! prevent development of radial pulses during advanced burning
+      use_drag_energy = .false.
       drag_coefficient = 1d0
       min_q_for_drag = 0.8d0
 

--- a/star/test_suite/make_pre_ccsn_13bvn/inlist_massive_defaults
+++ b/star/test_suite/make_pre_ccsn_13bvn/inlist_massive_defaults
@@ -24,6 +24,8 @@
 / ! end of star_job namelist
 
 &eos
+  mass_fraction_limit_for_Skye  = 1d-16
+
 / ! end of eos namelist
 
 &kap
@@ -40,7 +42,7 @@
 &controls
 
 ! For test_suite testing
-max_model_number = 6000
+max_model_number = 8000
 
 ! Initial model controls
      initial_mass = 12.0
@@ -103,11 +105,6 @@ max_model_number = 6000
 ! Let's decouple burning and mixing in zones above 4.2d9, or else
 ! you might run into convergence issues near cc without better numerical resolution, see MESA VI
 
-     ! To get the star to cc.
-     op_split_burn = .true.
-     op_split_burn_min_T = 4.2d9
-     op_split_burn_eps = 1d-5 !1d-7
-     op_split_burn_odescal = 1d-5 !1d-8
 
      ! high center T limit to avoid negative mass fractions
      sig_min_factor_for_high_Tcenter = 0.01
@@ -145,13 +142,17 @@ max_model_number = 6000
 ! solver controls
       ! Can't handle large residuals at this low of numerical resolution, so we need help.
       use_gold_tolerances = .true.
-      use_gold2_tolerances = .true.
+      use_gold2_tolerances = .false.
       convergence_ignore_equL_residuals = .true.
       make_gradr_sticky_in_solver_iters = .true. ! impossible without this.
       mlt_make_surface_no_mixing = .true.
       energy_eqn_option = 'dedt'
       include_composition_in_eps_grav = .true.
       !min_dq_for_xa = 1d-4    ! avoid over-resolving composition changes
+      gold_tol_residual_norm3 = 1d-5
+      gold_tol_max_residual3 = 1d-3
+      ignore_species_in_max_correction                = .false.
+      fix_d_eos_dxa_partials                          = .false.
 
 
 ! mesh resolution section

--- a/star/test_suite/make_pre_ccsn_13bvn/inlist_to_cc
+++ b/star/test_suite/make_pre_ccsn_13bvn/inlist_to_cc
@@ -17,9 +17,6 @@
 
 &controls
 
-! reduce op_split_burn_min_T to help with test_suite speed.
-     !op_split_burn_min_T = 1d9 ! results in photo check sum issues if toggled now.
-
 ! 300 km/s core infall stopping condition
      fe_core_infall_limit = 3d7
      non_fe_core_infall_limit = 1d99!3d7
@@ -28,23 +25,12 @@
       when_to_stop_atol = 1d-3
 
 
-! adjust overshoot, to prevent He shell convection from propagating inward in test case.
+! adjust overshoot, to prevent He shell convection from mergers.
      overshoot_scheme(1) = 'none'
-     overshoot_zone_type(1) = 'burn_He'
-     overshoot_zone_loc(1) = 'shell'
-     overshoot_bdy_loc(1) = 'bottom'
-
-
-     overshoot_scheme(2) = 'exponential'
-     overshoot_zone_type(2) = 'any'
-     overshoot_zone_loc(2) = 'any'
-     overshoot_bdy_loc(2) = 'any'
-     overshoot_f(2) = 0.01
-     overshoot_f0(2) = 0.004
-
-     min_overshoot_q = 0d0
+     overshoot_scheme(2) = 'none'
 
 ! prevent development of radial pulses during advanced burning
+      use_drag_energy = .false.
       drag_coefficient = 1d0
       min_q_for_drag = 0.8d0
 

--- a/star/test_suite/make_pre_ccsn_13bvn/inlist_to_post_si_burn
+++ b/star/test_suite/make_pre_ccsn_13bvn/inlist_to_post_si_burn
@@ -27,22 +27,11 @@
 
 ! adjust overshoot, to prevent He shell convection from propagating inward in test case.
      overshoot_scheme(1) = 'none'
-     overshoot_zone_type(1) = 'burn_He'
-     overshoot_zone_loc(1) = 'shell'
-     overshoot_bdy_loc(1) = 'bottom'
-
-
-     overshoot_scheme(2) = 'exponential'
-     overshoot_zone_type(2) = 'any'
-     overshoot_zone_loc(2) = 'any'
-     overshoot_bdy_loc(2) = 'any'
-     overshoot_f(2) = 0.01
-     overshoot_f0(2) = 0.004
-
-     min_overshoot_q = 0d0
+     overshoot_scheme(2) = 'none'
 
 
 ! prevent development of radial pulses during advanced burning
+      use_drag_energy = .false.
       drag_coefficient = 1d0
       min_q_for_drag = 0.8d0
 

--- a/star/test_suite/make_pre_ccsn_13bvn/standard_after_si_burn.mod
+++ b/star/test_suite/make_pre_ccsn_13bvn/standard_after_si_burn.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96e5c97b1277ec0fec955b0af21ac26d96278a55ba441a4c462cd9122cfafd1d
-size 941828
+oid sha256:05830b43577e70ed09bc67746d9d30a8116af98af5380ad477dcfe5c60eba240
+size 1031093

--- a/star/test_suite/make_pre_ccsn_13bvn/standard_near_zams.mod
+++ b/star/test_suite/make_pre_ccsn_13bvn/standard_near_zams.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6452a46d109dc3f43f98e739a8c4f83a64e2b92e82fe5d482e5ecd6bc430b2f0
-size 182578
+oid sha256:8a3b818d86ea0964db5c7805a2eab709a283dc03c58755b7fb782d4d2f492c06
+size 182573

--- a/star/test_suite/make_pre_ccsn_13bvn/standard_ready.mod
+++ b/star/test_suite/make_pre_ccsn_13bvn/standard_ready.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be5d7b8802fd5770c3617dcdd8af84d2b0ebb5477fc3299811daf9dc98a02e58
-size 340181
+oid sha256:4a611b789799cfc77df751ea6d19d68c4bee81c83d23633b7d522c2f384589de
+size 323933

--- a/star/test_suite/make_pre_ccsn_13bvn/standard_ready_to_remove.mod
+++ b/star/test_suite/make_pre_ccsn_13bvn/standard_ready_to_remove.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4aa0b5a0b5854d80f6f7c8fbf6cee8d3e5fe8c20d16d8222ade6a97a8b0c01d
-size 464418
+oid sha256:d934f68f9ccb80cd235ffecf057417b4c4ae1765ce47edb0aeb5fcc68b6320e3
+size 441585

--- a/star/test_suite/make_pre_ccsn_13bvn/standard_removed.mod
+++ b/star/test_suite/make_pre_ccsn_13bvn/standard_removed.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25a58d9c96acfe1818142e18611f7acc982a1e7fe09d09d34f90169385345437
-size 392422
+oid sha256:b7fd54782c295e5eeccba3f69f589a7bbc1824f780c8499d29c1cc5d84bff273
+size 367394


### PR DESCRIPTION
Updating the 13BVN model. Now letting it evolve implicitly and I turned off overshoot during late burning.