### PR TITLE
EOS data loading refactor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,6 @@
 data/star_data/zams_models/zams_z2m2_y28.data filter=lfs diff=lfs merge=lfs -text
 docs/source/assets/zams_z2m2_y28_patched.data filter=lfs diff=lfs merge=lfs -text
 neu/test/test_output filter=lfs diff=lfs merge=lfs -text
-
 # Try to get github to better understand what our filetypes are
 *.inc linguist-language=Fortran
 *inlist* linguist-language=Fortran
@@ -20,7 +19,6 @@ neu/test/test_output filter=lfs diff=lfs merge=lfs -text
 *.ph -linguist-detectable
 *.[1-9] -linguist-detectable
 *.in -linguist-detectable
-
 # Things to ignore from the release
 star/dev_cases_compare_pulses export-ignore
 star/dev_cases_star_to_RSP2 export-ignore
@@ -28,3 +26,4 @@ star/dev_cases_test_RSP2 export-ignore
 star/dev_cases_test_TDC export-ignore
 star/rsp2_utils export-ignore
 data/colors_data/colors_data.txz filter=lfs diff=lfs merge=lfs -text
+data/eosDT_data/helm-table.hdf5 filter=lfs diff=lfs merge=lfs -text

--- a/data/eosDT_data/helm-table.hdf5
+++ b/data/eosDT_data/helm-table.hdf5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45c188ee5470fae0c12967ddb42c2ced4305b0edb80d52ea876976968fa537e3
+size 230256916

--- a/eos/Makefile
+++ b/eos/Makefile
@@ -38,7 +38,7 @@ SRCS_CHECK = test/src/test_eos.f90 \
              test/src/test_eos_blend.f90 \
              test/src/test_eos_support.f90
 INTERNAL_DEPENDS_ON := const math utils chem num auto_diff interp_1d interp_2d forum
-EXTERNAL_DEPENDS_ON :=
+EXTERNAL_DEPENDS_ON := hdf5
 BINTYPE := lib
 INCLUDE_DIRS := -Iprivate -Ipublic -Idefaults
 

--- a/eos/Makefile
+++ b/eos/Makefile
@@ -37,7 +37,7 @@ SRCS_CHECK = test/src/test_eos.f90 \
              test/src/eos_support.f90 \
              test/src/test_eos_blend.f90 \
              test/src/test_eos_support.f90
-INTERNAL_DEPENDS_ON := const math utils chem num auto_diff interp_1d interp_2d
+INTERNAL_DEPENDS_ON := const math utils chem num auto_diff interp_1d interp_2d forum
 EXTERNAL_DEPENDS_ON :=
 BINTYPE := lib
 INCLUDE_DIRS := -Iprivate -Ipublic -Idefaults
@@ -65,9 +65,9 @@ install-cms:
 	fi
 
 install-dt:
-	if [ ! -r ../data/eosDT_data ]; then \
+	if [ ! -r ../data/eosDT_data/extract-completed ]; then \
 		tar -xJf eosDT_data.tar.xz -C ../data; \
-		xz --decompress --keep --stdout helm_table.dat.xz > ../data/eosDT_data/helm_table.dat; \
+                touch ../data/eosDT_data/extract-completed; \
 	fi
 
 install-pc:

--- a/eos/eosDT_builder/src/create_eos_files.f90
+++ b/eos/eosDT_builder/src/create_eos_files.f90
@@ -68,8 +68,6 @@ program create_eosDT_files
 
    if (whichz == 0) call Make_EoS_Files(whichz, 1d0, irad /= 0)
 
-   call free_helm_table(eos_ht)
-
 contains
 
    subroutine do_stop(str)

--- a/eos/eosDT_builder/src/helm_opal_scvh_driver.f90
+++ b/eos/eosDT_builder/src/helm_opal_scvh_driver.f90
@@ -23,7 +23,6 @@ module helm_opal_scvh_driver
    implicit none
 
    character(len=256) :: data_dir
-   integer, parameter :: imax = 261, jmax = 101  ! dimensions of our version of helm table
 
 contains
 
@@ -62,12 +61,6 @@ contains
       call eos_def_init
 
       ierr = 0
-      call alloc_helm_table(eos_ht, imax, jmax, ierr)
-      if (ierr /= 0) then
-         write (*, *) 'alloc helm table failed'
-         stop 1
-      end if
-
       call read_helm_table(eos_ht, data_dir, ierr) ! initialize helm
       if (ierr /= 0) then
          write (*, *) 'read helm table failed'

--- a/eos/eosDT_builder/src/helm_opal_scvh_driver.f90
+++ b/eos/eosDT_builder/src/helm_opal_scvh_driver.f90
@@ -68,7 +68,7 @@ contains
          stop 1
       end if
 
