### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/actions/install-mesa/action.yml
+++ b/.github/actions/install-mesa/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: Restore LFS cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: lfs-cache
       with:
         path: .git/lfs

--- a/.github/actions/install-sdk-linux/action.yml
+++ b/.github/actions/install-sdk-linux/action.yml
@@ -18,7 +18,7 @@ runs:
         sudo apt-get clean
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       id: cache
       with:
         path: |

--- a/.github/actions/install-sdk-macos/action.yml
+++ b/.github/actions/install-sdk-macos/action.yml
@@ -16,7 +16,7 @@ runs:
         brew install gnu-sed bash
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       id: cache
       with:
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install MESA on ${{ runner.os }} with SDK ${{matrix.sdk}}
         uses: ./.github/actions/install-mesa

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name : Install lcov
         run: |
@@ -66,10 +66,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save the html folder as an artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './.htmlcov/'
 
       - name: Deploy to Github Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -31,7 +31,7 @@ jobs:
           sdk: "24.7.1"
 
       - name: Checkout mesa_test
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: MESAHub/mesa_test
           path: mesa_test  # Store in $GITHUB_WORKSPACE/mesa_test

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
While tinkering with re-using the action to install the SDK under Linux, I noticed we've been getting various warnings about deprecated versions of Node.js in actions (e.g. [this action run](https://github.com/MESAHub/mesa/actions/runs/30671411764)). I think the actual problematic action is `checkout@v4` but this PR goes ahead and updates all the actions to their latest major versions.

There might be reasons we don't want the latest versions, in which case I'm to roll back one or two.