### PR TITLE
avoid repeated sums in mesh plan

### DIFF
--- a/star/private/mesh_plan.f90
+++ b/star/private/mesh_plan.f90
@@ -79,7 +79,7 @@
          integer :: j, k, k_old, k_new, nz, new_capacity, iounit, species, &
             max_k_old_for_split, min_k_old_for_split
          real(dp) :: D_mix_cutoff, next_xq, next_dq, max_dq_cntr, &
-            dq_sum, min_dq, min_dq_for_xa, min_dq_for_logT
+            min_dq, min_dq_for_xa, min_dq_for_logT
 
          logical, parameter :: write_plan_debug = .false.
 
@@ -604,7 +604,7 @@
 
             logical :: dbg, force_merge_with_one_more, du_div_cs_limit_flag
             real(dp) :: maxval_delta_xa, next_dq_max, beta_limit, &
-               remaining_dq_old, min_dr, abs_du_div_cs
+               remaining_dq_old, min_dr, abs_du_div_cs, xq_sum
             integer :: kk, k_old_init, k_old_next, k_old_next_max, j00, jm1, i, max_merge
 
             include 'formats'
@@ -615,6 +615,7 @@
             k_old = 1
             k_new = 1
             xq_new(1) = 0
+            xq_sum = 0d0
             min_dr = s% mesh_min_dr_div_dRstar*(s% r(1) - s% R_center)
             abs_du_div_cs = 0d0
 
@@ -911,7 +912,7 @@
                   return
                end if
 
-               dq_sum = sum(dq_new(1:k_new))
+               xq_sum = xq_sum + dq_new(k_new)
 
                k_new = k_new + 1
                if (max_allowed_nz > 0 .and. k_new > max_allowed_nz) then
@@ -921,17 +922,17 @@
                end if
 
                xq_new(k_new) = next_xq
-               if (abs(xq_new(k_new) - dq_sum) > 1d-6) then
+               if (abs(xq_new(k_new) - xq_sum) > 1d-6) then
                   write(*,'(A)')
                   write(*,*) 'k_new', k_new
-                  write(*,1) 'xq_new(k_new) - dq_sum', xq_new(k_new) - dq_sum
+                  write(*,1) 'xq_new(k_new) - xq_sum', xq_new(k_new) - xq_sum
                   write(*,1) 'xq_new(k_new)', xq_new(k_new)
-                  write(*,1) 'dq_sum', dq_sum
-                  write(*,*) 'pick_new_points: abs(xq_new(k_new) - dq_sum) > 1d-6'
+                  write(*,1) 'xq_sum', xq_sum
+                  write(*,*) 'pick_new_points: abs(xq_new(k_new) - xq_sum) > 1d-6'
                   ierr = -1
                   return
                end if
-               !write(*,2) 'xq_new(k_new) - dq_sum', k_new, xq_new(k_new) - dq_sum
+               !write(*,2) 'xq_new(k_new) - xq_sum', k_new, xq_new(k_new) - xq_sum
 
                ! increment k_old if necessary
                do while (k_old < nz_old)


### PR DESCRIPTION
Currently, MESA does a sum from 0-> k_new in dq on every iteration of the mesh plan do loop using the fortran instrinsic `sum()` function:

```
do  ! pick next point location
    ...
   dq_sum = sum(dq_new(1:k_new))
   
   k_new = k_new + 1
   ...
end do
```

This branch alters the dq sum inside mesh plan to one that is cumulative, hence changing the speed of this algorithm for the sum from O(n^2) to O(n) in time.

```
do  ! pick next point location
    ...
   xq_sum = xq_sum + dq_new(k_new)
   
   k_new = k_new + 1
   ...
end do
```

I did some timing tests below, where i specifically look at the time spent inside the mesh routines, as opposed to the global time the runs took. Generally i noticed a ~ 1% or less increase in total performance, but I can imagine anytime the mesh is changes a lot, this minor improvement will reduce the time spent remeshing. 

> Star/work mesh timing summary
> 
> Measured routine timing:
> MESA internal timer: remesh
> 
> This timing is for the whole remesh/do_mesh path, not just do_mesh_plan,
> but it is useful enough for this benchmark.
> 
> Test 1: default star/work to central H depletion
> controls:
>   pgstar off
>   stop at central h1 < 1d-3
>   OMP_NUM_THREADS = 4
> 
> single warm run:
>   baseline remesh time:   0.544 s
>   optimized remesh time:  0.475 s
>   difference:             0.069 s faster
>   relative change:        12.7% less remesh time
> 
> Test 2: 5 Msun to central He depletion
> controls:
>   pgstar off
>   initial_mass = 5
>   mesh_delta_coeff = 0.4
>   time_delta_coeff = 0.5
>   stop at central he4 < 1d-3
>   OMP_NUM_THREADS = 4
> 
> run 1, fresh install that generates caches:
>   baseline remesh time:   11.048 s
>   optimized remesh time:   6.901 s
>   difference:              4.147 s faster
>   relative change:         37.5% less remesh time
> 
> run 2, warm:
>   baseline remesh time:   11.017 s
>   optimized remesh time:   6.886 s
>   difference:              4.131 s faster
>   relative change:         37.5% less remesh time 

I don't believe this change needs a changelog entry.