-      call read_helm_table(eos_ht, data_dir, cache_dir, temp_cache_dir, use_cache, ierr) ! initialize helm
+      call read_helm_table(eos_ht, data_dir, ierr) ! initialize helm
       if (ierr /= 0) then
          write (*, *) 'read helm table failed'
          stop 1

--- a/eos/helm_table.dat.xz
+++ b/eos/helm_table.dat.xz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:832063bc437a9c32ec118810e1998767124b3149bb1693a1c0282663ebdab4f9
-size 248931776

--- a/eos/private/eos_initialize.f90
+++ b/eos/private/eos_initialize.f90
@@ -58,9 +58,7 @@
             if(use_mesa_temp_cache) call mkdir(eosDT_temp_cache_dir)
          end if
 
-         call alloc_helm_table(eos_ht, imax, jmax, ierr)
-         if (ierr /= 0) return
-
+         call alloc_helm_table(eos_ht, imax, jmax)
          call read_helm_table(eos_ht, eosDT_data_dir, ierr)
          if (ierr /= 0) return
 

--- a/eos/private/eos_initialize.f90
+++ b/eos/private/eos_initialize.f90
@@ -33,12 +33,6 @@
          character(*), intent(IN) :: eosDT_cache_dir_in
          logical, intent(in) :: use_cache
          integer, intent(OUT) :: ierr  ! 0 means AOK.
-         !integer, parameter :: imax = 261, jmax = 101
-            ! dimensions of small version of helm table
-         !integer, parameter :: imax = 1081, jmax = 401
-            ! dimensions of medium version of helm table; 40 points per decade
-         integer, parameter :: imax = 2701, jmax = 1001
-            ! dimensions of large version of helm table; 100 points per decade
          ! helm table lives in eosDT_data
          character (len=256) :: eosDT_data_dir
          ierr = 0
@@ -58,7 +52,6 @@
             if(use_mesa_temp_cache) call mkdir(eosDT_temp_cache_dir)
          end if
 
-         call alloc_helm_table(eos_ht, imax, jmax)
          call read_helm_table(eos_ht, eosDT_data_dir, ierr)
          if (ierr /= 0) return
 

--- a/eos/private/eos_initialize.f90
+++ b/eos/private/eos_initialize.f90
@@ -61,8 +61,7 @@
          call alloc_helm_table(eos_ht, imax, jmax, ierr)
          if (ierr /= 0) return
 
-         call read_helm_table(eos_ht, &
-            eosDT_data_dir, eosDT_cache_dir, eosDT_temp_cache_dir, use_cache_for_eos, ierr)
+         call read_helm_table(eos_ht, eosDT_data_dir, ierr)
          if (ierr /= 0) return
 
          call eos_def_init

--- a/eos/private/helm_alloc.f90
+++ b/eos/private/helm_alloc.f90
@@ -26,84 +26,65 @@
 
       contains
 
-      subroutine alloc_helm_table(h, imax, jmax, ierr)
+      subroutine alloc_helm_table(h, imax, jmax)
          ! This routine allocates a Helm_Table and places pointer to it in h.
          ! It also allocates the arrays in the Helm_Table record.
 
          use eos_def
 
-         type (Helm_Table), pointer :: h
+         type (Helm_Table), allocatable, intent(out) :: h
          integer, intent(in) :: imax, jmax
-         integer, intent(out) :: ierr  ! 0 means AOK.
 
-         ierr = 0
+         allocate(h)
 
-         allocate(h,stat=ierr)
-         if (ierr /= 0) return
-
+         h% with_coulomb_corrections = .true.
          h% imax = imax
          h% jmax = jmax
-         h% with_coulomb_corrections = .true.
 
-         call alloc_1d_array(h% d, imax)
-         call alloc_1d_array(h% t, jmax)
+         allocate(h% d(imax))
+         allocate(h% t(jmax))
 
          !..for the helmholtz free energy tables
-         call alloc_2d_array(h% f, imax, jmax)
-         call alloc_2d_array(h% fd, imax, jmax)
-         call alloc_2d_array(h% ft, imax, jmax)
-         call alloc_2d_array(h% fdd, imax, jmax)
-         call alloc_2d_array(h% ftt, imax, jmax)
-         call alloc_2d_array(h% fdt, imax, jmax)
-         call alloc_2d_array(h% fddt, imax, jmax)
-         call alloc_2d_array(h% fdtt, imax, jmax)
-         call alloc_2d_array(h% fddtt, imax, jmax)
+         allocate(h% f(imax, jmax))
+         allocate(h% fd(imax, jmax))
+         allocate(h% ft(imax, jmax))
+         allocate(h% fdd(imax, jmax))
+         allocate(h% ftt(imax, jmax))
+         allocate(h% fdt(imax, jmax))
+         allocate(h% fddt(imax, jmax))
+         allocate(h% fdtt(imax, jmax))
+         allocate(h% fddtt(imax, jmax))
 
          !..for the pressure derivative with density tables
