### PR TITLE
3: RTI state and conservative transport

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -90,6 +90,19 @@ the same ``v_flag`` correction. Energy equations that omit ``dKE/dt``,
 including the time-centered ``P d(1/rho)`` form used by pulsation models,
 continue to include viscous heating alone.
 
+Fixed RTI handling during model cuts and split/merge AMR. Relaxation to a
+stellar cut now restores an incoming ``RTI_flag``. Splitting a cell now
+preserves the mass-weighted ``alpha_RTI`` while keeping child values
+nonnegative and within the original stencil range. The optional behind-shock
+RTI ramp now also handles its zero default without division by zero and cannot
+produce a negative diffusion multiplier ahead of the shock.
+
+Fixed RTI momentum-diffusion energy accounting for cell-centered Riemann
+hydrodynamics. The total-energy equation now includes the matching midpoint
+mechanical work and interface dissipation. This preserves total energy while
+preventing RTI acceleration from drawing energy from an individual cell's
+internal energy.
+
 Important bug fix for ``r26.4.1`` identified by Emily Sandford and Louis Siebenaler: the ``lowT_Freedman11`` opacity option used ``[M/H]`` labels as the metal mass fraction when interpolating in ``Z``, resulting in incorrect opacities. We recommend users who use these low-temperature opacities, such as in planet models, update to the latest MESA version or employ the fixes in :ref:`the known bugs entry <freedman_lowt_z_bug>` and `gh-993 <https://github.com/MESAHub/mesa/pull/993>`_.
 
 The plasmon neutrino cooling rate used a hardcoded prefactor calculated with a Weinberg angle of 0.2319, while all other neutrino cooling processes used calculated prefactors taking the Weinberg angle as input, with default value 0.22290. Thus, modifying the value of the Weinberg angle resulted in changes to neutrino cooling processes except for the plasmon neutrinos. This affects all previous MESA versions, and was found and fixed by user Garv Chauhan, see :ref:`the known bugs entry <plasmon_weinberg_angle_bug>` and `gh-998 <https://github.com/MESAHub/mesa/pull/998>`_. Plasmon neutrinos now use the same Weinberg angle as all other processes and changing its value will affect the corresponding cooling rate. Changes to the plasmon neutrino prefactor for MESA's default Weinberg angle result in small numerical differences for stars where plasmon neutrino cooling is significant.

--- a/star/private/adjust_mesh_split_merge.f90
+++ b/star/private/adjust_mesh_split_merge.f90
@@ -1086,6 +1086,30 @@
       end subroutine split1_non_negative
 
 
+      subroutine split1_non_negative_mass_weighted( &
+            val, grad, dr, dm, dmR, dmL, min_val, max_val, new_valL, new_valR)
+         real(dp), intent(in) :: val, grad, dr, dm, dmR, dmL, min_val, max_val
+         real(dp), intent(out) :: new_valL, new_valR
+         real(dp) :: delta_val, f
+
+         new_valR = val
+         new_valL = val
+         if (val <= 0d0 .or. grad == 0d0) return
+
+         delta_val = 0.5d0*grad*dr
+         new_valR = val + dmL*delta_val/dm
+         new_valL = val - dmR*delta_val/dm
+         f = 1d0
+         if (new_valR < min_val) f = min(f, (val - min_val)/(val - new_valR))
+         if (new_valR > max_val) f = min(f, (max_val - val)/(new_valR - val))
+         if (new_valL < min_val) f = min(f, (val - min_val)/(val - new_valL))
+         if (new_valL > max_val) f = min(f, (max_val - val)/(new_valL - val))
+         delta_val = max(0d0, f)*delta_val
+         new_valR = val + dmL*delta_val/dm
+         new_valL = val - dmR*delta_val/dm
+      end subroutine split1_non_negative_mass_weighted
+
+
       subroutine do_split(s, i_split, species, tau_center, grad_xa, new_xa, ierr)
          use alloc, only: reallocate_star_info_arrays
          use star_utils, only: set_rmid, store_r_in_xh
