### PR TITLE
Fix tidal deformation omega on restart and remesh

### DIFF
--- a/star/private/mesh_adjust.f90
+++ b/star/private/mesh_adjust.f90
@@ -231,7 +231,7 @@
 
          if (s% rotation_flag) then
             call adjust_omega(s, nz, nz_old, comes_from, &
-               xq_old, xq, dq_old, dq, xh, j_rot_old, &
+               xq_old, xq, dq_old, dq, xh, j_rot_old, omega_old, &
                xout_old, xout_new, dqbar_old, dqbar, ierr)
             if (failed('adjust_omega')) return
             if (s% D_omega_flag) then
@@ -1925,14 +1925,14 @@
 
 
       subroutine adjust_omega(s, nz, nz_old, comes_from, &
-            old_xq, new_xq, old_dq, new_dq, xh, old_j_rot, &
+            old_xq, new_xq, old_dq, new_dq, xh, old_j_rot, old_omega, &
             xout_old, xout_new, old_dqbar, new_dqbar, ierr)
          use alloc
          type (star_info), pointer :: s
          integer, intent(in) :: nz, nz_old
          integer, dimension(:) :: comes_from
          real(dp), dimension(:) :: &
-            old_xq, new_xq, old_dq, new_dq, old_j_rot, &
+            old_xq, new_xq, old_dq, new_dq, old_j_rot, old_omega, &
             xout_old, xout_new, old_dqbar, new_dqbar
          real(dp), intent(in) :: xh(:,:)
          integer, intent(out) :: ierr
@@ -1944,7 +1944,8 @@
          do k = 1, nz
             op_err = 0
             call adjust1_omega(s, k, nz, nz_old, comes_from, &
-               xout_old, xout_new, old_dqbar, new_dqbar, old_j_rot, xh, op_err)
+               xout_old, xout_new, old_dqbar, new_dqbar, &
+               old_j_rot, old_omega, xh, op_err)
             if (op_err /= 0) ierr = op_err
          end do
 !$OMP END PARALLEL DO
@@ -1953,18 +1954,20 @@
 
 
       subroutine adjust1_omega(s, k, nz, nz_old, comes_from, &
-            xout_old, xout_new, old_dqbar, new_dqbar, old_j_rot, xh, ierr)
+            xout_old, xout_new, old_dqbar, new_dqbar, &
+            old_j_rot, old_omega, xh, ierr)
          use hydro_rotation, only: w_div_w_roche_jrot, update1_i_rot_from_xh
          ! set new value for s% omega(k)
          type (star_info), pointer :: s
          integer, intent(in) :: k, nz, nz_old
          integer, dimension(:) :: comes_from
          real(dp), dimension(:), intent(in) :: &
-            xout_old, xout_new, old_dqbar, new_dqbar, old_j_rot
+            xout_old, xout_new, old_dqbar, new_dqbar, old_j_rot, old_omega
          real(dp), intent(in) :: xh(:,:)
          integer, intent(out) :: ierr
 
-         real(dp) :: xq_outer, xq_inner, j_tot, xq0, xq1, new_point_dqbar, dq_sum, dq, r00
+         real(dp) :: xq_outer, xq_inner, j_tot, omega_tot, &
+            xq0, xq1, new_point_dqbar, dq_sum, dq, r00
          integer :: kk, k_outer
 
          integer, parameter :: k_dbg = -1
@@ -1987,7 +1990,8 @@
          end if
 
          dq_sum = 0d0
-         j_tot = 0
+         j_tot = 0d0
+         omega_tot = 0d0
          if (xq_outer >= xout_old(nz_old)) then
             ! new contained entirely in old center zone
             k_outer = nz_old
@@ -2016,6 +2020,7 @@
                   dq = new_point_dqbar - dq_sum
                   dq_sum = new_point_dqbar
                   j_tot = j_tot + old_j_rot(kk-1)*dq
+                  omega_tot = omega_tot + old_omega(kk-1)*dq
                   end if
                exit
             end if
@@ -2037,12 +2042,14 @@
                end if
 
                j_tot = j_tot + old_j_rot(kk)*dq
+               omega_tot = omega_tot + old_omega(kk)*dq
 
             else if (xq0 <= xq_outer .and. xq1 >= xq_inner) then  ! entire new k is in old kk
 
                dq = new_dqbar(k)
                dq_sum = dq_sum + dq
                j_tot = j_tot + old_j_rot(kk)*dq
+               omega_tot = omega_tot + old_omega(kk)*dq
 
             else  ! only use the part of old kk that is in new k
 
@@ -2075,6 +2082,7 @@
                end if
 
                j_tot = j_tot + old_j_rot(kk)*dq