-         call alloc_2d_array(h% dpdf, imax, jmax)
-         call alloc_2d_array(h% dpdfd, imax, jmax)
-         call alloc_2d_array(h% dpdft, imax, jmax)
-         call alloc_2d_array(h% dpdfdt, imax, jmax)
+         allocate(h% dpdf(imax, jmax))
+         allocate(h% dpdfd(imax, jmax))
+         allocate(h% dpdft(imax, jmax))
+         allocate(h% dpdfdt(imax, jmax))
 
          !..for chemical potential tables
-         call alloc_2d_array(h% ef, imax, jmax)
-         call alloc_2d_array(h% efd, imax, jmax)
-         call alloc_2d_array(h% eft, imax, jmax)
-         call alloc_2d_array(h% efdt, imax, jmax)
+         allocate(h% ef(imax, jmax))
+         allocate(h% efd(imax, jmax))
+         allocate(h% eft(imax, jmax))
+         allocate(h% efdt(imax, jmax))
 
          !..for the number density tables
-         call alloc_2d_array(h% xf, imax, jmax)
-         call alloc_2d_array(h% xfd, imax, jmax)
-         call alloc_2d_array(h% xft, imax, jmax)
-         call alloc_2d_array(h% xfdt, imax, jmax)
+         allocate(h% xf(imax, jmax))
+         allocate(h% xfd(imax, jmax))
+         allocate(h% xft(imax, jmax))
+         allocate(h% xfdt(imax, jmax))
 
          !..for storing the differences
-         call alloc_1d_array(h% dt_sav, jmax)
-         call alloc_1d_array(h% dt2_sav, jmax)
-         call alloc_1d_array(h% dti_sav, jmax)
-         call alloc_1d_array(h% dt2i_sav, jmax)
-         call alloc_1d_array(h% dt3i_sav, jmax)
+         allocate(h% dt_sav(jmax - 1))
+         allocate(h% dt2_sav(jmax - 1))
+         allocate(h% dti_sav(jmax - 1))
+         allocate(h% dt2i_sav(jmax - 1))
+         allocate(h% dt3i_sav(jmax - 1))
 
-         call alloc_1d_array(h% dd_sav, imax)
-         call alloc_1d_array(h% dd2_sav, imax)
-         call alloc_1d_array(h% ddi_sav, imax)
-         call alloc_1d_array(h% dd2i_sav, imax)
-         call alloc_1d_array(h% dd3i_sav, imax)
-
-         contains
-
-         subroutine alloc_1d_array(ptr,sz)
-            real(dp), dimension(:), pointer :: ptr
-            integer, intent(in) :: sz
-            allocate(ptr(sz),stat=ierr)
-         end subroutine alloc_1d_array
-
-         subroutine alloc_2d_array(ptr,sz1,sz2)
-            real(dp), dimension(:,:), pointer :: ptr
-            integer, intent(in) :: sz1,sz2
-            allocate(ptr(sz1,sz2),stat=ierr)
-         end subroutine alloc_2d_array
-
+         allocate(h% dd_sav(imax - 1))
+         allocate(h% dd2_sav(imax - 1))
+         allocate(h% ddi_sav(imax - 1))
+         allocate(h% dd2i_sav(imax - 1))
+         allocate(h% dd3i_sav(imax - 1))
 
       end subroutine alloc_helm_table
 
@@ -114,7 +95,7 @@
       use utils_lib, only: mv, switch_str
 
 
-      type (Helm_Table), pointer :: h
+      type (Helm_Table), intent(inout) :: h
       character(*), intent(IN) :: data_dir
       integer, intent(out) :: ierr
 
@@ -196,71 +177,5 @@
        h% dd3i_sav(:) = h% dd2i_sav * h% ddi_sav
 
       end subroutine read_helm_table
