### PR TITLE
fix_uninitialized RSP L on photo restart, bug found by Mami Dekka

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -44,6 +44,10 @@ The `MESA SDK <http://user.astro.wisc.edu/~townsend/static.php?ref=mesasdk>`__ r
 Bug Fixes
 ---------
 
+Fixed a bug where RSP photo restarts did not immediately reconstruct ``s% L``,
+which could leave ``s% L(1)`` with an uninitialized near-zero value and crash
+MESA when the KH timescale was recalculated on restart.
+
 Fixed a small bug where diffusive overshooting (overmixing) routines did not
 respect changes to the mixing length set by ``other_alpha_mlt``, and used the
 ``mixing_length_alpha`` instead. See `gh-1003 <https://github.com/MESAHub/mesa/pull/1003>`_.

--- a/star/private/rsp_def.f90
+++ b/star/private/rsp_def.f90
@@ -398,7 +398,7 @@
          type (star_info), pointer :: s
          integer, intent(in) :: iounit
          integer, intent(out) :: ierr
-         integer :: n
+         integer :: n, k
          include 'formats'
          call init_def(s)
          ierr = 0
@@ -430,6 +430,13 @@
             PPP0(1:n), PPQ0(1:n), PPT0(1:n), PPC0(1:n), VV0(1:n), &
             WORK(1:n), WORKQ(1:n), WORKT(1:n), WORKC(1:n)
          if (ierr /= 0) call mesa_error(__FILE__,__LINE__,'read failed in rsp_photo_in')
+         do k = 1, NZN
+            s% L(k) = 4d0*pi*pow2(photo_r(k))*s% Fr(k) + s% Lc(k) + s% Lt(k)
+            if (is_bad(s% L(k))) then
+               write(*,2) 'bad RSP photo L', k, s% L(k), s% Fr(k), s% Lc(k), s% Lt(k)
+               call mesa_error(__FILE__,__LINE__,'rsp_photo_in')
+            end if
+         end do
          if (writing_map) then
             write(*,*) 'sorry, cannot use photo to resume writing map data file'
             writing_map = .false.


### PR DESCRIPTION
@mami-deka discovered an issue in RSP's photo restart where on one of her clusters, L was being set to a small positive number, since it was uninitialized, and this lead to the call to calculate the KH_timescale (which asks for it asks for s% L(1), and divides by it) to produce a large infinite number from overflow, ultimately crashing her mesa run. 

from @mami-deka:

> I am using MESA `r23.05.1` for RSP and recently set up on a new cluster called Newton. Fresh runs work correctly on the Newton: `./rn` produces physically sensible output and writes photos. However, restarting from an existing photo with `./re` fails immediately.
> 
> On the old cluster, the restart behaves normally. After `read restart_photo`, it prints the expected RSP restart block:
> 
> net name [o18_and_ne22.net]
> RSP_flag T
> v_flag T
> tau_factor 
> kap_option 
> OMP_NUM_THREADS 
> 
> On Newton, the same restart instead prints only:
> 
> read restart_photo
> s% kh_timescale                  Infinity
> s% cgrav(1)    6.6743000000000004D-08
> mstar           ...
> radius          ...
> luminosity      ~6.9D-310


She also discovered the solution to this issue, which was to recalculate L upon restart.