### PR TITLE
Fix accurate AD summation in residual equations

### DIFF
--- a/star/private/hydro_energy.f90
+++ b/star/private/hydro_energy.f90
@@ -100,15 +100,29 @@
             ! eps_WD_sedimentation, eps_diffusion, eps_pre_mix, eps_phase_separation
          ! sum terms in esum_ad using accurate_auto_diff_real_star_order1
          if (eps_grav_form) then  ! for this case, dwork_dm doesn't include work by P since that is in eps_grav
-            esum_ad = - dL_dm_ad + sources_ad + &
-               others_ad - d_turbulent_energy_dt_ad - dwork_dm_ad + eps_grav_ad
+            esum_ad = -dL_dm_ad
+            esum_ad = esum_ad + sources_ad
+            esum_ad = esum_ad + others_ad
+            esum_ad = esum_ad - d_turbulent_energy_dt_ad
+            esum_ad = esum_ad - dwork_dm_ad
+            esum_ad = esum_ad + eps_grav_ad
          else if (s% using_velocity_time_centering .and. &
                 s% use_P_d_1_div_rho_form_of_work_when_time_centering_velocity) then
-            esum_ad = - dL_dm_ad + sources_ad + &
-               others_ad - d_turbulent_energy_dt_ad - dwork_dm_ad - de_dt_ad
+            esum_ad = -dL_dm_ad
+            esum_ad = esum_ad + sources_ad
+            esum_ad = esum_ad + others_ad
+            esum_ad = esum_ad - d_turbulent_energy_dt_ad
+            esum_ad = esum_ad - dwork_dm_ad
+            esum_ad = esum_ad - de_dt_ad
          else
-            esum_ad = - dL_dm_ad + sources_ad + &
-               others_ad - d_turbulent_energy_dt_ad - dwork_dm_ad - dke_dt_ad - dpe_dt_ad - de_dt_ad
+            esum_ad = -dL_dm_ad
+            esum_ad = esum_ad + sources_ad
+            esum_ad = esum_ad + others_ad
+            esum_ad = esum_ad - d_turbulent_energy_dt_ad
+            esum_ad = esum_ad - dwork_dm_ad
+            esum_ad = esum_ad - dke_dt_ad
+            esum_ad = esum_ad - dpe_dt_ad
+            esum_ad = esum_ad - de_dt_ad
          end if
          resid_ad = esum_ad  ! convert back to auto_diff_real_star_order1
          s% ergs_error(k) = -dm*dt*resid_ad%val  ! save ergs_error before scaling
@@ -222,6 +236,7 @@
             type(auto_diff_real_star_order1) :: &
                eps_nuc_ad, non_nuc_neu_ad, extra_heat_ad, Eq_ad, RTI_diffusion_ad, &
                v_00, v_p1, drag_force, drag_energy
+            type(accurate_auto_diff_real_star_order1) :: sources_sum_ad
             include 'formats'
             ierr = 0
 
@@ -301,7 +316,13 @@
                end if
             end if
 
-            sources_ad = eps_nuc_ad - non_nuc_neu_ad + extra_heat_ad + Eq_ad + RTI_diffusion_ad + drag_energy
+            sources_sum_ad = eps_nuc_ad
+            sources_sum_ad = sources_sum_ad - non_nuc_neu_ad
+            sources_sum_ad = sources_sum_ad + extra_heat_ad
+            sources_sum_ad = sources_sum_ad + Eq_ad
+            sources_sum_ad = sources_sum_ad + RTI_diffusion_ad
+            sources_sum_ad = sources_sum_ad + drag_energy
+            sources_ad = sources_sum_ad
 
             sources_ad%val = sources_ad%val + s% irradiation_heat(k)
 
@@ -560,7 +581,6 @@
 
       subroutine eval_dwork(s, k, skip_P, dwork_ad, dwork, &
             d_dwork_dxam1, d_dwork_dxa00, d_dwork_dxap1, ierr)
-         use accurate_sum_auto_diff_star_order1
          use auto_diff_support
          use star_utils, only: calc_Ptot_ad_tw
          type (star_info), pointer :: s
@@ -630,6 +650,7 @@
             P_face_ad, A_times_v_face_ad, mlt_Pturb_ad, &
             PtrbR_ad, PtrbL_ad, PvscL_ad, PvscR_ad, Ptrb_div_etrb, PL_ad, PR_ad, &
             Peos_ad, Ptrb_ad, Pvsc_ad, extra_P