-
-
-      subroutine free_helm_table(h)
-         use eos_def
-
-         type (Helm_Table), pointer :: h
-
-         call do_free(h% d)
-         call do_free(h% t)
-
-         call do_free2(h% f)
-         call do_free2(h% fd)
-         call do_free2(h% ft)
-         call do_free2(h% fdd)
-         call do_free2(h% ftt)
-         call do_free2(h% fdt)
-         call do_free2(h% fddt)
-         call do_free2(h% fdtt)
-         call do_free2(h% fddtt)
-
-         !..for the pressure derivative with density tables
-         call do_free2(h% dpdf)
-         call do_free2(h% dpdfd)
-         call do_free2(h% dpdft)
-         call do_free2(h% dpdfdt)
-
-         !..for chemical potential tables
-         call do_free2(h% ef)
-         call do_free2(h% efd)
-         call do_free2(h% eft)
-         call do_free2(h% efdt)
-
-         !..for the number density tables
-         call do_free2(h% xf)
-         call do_free2(h% xfd)
-         call do_free2(h% xft)
-         call do_free2(h% xfdt)
-
-         !..for storing the differences
-         call do_free(h% dt_sav)
-         call do_free(h% dt2_sav)
-         call do_free(h% dti_sav)
-         call do_free(h% dt2i_sav)
-         call do_free(h% dt3i_sav)
-         call do_free(h% dd_sav)
-         call do_free(h% dd2_sav)
-         call do_free(h% ddi_sav)
-         call do_free(h% dd2i_sav)
-         call do_free(h% dd3i_sav)
-
-         deallocate(h)
-         nullify(h)
-
-         contains
-
-         subroutine do_free(array_ptr)
-            real(dp), pointer :: array_ptr(:)
-            if (associated(array_ptr)) deallocate(array_ptr)
-         end subroutine do_free
-
-         subroutine do_free2(array_ptr)
-            real(dp), pointer :: array_ptr(:,:)
-            if (associated(array_ptr)) deallocate(array_ptr)
-         end subroutine do_free2
-
-      end subroutine free_helm_table
 
       end module helm_alloc

--- a/eos/private/helm_alloc.f90
+++ b/eos/private/helm_alloc.f90
@@ -89,31 +89,38 @@
       end subroutine alloc_helm_table
 
 
-      subroutine read_helm_table(h, data_dir, ierr)
-      use eos_def
-      use forum_m, only: hdf5io_t, OPEN_FILE_RO
-      use utils_lib, only: mv, switch_str
-
-
-      type (Helm_Table), intent(inout) :: h
-      character(*), intent(IN) :: data_dir
-      integer, intent(out) :: ierr
 
 !..this routine reads the helmholtz eos file, and
 !..must be called once before the helmeos routine is invoked.
+      subroutine read_helm_table(h, data_dir, ierr)
+      use eos_def
+      use forum_m, only: hdf5io_t, OPEN_FILE_RO
+      use hdf5, only: HSIZE_T
+      use utils_lib, only: mv, switch_str
 
-!..declare local variables
+      type (Helm_Table), allocatable, intent(out) :: h
+      character(*), intent(IN) :: data_dir
+      integer, intent(out) :: ierr
+
       character (len=256) :: filename
-      integer          :: i
+      integer :: i
+      integer(HSIZE_T), dimension(:), allocatable :: table_shape
       type(hdf5io_t) :: hi
 
        ierr = 0
 
-!..read the normal helmholtz free energy table
-       h% logtlo   = 3.0d0
-       h% logthi   = 13.0d0
-       h% logdlo   = -12.0d0
-       h% logdhi   = 15.0d0
+       write(filename,'(2a)') trim(data_dir), '/helm-table.hdf5'
+
+       hi = hdf5io_t(filename, OPEN_FILE_RO)
+
+       table_shape = hi% dset_shape("f")
+
+       call alloc_helm_table(h, int(table_shape(1)), int(table_shape(2)))
+
+       call hi% read_attr("logT_low", h% logtlo)
+       call hi% read_attr("logT_high", h% logthi)
+       call hi% read_attr("logRho_low", h% logdlo)
+       call hi% read_attr("logRho_high", h% logdhi)
 
        h% templo = exp10(h% logtlo)
        h% temphi = exp10(h% logthi)
@@ -124,10 +131,6 @@
        h% logtstpi = 1.0d0/h% logtstp
        h% logdstp  = (h% logdhi - h% logdlo)/real(h% imax-1,kind=dp)
        h% logdstpi = 1.0d0/h% logdstp
-
-       write(filename,'(2a)') trim(data_dir), '/helm-table.hdf5'
-
-       hi = hdf5io_t(filename, OPEN_FILE_RO)
 
        call hi% read_dset('f', h% f)
        call hi% read_dset('fd', h% fd)

--- a/eos/private/helm_alloc.f90
+++ b/eos/private/helm_alloc.f90
@@ -108,65 +108,25 @@
       end subroutine alloc_helm_table
 
 