@@ -1101,7 +1125,7 @@
             v, energy, v2_R, energy_R, rho_R, energy_C, rho_C, v2_L, energy_L, rho_L, &
             dLeft, dRght, dCntr, grad_rho, grad_energy, grad_v, &
             sumx, sumxp, new_xaL, new_xaR, star_PE0, star_PE1, &
-            grad_alpha, f, new_alphaL, new_alphaR, v_R, v_C, v_L, min_dm, &
+            grad_alpha, min_alpha, max_alpha, f, new_alphaL, new_alphaR, v_R, v_C, v_L, min_dm, &
             mlt_vcL, mlt_vcR, tauL, tauR, etrb, etrb_L, etrb_C, etrb_R, grad_etrb, &
             j_rot_new, dmbar_old, dmbar_p1_old, dmbar_new, dmbar_p1_new, dmbar_p2_new, J_old, &
             u_R, u_L, delta_u, delta_KE, delta_KE_div_dm, &
@@ -1255,8 +1279,13 @@
          grad_pressure = get1_grad(pressure_L, pressure_C, pressure_R, dLeft, dCntr, dRght)
          pressure_difference_target = -0.5d0*grad_pressure*dr_old
 
-         if (s% RTI_flag) grad_alpha = get1_grad( &
-            s% alpha_RTI(iL), s% alpha_RTI(iC), s% alpha_RTI(iR), dLeft, dCntr, dRght)
+         if (s% RTI_flag) then
+            grad_alpha = get1_grad( &
+               s% alpha_RTI(iL), s% alpha_RTI(iC), s% alpha_RTI(iR), dLeft, dCntr, dRght)
+            min_alpha = max(0d0, min( &
+               s% alpha_RTI(iL), s% alpha_RTI(iC), s% alpha_RTI(iR)))
+            max_alpha = max(s% alpha_RTI(iL), s% alpha_RTI(iC), s% alpha_RTI(iR))
+         end if
 
          if (s% RSP2_flag) then
             etrb_R = pow2(s% w(iR))
@@ -1461,9 +1490,10 @@
             if (i == 1) then
                s% alpha_RTI(ip) = s% alpha_RTI(i)
             else
-               call split1_non_negative( &
+               ! Preserve the mass-weighted RTI scalar when child densities differ.
+               call split1_non_negative_mass_weighted( &
                   s% alpha_RTI(i), grad_alpha, &
-                  dr, dV, dVR, dVL, new_alphaL, new_alphaR)
+                  dr, dm, dMR, dML, min_alpha, max_alpha, new_alphaL, new_alphaR)
                s% alpha_RTI(i) = new_alphaR
                s% alpha_RTI(ip) = new_alphaL
             end if

--- a/star/private/hydro_energy.f90
+++ b/star/private/hydro_energy.f90
@@ -234,14 +234,15 @@
 
          subroutine setup_sources_and_others(ierr) ! sources_ad, others_ad
             use hydro_rsp2, only: compute_Eq_cell, compute_Uq_face
+            use hydro_riemann, only: get_RTI_momentum_diffusion
             use tdc_hydro, only: &
                compute_tdc_Eq_div_w_face, compute_tdc_Uq_face, compute_tdc_Uq_dm_cell
             real(dp) :: alfa, beta
             integer, intent(out) :: ierr
             type(auto_diff_real_star_order1) :: &
                eps_nuc_ad, non_nuc_neu_ad, extra_heat_ad, Eq_ad, viscous_work_ad, &
-               Uq_00, Uq_p1, RTI_diffusion_ad, &
-               v_00, v_p1, drag_force, drag_energy
+               Uq_00, Uq_p1, RTI_diffusion_ad, RTI_momentum_energy_ad, &
+               RTI_force_ad, RTI_dissipation_ad, v_00, v_p1, drag_force, drag_energy
             type(accurate_auto_diff_real_star_order1) :: sources_sum_ad
             real(dp) :: kinetic_mass_factor
             logical :: have_v_viscous_work