+         type(accurate_auto_diff_real_star_order1) :: P_face_sum_ad
          logical :: test_partials
          integer :: j
          include 'formats'
@@ -759,7 +780,12 @@
             if (s% mlt_Pturb_factor > 0d0 .and. s% mlt_vc_old(k) > 0d0) &
                mlt_Pturb_ad = s% mlt_Pturb_factor*pow2(s% mlt_vc_old(k))*get_rho_face(s,k)/3d0
 
-            P_face_ad = Peos_ad + Pvsc_ad + Ptrb_ad + mlt_Pturb_ad + extra_P
+            P_face_sum_ad = Peos_ad
+            P_face_sum_ad = P_face_sum_ad + Pvsc_ad
+            P_face_sum_ad = P_face_sum_ad + Ptrb_ad
+            P_face_sum_ad = P_face_sum_ad + mlt_Pturb_ad
+            P_face_sum_ad = P_face_sum_ad + extra_P
+            P_face_ad = P_face_sum_ad
 
          end if
 
@@ -823,7 +849,6 @@
 
       subroutine eval_simple_PdV_work( &
             s, k, skip_P, dwork_ad, dwork, d_dwork_dxa00, ierr)
-         use accurate_sum_auto_diff_star_order1
          use auto_diff_support
          use star_utils, only: calc_Ptot_ad_tw
          type (star_info), pointer :: s

--- a/star/private/hydro_momentum.f90
+++ b/star/private/hydro_momentum.f90
@@ -138,8 +138,11 @@
          RTI_terms_dm_div_A_ad = RTI_terms_ad*dm_div_A_ad
 
          ! sum terms in residual_sum_ad using accurate_auto_diff_real_star_order1
-         residual_sum_ad = &
-            other_dm_div_A_ad + grav_dm_div_A_ad - dPtot_ad - d_mlt_Pturb_ad + RTI_terms_dm_div_A_ad
+         residual_sum_ad = other_dm_div_A_ad
+         residual_sum_ad = residual_sum_ad + grav_dm_div_A_ad
+         residual_sum_ad = residual_sum_ad - dPtot_ad
+         residual_sum_ad = residual_sum_ad - d_mlt_Pturb_ad
+         residual_sum_ad = residual_sum_ad + RTI_terms_dm_div_A_ad
 
          resid1_ad = residual_sum_ad  ! convert back to auto_diff_real_star_order1
          resid_ad = resid1_ad*iPtotavg_ad  ! scaling
@@ -382,6 +385,7 @@
          integer, intent(out) :: ierr
          type(auto_diff_real_star_order1) :: extra_ad, v_00, &
             drag
+         type(accurate_auto_diff_real_star_order1) :: other_sum_ad
          real(dp) :: accel, d_accel_dv
          logical :: test_partials, local_v_flag
 
@@ -437,7 +441,11 @@
 
          end if  ! v_flag
 
-         other_ad = extra_ad - accel_ad + drag + Uq_ad
+         other_sum_ad = extra_ad
+         other_sum_ad = other_sum_ad - accel_ad
+         other_sum_ad = other_sum_ad + drag
+         other_sum_ad = other_sum_ad + Uq_ad
+         other_ad = other_sum_ad
          other = other_ad%val
 
          !test_partials = (k == s% solver_test_partials_k)
@@ -458,7 +466,6 @@
             dPtot_ad, dPtot, d_dPtot_dxam1, d_dPtot_dxa00, &
             iPtotavg_ad, iPtotavg, d_iPtotavg_dxam1, d_iPtotavg_dxa00, ierr)
          use star_utils, only: calc_Ptot_ad_tw
-         use accurate_sum_auto_diff_star_order1
          use auto_diff_support
          type (star_info), pointer :: s
          integer, intent(in) :: k

--- a/star/private/hydro_riemann.f90
+++ b/star/private/hydro_riemann.f90
@@ -131,8 +131,12 @@
             if (ierr /= 0) return
          end if
 
-         sum_ad = flux_in_ad - flux_out_ad + &
-            geometry_source_ad + gravity_source_ad + diffusion_source_ad + Uq_cell
+         sum_ad = flux_in_ad
+         sum_ad = sum_ad - flux_out_ad
+         sum_ad = sum_ad + geometry_source_ad
+         sum_ad = sum_ad + gravity_source_ad
+         sum_ad = sum_ad + diffusion_source_ad
+         sum_ad = sum_ad + Uq_cell
          dudt_expected_ad = sum_ad
          dudt_expected_ad = dudt_expected_ad/dm
 