-      subroutine setup_td_deltas(h, imax, jmax)
-         use eos_def
-         type (Helm_Table), pointer :: h
-         integer, intent(in) :: imax, jmax
-         integer :: i, j
-         real(dp) :: dth,dt2,dti,dt2i,dt3i,dd,dd2,ddi,dd2i,dd3i
-         !..construct the temperature and density deltas and their inverses
-         do j=1,jmax-1
-            dth         = h% t(j+1) - h% t(j)
-            dt2         = dth * dth
-            dti         = 1.0d0/dth
-            dt2i        = 1.0d0/dt2
-            dt3i        = dt2i*dti
-            h% dt_sav(j)   = dth
-            h% dt2_sav(j)  = dt2
-            h% dti_sav(j)  = dti
-            h% dt2i_sav(j) = dt2i
-            h% dt3i_sav(j) = dt3i
-         end do
-         do i=1,imax-1
-            dd          = h% d(i+1) - h% d(i)
-            dd2         = dd * dd
-            ddi         = 1.0d0/dd
-            dd2i        = 1.0d0/dd2
-            dd3i        = dd2i*ddi
-            h% dd_sav(i)   = dd
-            h% dd2_sav(i)  = dd2
-            h% ddi_sav(i)  = ddi
-            h% dd2i_sav(i) = dd2i
-            h% dd3i_sav(i) = dd3i
-         end do
-      end subroutine setup_td_deltas
-
-
-      subroutine read_helm_table(h, data_dir, cache_dir, temp_cache_dir, use_cache, ierr)
+      subroutine read_helm_table(h, data_dir, ierr)
       use eos_def
+      use forum_m, only: hdf5io_t, OPEN_FILE_RO
       use utils_lib, only: mv, switch_str
 
 
       type (Helm_Table), pointer :: h
-      character(*), intent(IN) :: data_dir, cache_dir, temp_cache_dir
-      logical, intent(IN) :: use_cache
+      character(*), intent(IN) :: data_dir
       integer, intent(out) :: ierr
 
 !..this routine reads the helmholtz eos file, and
 !..must be called once before the helmeos routine is invoked.
 
 !..declare local variables
-      character (len=256) :: filename, message, temp_filename
-      character (len=500) :: buf
-      character (len=26) :: s26
-      real(dp), target :: vec_ary(20)
-      real(dp), pointer :: vec(:)
-      integer          :: i,j,k,ios,imax,jmax,n
-      real(dp) :: tsav,dsav
-      logical, parameter :: dmp = .false.
+      character (len=256) :: filename
+      integer          :: i
+      type(hdf5io_t) :: hi
 
        ierr = 0
-       vec => vec_ary
 
 !..read the normal helmholtz free energy table
        h% logtlo   = 3.0d0
@@ -179,223 +139,61 @@
        h% denlo = exp10(h% logdlo)
        h% denhi = exp10(h% logdhi)
 
-       imax = h% imax
-       jmax = h% jmax
-       h% logtstp  = (h% logthi - h% logtlo)/real(jmax-1,kind=dp)
+       h% logtstp  = (h% logthi - h% logtlo)/real(h% jmax-1,kind=dp)
        h% logtstpi = 1.0d0/h% logtstp
-       h% logdstp  = (h% logdhi - h% logdlo)/real(imax-1,kind=dp)
+       h% logdstp  = (h% logdhi - h% logdlo)/real(h% imax-1,kind=dp)
        h% logdstpi = 1.0d0/h% logdstp
 
-       ios = -1
-       if (use_cache) then
-         write(filename,'(2a)') trim(cache_dir), '/helm_table.bin'
-         open(unit=19,file=trim(filename), &
-               action='read',status='old',iostat=ios,form='unformatted')
-       end if
+       write(filename,'(2a)') trim(data_dir), '/helm-table.hdf5'
 
-       if (ios == 0) then
+       hi = hdf5io_t(filename, OPEN_FILE_RO)
 
-          read(19) imax
-          read(19) jmax
+       call hi% read_dset('f', h% f)
+       call hi% read_dset('fd', h% fd)
+       call hi% read_dset('ft', h% ft)
+       call hi% read_dset('fdd', h% fdd)
+       call hi% read_dset('ftt', h% ftt)
+       call hi% read_dset('fdt', h% fdt)
+       call hi% read_dset('fddt', h% fddt)
+       call hi% read_dset('fdtt', h% fdtt)
+       call hi% read_dset('fddtt', h% fddtt)
 