@@ -342,6 +343,17 @@
             end if
 
             call setup_RTI_diffusion(RTI_diffusion_ad)
+            RTI_momentum_energy_ad = 0d0
+            if (s% u_flag) then
+               call get_RTI_momentum_diffusion(s, k, RTI_force_ad, RTI_dissipation_ad)
+               RTI_momentum_energy_ad = RTI_dissipation_ad/dm
+               if (include_dke_dt) then
+                  v_00 = 0.5d0*(wrap_u_00(s,k) + s% u_start(k))
+                  ! Keep RTI momentum diffusion from drawing energy from an accelerated cell.
+                  RTI_momentum_energy_ad = RTI_momentum_energy_ad + v_00*RTI_force_ad/dm
+               end if
+            end if
+
             drag_energy = 0d0
             s% FdotV_drag_energy(k) = 0
             if (k /= s% nz) then
@@ -371,6 +383,7 @@
             sources_sum_ad = sources_sum_ad + Eq_ad
             sources_sum_ad = sources_sum_ad + viscous_work_ad
             sources_sum_ad = sources_sum_ad + RTI_diffusion_ad
+            sources_sum_ad = sources_sum_ad + RTI_momentum_energy_ad
             sources_sum_ad = sources_sum_ad + drag_energy
             sources_ad = sources_sum_ad
 

--- a/star/private/hydro_riemann.f90
+++ b/star/private/hydro_riemann.f90
@@ -43,7 +43,7 @@
 
       private
       public :: do_surf_Riemann_dudt_eqn, do1_Riemann_momentum_eqn, &
-         do_uface_and_Pface
+         do_uface_and_Pface, get_RTI_momentum_diffusion
          ! Riemann energy eqn is now part of the standard energy equation
          ! Riemann dlnR_dt rqn is now part of the standard radius equation
 
@@ -88,7 +88,7 @@
             Uq_cell
          type(accurate_auto_diff_real_star_order1) :: sum_ad
          real(dp) :: dt, dm, ie_plus_ke, scal, residual
-         logical :: dbg, do_diffusion, test_partials
+         logical :: dbg, test_partials
          real(dp) :: v_drag, drag_factor, drag_fraction
 
          include 'formats'
@@ -257,37 +257,56 @@
          end subroutine setup_gravity_source
 
          subroutine setup_diffusion_source
-            type(auto_diff_real_star_order1) :: u_m1, u_00, u_p1
-            real(dp) :: sig00, sigp1
-            do_diffusion = s% RTI_flag .and. s% dudt_RTI_diffusion_factor > 0d0
-            if (do_diffusion) then  ! add diffusion source term to dudt
-               u_p1 = 0d0  ! sets val and d1Array to 0
-               if (k < nz) then
-                  sigp1 = s% dudt_RTI_diffusion_factor*s% sig_RTI(k+1)
-                  u_p1%val = s% u(k+1)
-                  u_p1%d1Array(i_v_p1) = 1d0
-               else
-                  sigp1 = 0
-               end if
-               u_m1 = 0d0  ! sets val and d1Array to 0
-               if (k > 1) then
-                  sig00 = s% dudt_RTI_diffusion_factor*s% sig_RTI(k)
-                  u_m1%val = s% u(k-1)
-                  u_m1%d1Array(i_v_m1) = 1d0
-               else
-                  sig00 = 0
-               end if
-               u_00 = 0d0  ! sets val and d1Array to 0
-               u_00%val = s% u(k)
-               u_00%d1Array(i_v_00) = 1d0
-               diffusion_source_ad = sig00*(u_m1 - u_00) - sigp1*(u_00 - u_p1)
-            else
-               diffusion_source_ad = 0d0
-            end if
+            type(auto_diff_real_star_order1) :: dissipation_ad
+            call get_RTI_momentum_diffusion(s, k, diffusion_source_ad, dissipation_ad)
             s% dudt_RTI(k) = diffusion_source_ad%val/dm
          end subroutine setup_diffusion_source
 
       end subroutine do1_dudt_eqn