--- a/star/private/hydro_rsp2.f90
+++ b/star/private/hydro_rsp2.f90
@@ -118,6 +118,7 @@
          integer, intent(out) :: ierr
          type(auto_diff_real_star_order1) ::  &
             L_expected, L_actual,resid
+         type(accurate_auto_diff_real_star_order1) :: L_sum
          real(dp) :: scale, residual, L_start_max
          logical :: test_partials
          include 'formats'
@@ -132,7 +133,10 @@
          ierr = 0
          !L_expected = compute_L_face(s, k, ierr)
          !if (ierr /= 0) return
-         L_expected = s% Lr_ad(k) + s% Lc_ad(k) + s% Lt_ad(k)
+         L_sum = s% Lr_ad(k)
+         L_sum = L_sum + s% Lc_ad(k)
+         L_sum = L_sum + s% Lt_ad(k)
+         L_expected = L_sum
          L_actual = wrap_L_00(s, k)
          L_start_max = maxval(s% L_start(1:s% nz))
          scale = 1d0/L_start_max
@@ -317,7 +321,11 @@
             call setup_dt_Eq_ad(ierr); if (ierr /= 0) return  ! erg g^-1
             call set_energy_eqn_scal(s, k, scal, ierr); if (ierr /= 0) return  ! 1/(erg g^-1 s^-1)
             ! sum terms in esum_ad using accurate_auto_diff_real_star_order1
-            esum_ad = d_turbulent_energy_ad + Ptrb_dV_ad + dt_dLt_dm_ad - dt_C_ad - dt_Eq_ad  ! erg g^-1
+            esum_ad = d_turbulent_energy_ad
+            esum_ad = esum_ad + Ptrb_dV_ad
+            esum_ad = esum_ad + dt_dLt_dm_ad
+            esum_ad = esum_ad - dt_C_ad
+            esum_ad = esum_ad - dt_Eq_ad  ! erg g^-1
             resid_ad = esum_ad
 
             if (k==-35 .and. s% solver_iter == 1) then
@@ -971,6 +979,7 @@
          type (star_info), pointer, intent(in) :: s
          integer, intent(in) :: k
          type(auto_diff_real_star_order1), intent(out) :: L, Lr, Lc, Lt
+         type(accurate_auto_diff_real_star_order1) :: L_sum
          integer, intent(out) :: ierr
          include 'formats'
          ierr = 0
@@ -993,7 +1002,10 @@
             Lt = compute_Lt(s, k, ierr)
             if (ierr /= 0) return
          end if
-         L = Lr + Lc + Lt
+         L_sum = Lr
+         L_sum = L_sum + Lc
+         L_sum = L_sum + Lt
+         L = L_sum
          s% Lr_ad(k) = Lr
          s% Lc_ad(k) = Lc
          s% Lt_ad(k) = Lt

--- a/star/private/hydro_rsp2_support.f90
+++ b/star/private/hydro_rsp2_support.f90
@@ -24,7 +24,6 @@
       use utils_lib, only: is_bad
       use auto_diff
       use auto_diff_support
-      use accurate_sum_auto_diff_star_order1
       use star_utils
 
       implicit none

--- a/star/private/tdc_hydro.f90
+++ b/star/private/tdc_hydro.f90
@@ -24,7 +24,6 @@ module tdc_hydro
    use utils_lib, only: is_bad
    use auto_diff
    use auto_diff_support
-   use accurate_sum_auto_diff_star_order1
    use star_utils
 
    implicit none

--- a/star/private/tdc_hydro_support.f90
+++ b/star/private/tdc_hydro_support.f90
@@ -24,7 +24,6 @@ module tdc_hydro_support
    use utils_lib, only: is_bad
    use auto_diff
    use auto_diff_support
-   use accurate_sum_auto_diff_star_order1
    use star_utils
 
    implicit none

--- a/star/test_suite/make_o_ne_wd/inlist_c_burn
+++ b/star/test_suite/make_o_ne_wd/inlist_c_burn
@@ -15,6 +15,7 @@
 
 
 &eos
+mass_fraction_limit_for_skye = 1d-16
 / ! end of eos namelist
 
 &kap
@@ -78,12 +79,6 @@
 ! mesh
 
 ! solver