-         if (imax /= h% imax .or. jmax /= h% jmax) then
-            ios = 1  ! wrong cached info
-         else
-             read(19) h% f(1:imax,1:jmax)
-             read(19) h% fd(1:imax,1:jmax)
-             read(19) h% ft(1:imax,1:jmax)
-             read(19) h% fdd(1:imax,1:jmax)
-             read(19) h% ftt(1:imax,1:jmax)
-             read(19) h% fdt(1:imax,1:jmax)
-             read(19) h% fddt(1:imax,1:jmax)
-             read(19) h% fdtt(1:imax,1:jmax)
-             read(19) h% fddtt(1:imax,1:jmax)
-             read(19) h% dpdf(1:imax,1:jmax)
-             read(19) h% dpdfd(1:imax,1:jmax)
-             read(19) h% dpdft(1:imax,1:jmax)
-             read(19) h% dpdfdt(1:imax,1:jmax)
-             read(19) h% ef(1:imax,1:jmax)
-             read(19) h% efd(1:imax,1:jmax)
-             read(19) h% eft(1:imax,1:jmax)
-             read(19) h% efdt(1:imax,1:jmax)
-             read(19) h% xf(1:imax,1:jmax)
-             read(19) h% xfd(1:imax,1:jmax)
-             read(19) h% xft(1:imax,1:jmax)
-             read(19) h% xfdt(1:imax,1:jmax)
+       call hi% read_dset('dpdf', h% dpdf)
+       call hi% read_dset('dpdfd', h% dpdfd)
+       call hi% read_dset('dpdft', h% dpdft)
+       call hi% read_dset('dpdfdt', h% dpdfdt)
 
-            do j=1,jmax
-               tsav = h% logtlo + (j-1)*h% logtstp
-               h% t(j) = exp10(tsav)
-            end do
-            do i=1,imax
-               dsav = h% logdlo + (i-1)*h% logdstp
-               h% d(i) = exp10(dsav)
-            end do
-         end if
+       call hi% read_dset('ef', h% ef)
+       call hi% read_dset('efd', h% efd)
+       call hi% read_dset('eft', h% eft)
+       call hi% read_dset('efdt', h% efdt)
 
-         close(unit=19)
-       end if
+       call hi% read_dset('xf', h% xf)
+       call hi% read_dset('xfd', h% xfd)
+       call hi% read_dset('xft', h% xft)
+       call hi% read_dset('xfdt', h% xfdt)
 
-       if (ios /= 0) then
+       call hi% final()
 
-          write(filename,'(2a)') trim(data_dir), '/helm_table.dat'
-          write(*,*) 'read  ', trim(filename)
+       do i=1,h% jmax
+          h% t(i) = exp10(h% logtlo + (i-1)*h% logtstp)
+       end do
 
-          ios = 0
-          open(unit=19,file=trim(filename),action='read',status='old',iostat=ios)
-          if (ios /= 0) then
-            write(*,'(3a,i6)') 'failed to open ', trim(filename), ' : ios ', ios
-            ierr = -1
-            return
-          end if
+       do i=1,h% imax
+          h% d(i) = exp10(h% logdlo + (i-1)*h% logdstp)
+       end do
 
-          do j=1,jmax
-            tsav = h% logtlo + (j-1)*h% logtstp
-            h% t(j) = exp10(tsav)
-            do i=1,imax
-               dsav = h% logdlo + (i-1)*h% logdstp
-               h% d(i) = exp10(dsav)
-               read(19,'(a)',iostat=ierr) buf
-               if (ierr == 0) call str_to_vector(buf, vec, n, ierr)
-               if (ierr /= 0 .or. n /= 9) then
-                  write(*,'(a)') 'failed while reading ' // trim(filename)
-                  close(19)
-                  return
-               end if
-               h% f(i,j) = vec(1)
-               h% fd(i,j) = vec(2)
-               h% ft(i,j) = vec(3)
-               h% fdd(i,j) = vec(4)
-               h% ftt(i,j) = vec(5)
-               h% fdt(i,j) = vec(6)
-               h% fddt(i,j) = vec(7)
-               h% fdtt(i,j) = vec(8)
-               h% fddtt(i,j) = vec(9)
-               if (dmp) then
-                  do k=1,9
-                     write(*,'(1pd24.16)',advance='no') vec(k)
-                  end do
-                  write(*,'(A)')
-               end if
-            end do
-          end do
+       h% dt_sav(:) = h% t(2:h% jmax) - h% t(1:h% jmax-1)
+       h% dt2_sav(:) = h% dt_sav * h% dt_sav
+       h% dti_sav(:) = 1d0 / h% dt_sav
+       h% dt2i_sav(:) = 1d0 / h% dt2_sav
+       h% dt3i_sav(:) = h% dt2i_sav * h% dti_sav
 