+               omega_tot = omega_tot + old_omega(kk)*dq
 
                if (dq <= 0) then
                   ierr = -1
@@ -2095,6 +2103,8 @@
          end do
 
          s% j_rot(k) = j_tot/dq_sum
+         ! set an omega seed before evaluating a rotation-dependent moment of inertia
+         s% omega(k) = omega_tot/dq_sum
          r00 = get_r_from_xh(s,k)
          s% w_div_w_crit_roche(k) = &
             w_div_w_roche_jrot(r00,s% m(k),s% j_rot(k),s% cgrav(k), &

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -105,16 +105,16 @@
             ! the angular momentum in order to initialize the model. This flag is here
             ! to account for the loading of old saved models.
             if (s% have_j_rot) then
-               !if (restart) then
+               if (restart) then
                   ! only need to compute irot, w_div_w_crit_roche is stored in photos
-               !   call set_i_rot_from_omega_and_j_rot(s)
-               !else
+                  call set_i_rot_from_omega_and_j_rot(s)
+               else
                   ! need to set w_div_w_crit_roche as well
-               call use_xh_to_update_i_rot(s)
-               do k=1, s% nz
-                  s% omega(k) = s% j_rot(k)/s% i_rot(k)% val
-               end do
-               !end if
+                  call use_xh_to_update_i_rot(s)
+                  do k=1, s% nz
+                     s% omega(k) = s% j_rot(k)/s% i_rot(k)% val
+                  end do
+               end if
             else
                ! need to recompute irot and jrot
                call use_xh_to_update_i_rot_and_j_rot(s)


### PR DESCRIPTION
I think the photo restart issue in https://github.com/MESAHub/mesa/pull/1007 comes from two related problems in models using tidal deformation.

With tidal deformation, the moment of inertia used by MESA is

```math
i_{\rm rot}(k)
=
f_{\rm tide}(k)\,i_{\rm rot,tidal}(k)
+
\left[1-f_{\rm tide}(k)\right]i_{\rm rot,single}(k).
```

Here, `f_tide` depends on how closely the shell is rotating at the synchronous angular velocity. By default,

```math
\begin{aligned}
\omega_{\rm sync} &= \frac{2\pi}{P_{\rm orb}}, \\[4pt]
f_{\rm sync} &=
\min\left(
\frac{|\omega|}{\omega_{\rm sync}},
\frac{\omega_{\rm sync}}{|\omega|}
\right), \\[4pt]
f_{\rm tide} &=
\frac{1}{
1+\exp\left[-w\left(f_{\rm sync}-f_0\right)\right]
}.
\end{aligned}
```

Here, `w` is `f_sync_switch_width` and `f_0` is `f_sync_switch_from_rot_defor`.

1. When restarting from a photo, `finish_load_model` is called before the binary tidal-deformation hooks are attached. The call to `use_xh_to_update_i_rot` therefore calculates only `i_rot,single`, rather than the blended `i_rot` given above. MESA then replaces the `omega` stored in the photo with

```math
\omega = \frac{j_{\rm rot}}{i_{\rm rot,single}}.
```

This changes the rotation state because the model before the restart used the blended tidal moment of inertia. The photo stores `omega`, `j_rot`, and `w_div_w_crit_roche`, but it does not store `i_rot` directly. On a photo restart, MESA now keeps the stored `omega` and `w_div_w_crit_roche` and recovers the effective moment of inertia from

```math
i_{\rm rot} = \frac{j_{\rm rot}}{\omega}.
```

This recovers the blended `i_rot` represented by the stored `j_rot` and `omega`, even though the tidal hooks have not yet been attached. Loading a `.mod` file keeps the existing behavior because saved models do not contain the complete state of the model.

2. During mesh adjustment, the tidal hooks are attached and MESA does calculate the blended `i_rot`. However, the old code reconstructed `j_rot` on the new mesh and evaluated `i_rot` before setting `omega` on that mesh. Since `f_tide` depends on `omega`, the tidal blend read an unset or leftover value of `omega`. This could produce different `i_rot` and `omega` values in uninterrupted and restarted runs.

MESA now reconstructs the old `omega` over the same cell overlaps used for `j_rot` and sets this temporary value before evaluating the tidal blend. It then calculates the final value from

```math
\omega = \frac{j_{\rm rot}}{i_{\rm rot}},
```

where `i_rot` is the blended tidal moment of inertia. Angular momentum remains the conserved quantity during remeshing. The reconstructed `omega` is used only to evaluate `f_tide` with a defined value.

Together, these changes preserve the blended tidal rotation state stored in a photo and prevent tidal remeshing from evaluating `i_rot` with an unset value of `omega`.