+
+
+      subroutine get_RTI_momentum_diffusion(s, k, force_ad, dissipation_ad)
+         type (star_info), pointer :: s
+         integer, intent(in) :: k
+         type(auto_diff_real_star_order1), intent(out) :: force_ad, dissipation_ad
+
+         real(dp) :: sig00, sigp1
+         type(auto_diff_real_star_order1) :: &
+            u_m1, u_00, u_p1, ubar_m1, ubar_00, ubar_p1, &
+            du00, dup1, dubar00, dubarp1
+
+         force_ad = 0d0
+         dissipation_ad = 0d0
+         if (.not. s% RTI_flag .or. s% dudt_RTI_diffusion_factor <= 0d0) return
+
+         u_m1 = 0d0
+         u_p1 = 0d0
+         ubar_m1 = 0d0
+         ubar_p1 = 0d0
+         sig00 = 0d0
+         sigp1 = 0d0
+
+         u_00 = wrap_u_00(s,k)
+         ubar_00 = 0.5d0*(u_00 + s% u_start(k))
+         if (k > 1) then
+            u_m1 = wrap_u_m1(s,k)
+            ubar_m1 = 0.5d0*(u_m1 + s% u_start(k-1))
+            sig00 = s% dudt_RTI_diffusion_factor*s% sig_RTI(k)
+         end if
+         if (k < s% nz) then
+            u_p1 = wrap_u_p1(s,k)
+            ubar_p1 = 0.5d0*(u_p1 + s% u_start(k+1))
+            sigp1 = s% dudt_RTI_diffusion_factor*s% sig_RTI(k+1)
+         end if
+
+         du00 = u_m1 - u_00
+         dup1 = u_00 - u_p1
+         dubar00 = ubar_m1 - ubar_00
+         dubarp1 = ubar_00 - ubar_p1
+         force_ad = sig00*du00 - sigp1*dup1
+         ! Share the kinetic energy dissipated at each interface between its cells.
+         dissipation_ad = 0.5d0*(sig00*du00*dubar00 + sigp1*dup1*dubarp1)
+      end subroutine get_RTI_momentum_diffusion
 
 
       subroutine do_uface_and_Pface(s, ierr)

--- a/star/private/mix_info.f90
+++ b/star/private/mix_info.f90
@@ -2031,8 +2031,8 @@
                end if
             end if
 
-            if (shock_mass_start - s% m(k) < min_dm) &
-               C = C*(shock_mass_start - s% m(k))/min_dm
+            if (min_dm > 0d0 .and. shock_mass_start - s% m(k) < min_dm) &
+               C = C*max(0d0, (shock_mass_start - s% m(k))/min_dm)
 
             if (k > 1) then
                alpha_face = &

--- a/star/private/remove_shells.f90
+++ b/star/private/remove_shells.f90
@@ -1366,12 +1366,18 @@
 
          s% generations = 1
 
-         ! restore v_flag and u_flag
+         ! restore v_flag, u_flag, and RTI_flag
          if (v_flag) then
             call set_v_flag(id, .true., ierr)
+            if (ierr /= 0) return
          end if
          if (u_flag) then
             call set_u_flag(id, .true., ierr)
+            if (ierr /= 0) return
+         end if
+         if (RTI_flag) then
+            call set_RTI_flag(id, .true., ierr)
+            if (ierr /= 0) return
          end if
 
          ! this avoids the history file from being rewritten


### PR DESCRIPTION
Draft stacked commits of hydro changes and bug fixes to MESA. Relies on https://github.com/MESAHub/mesa/pull/1045.

Stack layer 3 of 7.

## RTI state and conservative transport (`732a644a9`)

- Preserve and remap RTI state
- Preserve RTI state across model cuts
- Compatible RTI momentum-diffusion energy update
- RTI lifecycle diagnostics