-         !..read the pressure derivative with density table
-          do j=1,jmax
-           do i=1,imax
-            read(19,'(a)',iostat=ierr) buf
-            if (ierr == 0) call str_to_vector(buf, vec, n, ierr)
-            if (ierr /= 0 .or. n /= 4) then
-               write(*,'(a)') 'failed while reading ' // trim(filename)
-               close(19)
-               return
-            end if
-            h% dpdf(i,j) = vec(1)
-            h% dpdfd(i,j) = vec(2)
-            h% dpdft(i,j) = vec(3)
-            h% dpdfdt(i,j) = vec(4)
-            if (dmp) then
-               do k=1,4
-                  write(*,'(1pd24.16)',advance='no') vec(k)
-               end do
-               write(*,'(A)')
-            end if
-           end do
-          end do
-
-         !..read the electron chemical potential table
-          do j=1,jmax
-           do i=1,imax
-            read(19,'(a)',iostat=ierr) buf
-            if (ierr == 0) call str_to_vector(buf, vec, n, ierr)
-            if (ierr /= 0 .or. n /= 4) then
-               write(*,'(a)') 'failed while reading ' // trim(filename)
-               close(19)
-               return
-            end if
-            h% ef(i,j) = vec(1)
-            h% efd(i,j) = vec(2)
-            h% eft(i,j) = vec(3)
-            h% efdt(i,j) = vec(4)
-            if (dmp) then
-               do k=1,4
-                  write(*,'(1pd24.16)',advance='no') vec(k)
-               end do
-               write(*,'(A)')
-            end if
-           end do
-          end do
-
-         !..read the number density table
-          do j=1,jmax
-           do i=1,imax
-            read(19,'(a)',iostat=ierr) buf
-            if (ierr == 0) call str_to_vector(buf, vec, n, ierr)
-            if (ierr /= 0 .or. n /= 4) then
-               write(*,'(a)') 'failed while reading ' // trim(filename)
-               close(19)
-               return
-            end if
-            h% xf(i,j) = vec(1)
-            h% xfd(i,j) = vec(2)
-            h% xft(i,j) = vec(3)
-            h% xfdt(i,j) = vec(4)
-            if (dmp) then
-               do k=1,4
-                  write(*,'(1pd24.16)',advance='no') vec(k)
-               end do
-               write(*,'(A)')
-            end if
-           end do
-          end do
-
-          close(unit=19)
-          !..write cachefile
-
-          if (dmp) call mesa_error(__FILE__,__LINE__,'helm_alloc')
-
-          ios = -1
-          if (use_cache) then
-            write(filename,'(2a)') trim(cache_dir), '/helm_table.bin'
-            write(temp_filename,'(2a)') trim(temp_cache_dir), '/helm_table.bin'
-            write(*,*) 'write ', trim(filename)
-            open(unit=19,file=trim(switch_str(temp_filename, filename, use_mesa_temp_cache)),  &
-             status='replace', iostat=ios,action='write',form='unformatted')
-          end if
-
-          if (ios == 0) then
-             write(19) imax
-             write(19) jmax
-             write(19) h% f(1:imax,1:jmax)
-             write(19) h% fd(1:imax,1:jmax)
-             write(19) h% ft(1:imax,1:jmax)
-             write(19) h% fdd(1:imax,1:jmax)
-             write(19) h% ftt(1:imax,1:jmax)
-             write(19) h% fdt(1:imax,1:jmax)
-             write(19) h% fddt(1:imax,1:jmax)
-             write(19) h% fdtt(1:imax,1:jmax)
-             write(19) h% fddtt(1:imax,1:jmax)
-             write(19) h% dpdf(1:imax,1:jmax)
-             write(19) h% dpdfd(1:imax,1:jmax)
-             write(19) h% dpdft(1:imax,1:jmax)
-             write(19) h% dpdfdt(1:imax,1:jmax)
-             write(19) h% ef(1:imax,1:jmax)
-             write(19) h% efd(1:imax,1:jmax)
-             write(19) h% eft(1:imax,1:jmax)
-             write(19) h% efdt(1:imax,1:jmax)
-             write(19) h% xf(1:imax,1:jmax)
-             write(19) h% xfd(1:imax,1:jmax)
-             write(19) h% xft(1:imax,1:jmax)
-             write(19) h% xfdt(1:imax,1:jmax)
-             close(unit=19)
-
-             if (use_mesa_temp_cache) call mv(temp_filename,filename,.true.)
-
-          end if
-
-       end if
-
-       call setup_td_deltas(h, imax, jmax)
+       h% dd_sav(:) = h% d(2:h% imax) - h% d(1:h% imax-1)
+       h% dd2_sav(:) = h% dd_sav * h% dd_sav
+       h% ddi_sav(:) = 1d0 / h% dd_sav
+       h% dd2i_sav(:) = 1d0 / h% dd2_sav
+       h% dd3i_sav(:) = h% dd2i_sav * h% ddi_sav
 
       end subroutine read_helm_table
 