-      op_split_burn = .true.
-      op_split_burn_min_T = 3d8
-
-      op_split_burn_eps = 1d-7
-      op_split_burn_odescal = 1d-8
-
       convergence_ignore_equL_residuals = .false.
       make_gradr_sticky_in_solver_iters = .false.
 

--- a/star/test_suite/make_o_ne_wd/inlist_o_ne_wd
+++ b/star/test_suite/make_o_ne_wd/inlist_o_ne_wd
@@ -15,6 +15,7 @@
 
 
 &eos
+mass_fraction_limit_for_skye = 1d-16
 / ! end of eos namelist
 
 &kap
@@ -83,12 +84,6 @@
 ! mesh
 
 ! solver
-      op_split_burn = .true.
-      op_split_burn_min_T = 3d8
-
-      op_split_burn_eps = 1d-7
-      op_split_burn_odescal = 1d-8
-
       convergence_ignore_equL_residuals = .true.
       make_gradr_sticky_in_solver_iters = .true.
 

--- a/star/test_suite/make_o_ne_wd/inlist_settle_envelope
+++ b/star/test_suite/make_o_ne_wd/inlist_settle_envelope
@@ -15,6 +15,7 @@
 
 
 &eos
+mass_fraction_limit_for_skye = 1d-16
 / ! end of eos namelist
 
 &kap
@@ -69,13 +70,7 @@
      delta_XSi_cntr_hard_limit = -1
 
 ! mesh
-
 ! solver
-      op_split_burn = .true.
-      op_split_burn_min_T = 3d8
-
-      op_split_burn_eps = 1d-7
-      op_split_burn_odescal = 1d-8
 
       convergence_ignore_equL_residuals = .true.
       make_gradr_sticky_in_solver_iters = .true.

--- a/star/test_suite/make_o_ne_wd/standard_agb.mod
+++ b/star/test_suite/make_o_ne_wd/standard_agb.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13e4d1ded520aa3f9c6a6f974e06228f16a1424440cb1190f0b6238056f06f9f
-size 633331
+oid sha256:eef779478fc1a459ff41280ebc2e852f0b975308bb120ab8a3e955c178f3e7a1
+size 633333

--- a/star/test_suite/make_o_ne_wd/standard_c_burn.mod
+++ b/star/test_suite/make_o_ne_wd/standard_c_burn.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8b6f7240a78d6fa9a4276b527064166d8747d1617713f31e7cfef1d5a73c8a4
-size 746920
+oid sha256:10569b28524d2447df9e3269cee3bc5d551d6591610655dfa2bc5262eef4abd0
+size 708458

--- a/star/test_suite/make_o_ne_wd/standard_zams.mod
+++ b/star/test_suite/make_o_ne_wd/standard_zams.mod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:480fa0535114b1600a9edd6b9b586cefff112d154ddbc95ea5ef64c88b572692
-size 369492
+oid sha256:ac53bbb5cf381bab5613166e1db03400938bc1ff4e49e853f7e620c15fd2fadf
+size 365287

--- a/star/test_suite/make_pre_ccsn_13bvn/inlist_to_cc
+++ b/star/test_suite/make_pre_ccsn_13bvn/inlist_to_cc
@@ -10,7 +10,8 @@
       change_initial_net = .true.
       new_net_name = 'approx21_cr60_plus_co56.net'
 
-
+      set_initial_dt = .true.
+      years_for_initial_dt = 1d-5
 
 / ! end of star_job namelist
 
@@ -65,7 +66,7 @@
       photo_interval = 50
       !profile_interval = 1
       !history_interval = 1
-      terminal_interval = 10
+      terminal_interval = 1
 
       x_integer_ctrl(1) = 6 ! inlist_part
 


### PR DESCRIPTION
I believe the accurate AD summation types in mesa's residual equations were just being assigned the result of a normal AD expression sum, so the (dp) cancellation had already happened before the compensated summation logic even runs. So the accurate AD summation was not really being leveraged at all. I would call this an inconsequential bug, but fixing it could yield benefits.

This pr fixes the accurate AD sums to accumulate term-by-term through the accurate type, so each add/subtract actually uses the compensation algorithm. I added this type to a couple other locations where it might make sense (summing sources in hydro energy and in RSP2 turbulent energy and luminosity equations), and I did some minor clean up. 

I'm not sure if this will help mesa convergence or not, it could in principle, but the point remains: this branch makes the intended behavior on main actually happen in practice. We will have to test and see if any thing changes in practice...