--- a/eos/public/eos_def.f90
+++ b/eos/public/eos_def.f90
@@ -346,7 +346,7 @@
 
       ! data table types
 
-      type (HELM_Table), pointer :: eos_ht
+      type (Helm_Table), allocatable, target :: eos_ht
 
       ! for mesa (logQ,logT) tables
       type EosDT_XZ_Info

--- a/eos/public/eos_lib.f90
+++ b/eos/public/eos_lib.f90
@@ -40,8 +40,8 @@
 
       subroutine eos_shutdown
          use eos_def
-         use helm_alloc,only:free_helm_table
-         if (associated(eos_ht)) call free_helm_table(eos_ht)
+
+         deallocate(eos_ht)
          call eos_def_shutdown
       end subroutine eos_shutdown
 

--- a/eos/public/helm_def.dek
+++ b/eos/public/helm_def.dek
@@ -598,49 +598,49 @@
          double precision :: denhi ! 10**logdhi
          double precision :: logdstp
          double precision :: logdstpi
-         double precision, dimension(:), pointer :: d ! (imax)
-         double precision, dimension(:), pointer :: t ! (jmax)
+         double precision, dimension(:), allocatable :: d ! (imax)
+         double precision, dimension(:), allocatable :: t ! (jmax)
 
          !..for the helmholtz free energy tables
-         double precision, dimension(:,:), pointer :: f ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: fd ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: ft ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: fdd ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: ftt ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: fdt ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: fddt ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: fdtt ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: fddtt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: f ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: fd ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: ft ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: fdd ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: ftt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: fdt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: fddt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: fdtt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: fddtt ! (imax,jmax)
 
          !..for the pressure derivative with density tables
-         double precision, dimension(:,:), pointer :: dpdf ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: dpdfd ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: dpdft ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: dpdfdt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: dpdf ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: dpdfd ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: dpdft ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: dpdfdt ! (imax,jmax)
 
          !..for chemical potential tables
-         double precision, dimension(:,:), pointer :: ef ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: efd ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: eft ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: efdt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: ef ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: efd ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: eft ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: efdt ! (imax,jmax)
 
          !..for the number density tables
-         double precision, dimension(:,:), pointer :: xf ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: xfd ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: xft ! (imax,jmax)
-         double precision, dimension(:,:), pointer :: xfdt ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: xf ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: xfd ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: xft ! (imax,jmax)
+         double precision, dimension(:,:), allocatable :: xfdt ! (imax,jmax)
 
          !..for storing the differences
-         double precision, dimension(:), pointer :: dt_sav ! (jmax)
-         double precision, dimension(:), pointer :: dt2_sav ! (jmax)
-         double precision, dimension(:), pointer :: dti_sav ! (jmax)
-         double precision, dimension(:), pointer :: dt2i_sav ! (jmax)
-         double precision, dimension(:), pointer :: dt3i_sav ! (jmax)
-         double precision, dimension(:), pointer :: dd_sav ! (imax)
-         double precision, dimension(:), pointer :: dd2_sav ! (imax)
-         double precision, dimension(:), pointer :: ddi_sav ! (imax)
-         double precision, dimension(:), pointer :: dd2i_sav ! (imax)
-         double precision, dimension(:), pointer :: dd3i_sav ! (jmax)
+         double precision, dimension(:), allocatable :: dt_sav ! (jmax)
+         double precision, dimension(:), allocatable :: dt2_sav ! (jmax)
+         double precision, dimension(:), allocatable :: dti_sav ! (jmax)
+         double precision, dimension(:), allocatable :: dt2i_sav ! (jmax)
+         double precision, dimension(:), allocatable :: dt3i_sav ! (jmax)
+         double precision, dimension(:), allocatable :: dd_sav ! (imax)
+         double precision, dimension(:), allocatable :: dd2_sav ! (imax)
+         double precision, dimension(:), allocatable :: ddi_sav ! (imax)
+         double precision, dimension(:), allocatable :: dd2i_sav ! (imax)
+         double precision, dimension(:), allocatable :: dd3i_sav ! (jmax)
 
       end type Helm_Table
 


### PR DESCRIPTION
To run the changes in this PR you will need additional hdf5 filters (specifically [the blosc2 library plugin](https://github.com/Blosc/HDF5-Blosc2)). I have not tested installing the library on its own, but there is a python package that ships a bunch of HDF5 filters including blosc2 which can be used by other programs as well. See https://hdf5plugin.readthedocs.io/en/stable/usage.html#use-hdf5-filters-in-other-applications for instructions.