### PR TITLE
4: Radiation-hydrodynamic equations and boundaries

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -49,6 +49,15 @@ Additional controls are available for TDC envelope remeshing:
 - ``TDC_hydro_nz_inner`` adds geometrically spaced zones near the inner boundary.
 - ``TDC_hydro_nz_T_gradient`` adds zones according to the variation in ``logT`` below ``TDC_hydro_T_anchor`` while retaining the mass-based mesh.
 
+Restored the default-off ``constant_L`` control for idealized hydrodynamic
+tests. It replaces the temperature-gradient equation with
+``L(k) = L(k+1)``, using ``L_center`` at the innermost boundary, and applies
+the same relation at the surface instead of a temperature boundary condition.
+The surface-luminosity timestep limit is disabled because luminosity is
+prescribed by this equation. The momentum boundary condition remains
+independently selectable. Explicit momentum boundaries do not evaluate unused
+atmospheric pressure-temperature data.
+
 Metric zoning for split/merge AMR now uses ``split_merge_amr_MaxLong`` both
 to split an existing oversized cell and to reject a proposed merge whose
 summed metric would exceed the same limit. This removes the redundant metric
@@ -102,6 +111,37 @@ hydrodynamics. The total-energy equation now includes the matching midpoint
 mechanical work and interface dissipation. This preserves total energy while
 preventing RTI acceleration from drawing energy from an individual cell's
 internal energy.
+
+Fixed the post-hydrodynamic convergence check to honor
+``hydro_mtx_min_allowed_logT``. Previously it imposed a separate hard-coded
+``logT = 1`` floor after the Newton solve, so lowering the documented matrix
+limit could not permit colder models.
+
+Fixed the luminosity correction weight when the luminosity is zero or inward.
+Its scale now has a 1 erg/s floor and uses the magnitude of the starting
+surface luminosity, preventing division by zero and cancellation between
+oppositely signed luminosities.
+
+Fixed the photospheric luminosity when the photosphere lies inside the model.
+The luminosity interpolated at the photospheric optical depth is no longer
+replaced by the surface luminosity. ``photosphere_L`` and ``Teff`` therefore
+use the same photospheric radius and luminosity, while ``log_L`` continues to
+report the surface luminosity.
+
+Fixed the radiative-luminosity split in the ``dPrad/dm`` temperature gradient
+equation when an actively convective face has negative ``gradr``.
+The equation now retains the counterflowing convective luminosity instead of
+treating the total luminosity as radiative, preventing one-cell temperature
+inversions in dynamic models. The equivalent ``L0*gradT`` form is evaluated
+directly from the face state, avoiding the removable ``L/gradr`` singularity
+when the luminosity and ``gradr`` pass through zero. The reported convective
+and radiative luminosities use the same pole-free split. The split now also
+uses the local MLT state rather than the dominant chemical-mixing label, so
+RTI mixing cannot incorrectly make an active convective face radiative.
+
+Added an optional floor on the atmospheric pressure used by the momentum
+outer boundary. The floor prevents a hydrostatic atmosphere from supplying
+less than the radiation pressure at its boundary temperature.
 
 Important bug fix for ``r26.4.1`` identified by Emily Sandford and Louis Siebenaler: the ``lowT_Freedman11`` opacity option used ``[M/H]`` labels as the metal mass fraction when interpolating in ``Z``, resulting in incorrect opacities. We recommend users who use these low-temperature opacities, such as in planet models, update to the latest MESA version or employ the fixes in :ref:`the known bugs entry <freedman_lowt_z_bug>` and `gh-993 <https://github.com/MESAHub/mesa/pull/993>`_.
 

--- a/star/defaults/controls.defaults
+++ b/star/defaults/controls.defaults
@@ -4774,6 +4774,20 @@
     use_momentum_outer_BC = .false.
 
 
+      ! floor_momentum_outer_BC_at_Prad
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! When using ``use_momentum_outer_BC``, require the pressure applied to
+      ! the momentum equation to be at least the radiation pressure at the
+      ! atmospheric boundary temperature. This preserves the atmospheric
+      ! pressure when its implied gas pressure is nonnegative and otherwise
+      ! uses zero gas pressure. Ignored for other outer boundary conditions.
+
+      ! ::
+
+    floor_momentum_outer_BC_at_Prad = .false.
+
+
       ! use_zero_Pgas_outer_BC
       ! ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -7742,6 +7756,18 @@
 ! eos controls
 ! ============
 
+      ! min_logRho_for_eos
+      ! ~~~~~~~~~~~~~~~~~~
+
+      ! Calls to the EOS with ``log10(rho)`` below this value return an
+      ! error.  Values below -30 are not supported because high-order
+      ! density derivatives can overflow at sufficiently low density.
+
+      ! ::
+
+    min_logRho_for_eos = -30d0
+
+
       ! fix_d_eos_dxa_partials
       ! ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -8621,8 +8647,9 @@
       !|     recall that gradT(k) is expected dlnT/dlnPeos at face k from MLT.
       !|
       !|     if (use_dPrad_dm_form_of_T_gradient_eqn)
-      !|         if (gradT < gradr) then
-      !|            use L_rad = L*gradT/gradr (see, e.g., Cox&Giuli 14.109)
+      !|         if convection is active then
+      !|            use L_rad = L0*gradT (see, e.g., Cox&Giuli 14.109),
+      !|            where L0 = L/gradr is evaluated directly from the face state
       !|         else
       !|            use L_rad = L
       !|     if (use_flux_limiting_with_dPrad_dm_form)
@@ -8641,6 +8668,20 @@
     min_kap_for_dPrad_dm_eqn = 1d-4
     use_flux_limiting_with_dPrad_dm_form = .false.
     use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = .false.
+
+
+      ! constant_L
+      ! ~~~~~~~~~~
+
+      ! If true, replace the temperature-gradient equation by ``L(k) = L(k+1)``,
+      ! with ``L(nz) = L_center``. At the surface, use ``L(1) = L(2)`` instead
+      ! of the temperature boundary condition. This option is intended for
+      ! hydrodynamic comparison tests that do not solve a radiative
+      ! temperature gradient.
+
+      ! ::
+
+    constant_L = .false.
 
 
 ! Hydrodynamic drag

--- a/star/private/ctrls_io.f90
+++ b/star/private/ctrls_io.f90
@@ -340,7 +340,7 @@
     phase_separation_no_diffusion, &
 
     ! eos controls
-    fix_d_eos_dxa_partials, &
+    min_logRho_for_eos, fix_d_eos_dxa_partials, &
 
     ! opacity controls
     use_simple_es_for_kap, use_starting_composition_for_kap, &
@@ -366,7 +366,7 @@
     max_abs_rel_change_surf_lnS, &
     max_num_surf_revisions, Gamma_lnS_eps_grav_full_off, Gamma_lnS_eps_grav_full_on, &
     use_dPrad_dm_form_of_T_gradient_eqn, use_flux_limiting_with_dPrad_dm_form, &
-    use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn, dedt_eqn_r_scale, &
+    use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn, constant_L, dedt_eqn_r_scale, &
     RTI_A, RTI_B, RTI_C, RTI_D, RTI_max_alpha, RTI_C_X_factor, RTI_C_X0_frac, steps_before_use_velocity_time_centering, &
     RTI_dm_for_center_eta_nondecreasing, RTI_min_dm_behind_shock_for_full_on, RTI_energy_floor, &
     RTI_D_mix_floor, RTI_min_m_for_D_mix_floor, RTI_log_max_boost, RTI_m_full_boost, RTI_m_no_boost, &
@@ -517,7 +517,8 @@
     atm_irradiated_kap_v, atm_irradiated_kap_v_div_kap_th, atm_irradiated_P_surf, &
     atm_irradiated_max_iters, &
 
-    use_compression_outer_BC, use_momentum_outer_BC, use_zero_Pgas_outer_BC, &
+    use_compression_outer_BC, use_momentum_outer_BC, floor_momentum_outer_BC_at_Prad, &
+    use_zero_Pgas_outer_BC, &
     fixed_Psurf, use_fixed_Psurf_outer_BC, fixed_vsurf, use_fixed_vsurf_outer_BC, use_RSP_L_eqn_outer_BC, &
 
     atm_build_tau_outer, atm_build_dlogtau, atm_build_errtol, &
@@ -662,6 +663,12 @@
        write(*,'(a)') 'WARNING: split/merge AMR metric zoning has no positive weights.'
        write(*,'(a)') 'Falling back to the legacy split/merge AMR zoning controls.'
        have_warned_about_zero_split_merge_amr_metric_weights = .true.
+    end if
+
+    if (s% min_logRho_for_eos < -30d0) then
+       write(*,'(a)') 'min_logRho_for_eos must be at least -30'
+       ierr = -1
+       return
     end if
 
     if (.not. (trim(s% energy_eqn_option) == 'dedt' .or. trim(s% energy_eqn_option) == 'eps_grav')) then
@@ -1294,6 +1301,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  s% use_compression_outer_BC = use_compression_outer_BC
  s% use_momentum_outer_BC = use_momentum_outer_BC
+ s% floor_momentum_outer_BC_at_Prad = floor_momentum_outer_BC_at_Prad
  s% use_zero_Pgas_outer_BC = use_zero_Pgas_outer_BC
  s% fixed_vsurf = fixed_vsurf
  s% use_fixed_vsurf_outer_BC = use_fixed_vsurf_outer_BC
@@ -1822,6 +1830,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% phase_separation_no_diffusion = phase_separation_no_diffusion
 
  ! eos controls
+ s% min_logRho_for_eos = min_logRho_for_eos
  s% fix_d_eos_dxa_partials = fix_d_eos_dxa_partials
 
  ! opacity controls
@@ -1878,6 +1887,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  s% use_dPrad_dm_form_of_T_gradient_eqn = use_dPrad_dm_form_of_T_gradient_eqn
  s% use_flux_limiting_with_dPrad_dm_form = use_flux_limiting_with_dPrad_dm_form
  s% use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn
+ s% constant_L = constant_L
  s% include_P_in_velocity_time_centering = include_P_in_velocity_time_centering
  s% include_L_in_velocity_time_centering = include_L_in_velocity_time_centering
  s% use_P_d_1_div_rho_form_of_work_when_time_centering_velocity = use_P_d_1_div_rho_form_of_work_when_time_centering_velocity
@@ -3031,6 +3041,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
 
  use_compression_outer_BC = s% use_compression_outer_BC
  use_momentum_outer_BC = s% use_momentum_outer_BC
+ floor_momentum_outer_BC_at_Prad = s% floor_momentum_outer_BC_at_Prad
  use_zero_Pgas_outer_BC = s% use_zero_Pgas_outer_BC
  fixed_vsurf = s% fixed_vsurf
  use_fixed_vsurf_outer_BC = s% use_fixed_vsurf_outer_BC
@@ -3552,6 +3563,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  diffusion_isolve_solver = s% diffusion_isolve_solver
 
  ! eos controls
+ min_logRho_for_eos = s% min_logRho_for_eos
  fix_d_eos_dxa_partials = s% fix_d_eos_dxa_partials
 
  ! opacity controls
@@ -3607,6 +3619,7 @@ s% gradT_excess_max_log_tau_full_off = gradT_excess_max_log_tau_full_off
  use_dPrad_dm_form_of_T_gradient_eqn = s% use_dPrad_dm_form_of_T_gradient_eqn
  use_flux_limiting_with_dPrad_dm_form = s% use_flux_limiting_with_dPrad_dm_form
  use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn = s% use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn
+ constant_L = s% constant_L
  steps_before_use_velocity_time_centering = s% steps_before_use_velocity_time_centering
  include_P_in_velocity_time_centering = s% include_P_in_velocity_time_centering
  include_L_in_velocity_time_centering = s% include_L_in_velocity_time_centering

--- a/star/private/eos_support.f90
+++ b/star/private/eos_support.f90
@@ -36,7 +36,6 @@ module eos_support
   public :: solve_eos_given_PgasT_auto
 
   integer, parameter :: MAX_ITER_FOR_SOLVE = 100
-
 contains
 
   ! Get eos results data given density & temperature
@@ -67,9 +66,8 @@ contains
     if (s% doing_timing) &
        s% timing_num_get_eos_calls = s% timing_num_get_eos_calls + 1
 
-    if(logRho < -25) then
-      ! Provide some hard lower limit on what we would even try to evalue the eos at
-      ! Going to low causes FPE's when we try to evaluate certain derivatives that need (rho**power)
+    if (logRho < s% min_logRho_for_eos) then
+      ! Avoid FPEs in high-order density derivatives at extremely low density.
       s% retry_message = 'eos evaluated at too low a density'
       ierr = -1
       return

--- a/star/private/hydro_eqns.f90
+++ b/star/private/hydro_eqns.f90
@@ -20,7 +20,7 @@
       module hydro_eqns
 
       use star_private_def
-      use const_def, only: dp, pi, ln10, two_thirds
+      use const_def, only: dp, pi, ln10, two_thirds, crad
       use star_utils, only: em1, e00, ep1
       use utils_lib, only: mesa_error, is_bad
       use auto_diff
@@ -723,6 +723,7 @@
 
          use star_utils, only: save_eqn_residual_info
          use eos_lib, only: Radiation_Pressure
+         use hydro_temperature, only: do1_constant_L_eqn
 
          type (star_info), pointer :: s
          integer, intent(in) :: nvar
@@ -730,7 +731,7 @@
          integer, intent(out) :: ierr
 
          type(auto_diff_real_star_order1) :: &
-            P_bc_ad, T_bc_ad, lnP_bc_ad, lnT_bc_ad, resid_ad
+            P_bc_ad, T_bc_ad, lnP_bc_ad, lnT_bc_ad, Prad_bc_ad, resid_ad
          integer :: i_P_eqn
          logical :: offset_T_to_cell_center, offset_P_to_cell_center, &
             need_P_surf, need_T_surf, test_partials
@@ -772,7 +773,7 @@
 
          need_T_surf = .false.
          if ((.not. do_equL) .or. &
-               (s% RSP2_flag) .or. (s% use_RSP_L_eqn_outer_BC)) then
+               s% constant_L .or. (s% RSP2_flag) .or. (s% use_RSP_L_eqn_outer_BC)) then
             ! no Tsurf BC
          else
             need_T_surf = .true.
@@ -785,11 +786,22 @@
          if (s% use_other_surface_PT .or. s% RSP2_flag .or. s% use_RSP_L_eqn_outer_BC) &
             offset_T_to_cell_center = .false.
 
-         call get_PT_bc_ad(ierr)
-         if (ierr /= 0) return
+         ! Constant-L tests with an explicit momentum BC need no atmospheric P-T data.
+         if (.not. s% constant_L .or. need_P_surf) then
+            call get_PT_bc_ad(ierr)
+            if (ierr /= 0) return
+         end if
 
          if (need_P_surf) then
             if (s% use_momentum_outer_BC) then
+               if (s% floor_momentum_outer_BC_at_Prad) then
+                  ! Do not let the atmosphere imply negative gas pressure.
+                  Prad_bc_ad = (crad/3d0)*pow4(T_bc_ad)
+                  if (P_bc_ad%val < Prad_bc_ad%val) then
+                     P_bc_ad = Prad_bc_ad
+                     s% P_surf = P_bc_ad%val
+                  end if
+               end if
                call set_momentum_BC(ierr)
             else
                call set_Psurf_BC(ierr)
@@ -797,7 +809,10 @@
             if (ierr /= 0) return
          end if
 
-         if (need_T_surf) then
+         if (do_equL .and. s% constant_L) then
+            call do1_constant_L_eqn(s, 1, nvar, ierr)
+            if (ierr /= 0) return
+         else if (need_T_surf) then
             call set_Tsurf_BC(ierr)
             if (ierr /= 0) return
          end if

--- a/star/private/hydro_temperature.f90
+++ b/star/private/hydro_temperature.f90
@@ -21,7 +21,8 @@
 
       use star_private_def
       use const_def, only: dp, ln10, pi4, crad, clight, convective_mixing
-      use reconstructed_face_support, only: get_reconstructed_face_eos_kap_ad
+      use reconstructed_face_support, only: get_reconstructed_face_eos_kap_ad, &
+         get_effective_gradr_factor_ad, get_Lrad_per_gradT_face_ad
       use utils_lib, only: mesa_error, is_bad
       use auto_diff
       use auto_diff_support
@@ -32,6 +33,7 @@
       public :: do1_alt_dlnT_dm_eqn
       public :: do1_gradT_eqn
       public :: do1_dlnT_dm_eqn
+      public :: do1_constant_L_eqn
 
       contains
 
@@ -43,14 +45,15 @@
       ! L_rad_start = (-d_P_rad/dm_bar*clight*area^2/<opacity_face>)_start
       subroutine do1_alt_dlnT_dm_eqn(s, k, nvar, ierr)
          use eos_def
-         use star_utils, only: save_eqn_residual_info, get_face_weights
+         use star_utils, only: save_eqn_residual_info, get_T_face, get_Peos_face, get_kap_face
          type (star_info), pointer :: s
          integer, intent(in) :: k, nvar
          integer, intent(out) :: ierr
 
-         real(dp) :: alfa, beta, scale, dm_bar
+         real(dp) :: scale, dm_bar
          type(auto_diff_real_star_order1) :: L_ad, r_00, area, area2, Lrad_ad, &
-            kap_00, kap_m1, kap_face, d_P_rad_expected_ad, T_m1, T4_m1, T_00, T4_00, &
+            opacity_face, kap_face, L0_ad, gradr_factor, &
+            d_P_rad_expected_ad, T_m1, T4_m1, T_00, T4_00, &
             P_rad_m1, P_rad_00, d_P_rad_actual_ad, resid
          type(auto_diff_real_star_order1) :: T_face, rho_face, P_face, Cp_face, ChiRho_face, ChiT_face, grada_face
          type(auto_diff_real_star_order1) :: flxR, flxLambda
@@ -74,35 +77,36 @@
 
          dbg = .false.
 
-         call get_face_weights(s, k, alfa, beta)
-
          scale = s% energy_start(k)*s% rho_start(k)
          dm_bar = s% dm_bar(k)
          L_ad = wrap_L_00(s,k)
          r_00 = wrap_r_00(s,k)
          area = pi4*pow2(r_00); area2 = pow2(area)
 
+         if (s% use_face_reconstruction) then
+            call get_reconstructed_face_eos_kap_ad( &
+               s, k, T_face, rho_face, P_face, Cp_face, ChiRho_face, ChiT_face, grada_face, opacity_face, ierr)
+            if (ierr /= 0) return
+         else
+            T_face = get_T_face(s, k)
+            P_face = get_Peos_face(s, k)
+            opacity_face = get_kap_face(s, k)
+         end if
+
+         gradr_factor = get_effective_gradr_factor_ad(s, k)
+         ! RTI can replace the final chemical-mixing label while MLT remains active.
          if (s% lnT(k)/ln10 <= s% max_logT_for_mlt &
-               .and. s% mixing_type(k) == convective_mixing .and. s% gradr(k) > 0d0 &
-               .and. abs(s% gradr(k) - s% gradT(k)) > abs(s% gradr(k))*1d-5) then
-            Lrad_ad = L_ad*s% gradT_ad(k)/s% gradr_ad(k)  ! C&G 14.109
+               .and. s% mlt_mixing_type(k) == convective_mixing &
+               .and. abs(gradr_factor%val) > 1d-20) then
+            ! Evaluate L/gradr analytically so the split is finite at zero luminosity.
+            L0_ad = get_Lrad_per_gradT_face_ad( &
+               s, k, T_face, P_face, opacity_face, gradr_factor)
+            Lrad_ad = L0_ad*s% gradT_ad(k)  ! C&G 14.109
          else
             Lrad_ad = L_ad
          end if
 
-         if (s% use_face_reconstruction) then
-            if (s% reconstructed_face_state_valid(k)) then
-               kap_face = s% reconstructed_opacity_face_ad(k)
-            else
-               call get_reconstructed_face_eos_kap_ad( &
-                  s, k, T_face, rho_face, P_face, Cp_face, ChiRho_face, ChiT_face, grada_face, kap_face, ierr)
-               if (ierr /= 0) return
-            end if
-         else
-            kap_00 = wrap_kap_00(s,k)
-            kap_m1 = wrap_kap_m1(s,k)
-            kap_face = alfa*kap_00 + beta*kap_m1
-         end if
+         kap_face = opacity_face
          if (kap_face%val < s% min_kap_for_dPrad_dm_eqn) &
             kap_face = s% min_kap_for_dPrad_dm_eqn
 
@@ -112,8 +116,6 @@
          ! calculate actual d_P_rad in current model
          T_m1 = wrap_T_m1(s,k); T4_m1 = pow4(T_m1)
          T_00 = wrap_T_00(s,k); T4_00 = pow4(T_00)
-
-         !d_P_rad_expected = d_P_rad_expected*s% gradr_factor(k) !TODO(Pablo): check this
 
          P_rad_m1 = (crad/3._dp)*T4_m1
          P_rad_00 = (crad/3._dp)*T4_00
@@ -265,6 +267,11 @@
          i_equL = s% i_equL
          if (i_equL == 0) return
 
+         if (s% constant_L) then
+            call do1_constant_L_eqn(s, k, nvar, ierr)
+            return
+         end if
+
          if (k ==1 .and. s% use_RSP_L_eqn_outer_BC) then
             call set_RSP_Lsurf_BC(s, nvar, ierr)
             return
@@ -324,6 +331,24 @@
             s, k, nvar, i_equL, resid, 'do1_dlnT_dm_eqn', ierr)
 
       end subroutine do1_dlnT_dm_eqn
+
+
+      subroutine do1_constant_L_eqn(s, k, nvar, ierr)
+         use star_utils, only: save_eqn_residual_info
+         type(star_info), pointer :: s
+         integer, intent(in) :: k, nvar
+         integer, intent(out) :: ierr
+         type(auto_diff_real_star_order1) :: resid
+         real(dp) :: scale
+
+         ierr = 0
+         scale = max(1d0, abs(s% L_center), abs(s% L_start(k)))
+         if (k < s% nz) scale = max(scale, abs(s% L_start(k + 1)))
+         resid = (wrap_L_00(s, k) - wrap_L_p1(s, k))/scale
+         s% equ(s% i_equL, k) = resid%val
+         call save_eqn_residual_info( &
+            s, k, nvar, s% i_equL, resid, 'do1_constant_L_eqn', ierr)
+      end subroutine do1_constant_L_eqn
 
 
 

--- a/star/private/report.f90
+++ b/star/private/report.f90
@@ -409,7 +409,7 @@
 
                if (s% report_max_infall_inside_fe_core) then  ! report peak infall velocity inside fe_core (not necessarily the maximum, since infall tends to start outside in)
                   if (mass_sum > s% fe_core_infall_mass*msun) then ! prevents toggling when k == nz
-                     s% fe_core_infall = - minval(s%v(k_fe:nz))
+                     s% fe_core_infall = -minval(velocity(k_fe:nz))
                   end if
                else !(default in r24.03.1 prior) report max infall velocity anywhere
                   if(mass_sum > s% fe_core_infall_mass*msun) then

--- a/star/private/solver_support.f90
+++ b/star/private/solver_support.f90
@@ -343,7 +343,9 @@
          if (s% include_L_in_correction_limits) then
             skip1 = 0
             do k=1,nz
-               s% correction_weight(s% i_lum,k) = 1d0/(frac*s% L_start(1) + abs(s% L(k)))
+               ! Keep zero luminosity from producing a nonfinite correction weight.
+               s% correction_weight(s% i_lum,k) = 1d0/ &
+                  max(1d0, frac*abs(s% L_start(1)) + abs(s% L(k)))
             end do
          else
             skip1 = s% i_lum

--- a/star/private/star_utils.f90
+++ b/star/private/star_utils.f90
@@ -1185,7 +1185,7 @@
                   v = s% v(k) + (s% v(k+1) - s% v(k))*(tau_phot - tau00)/dtau
                end if
                L = s% L(k) + (s% L(k+1) - s% L(k))*(tau_phot - tau00)/dtau
-               L = max(1d0, s% L(1))  ! don't use negative L(1)
+               L = max(1d0, L)  ! blackbody temperature requires positive luminosity
                logg = safe_log10(s% cgrav(k_phot)*m/(r*r))
                k_phot = k
                ! don't bother interpolating these.

--- a/star/private/struct_burn_mix.f90
+++ b/star/private/struct_burn_mix.f90
@@ -722,8 +722,8 @@
                if (s% lnT(k) > ln10*12) then
                   if (report) write(*,2) 'after hydro, logT > 12 in cell k', k, s% lnT(k)
                   converged = .false.  !; exit
-               else if (s% lnT(k) < ln10) then
-                  if (report) write(*,*) 'after hydro, logT < 1 in cell k', k
+               else if (s% lnT(k) < ln10*s% hydro_mtx_min_allowed_logT) then
+                  if (report) write(*,*) 'after hydro, logT < hydro_mtx_min_allowed_logT in cell k', k
                   converged = .false.  !; exit
                else if (s% lnd(k) > ln10*12) then
                   if (report) write(*,*) 'after hydro, logRho > 12 in cell k', k

--- a/star/private/timestep.f90
+++ b/star/private/timestep.f90
@@ -1967,7 +1967,8 @@
          check_delta_lgL = keep_going
          dt_limit_ratio = 0d0
          if (s% doing_relax) return
-         if (s% L_surf < s% delta_lgL_limit_L_min .or. s% L_surf_old <= 0d0) then
+         if (s% L_surf < s% delta_lgL_limit_L_min .or. &
+               s% L_surf_old <= 0d0 .or. s% constant_L) then
             dlgL = 0
          else
             dlgL = log10(s% L_surf/s% L_surf_old)
@@ -2428,5 +2429,4 @@
 
 
       end module timestep
-
 

--- a/star_data/private/star_controls.inc
+++ b/star_data/private/star_controls.inc
@@ -428,6 +428,7 @@
 
          logical :: use_compression_outer_BC
          logical :: use_momentum_outer_BC
+         logical :: floor_momentum_outer_BC_at_Prad
          logical :: use_zero_Pgas_outer_BC
          logical :: use_fixed_vsurf_outer_BC
          real(dp) :: fixed_vsurf
@@ -851,6 +852,7 @@
             use_dPrad_dm_form_of_T_gradient_eqn, &
             use_flux_limiting_with_dPrad_dm_form, &
             use_gradT_actual_vs_gradT_MLT_for_T_gradient_eqn, &
+            constant_L, &
             no_dedt_form_during_relax, &
             include_P_in_velocity_time_centering, &
             include_L_in_velocity_time_centering, &
@@ -1360,6 +1362,7 @@
          character (len=strlen) :: zams_filename
          logical :: set_rho_to_dm_div_dV
 
+         real(dp) :: min_logRho_for_eos
          logical :: fix_d_eos_dxa_partials
 
          logical :: use_other_surface_PT


### PR DESCRIPTION
Draft stacked commits of hydro changes and bug fixes to MESA. Relies on https://github.com/MESAHub/mesa/pull/1045.

Stack layer 4 of 7.

## Radiation-hydrodynamic equations and boundaries (`92f5cbd21`)

- Correct the `dPrad/dm` luminosity equation
- Radiation-pressure surface momentum boundary floor
- Configurable hydrodynamic EOS density floor
- Constant-luminosity hydrodynamic option
- Luminosity weighting and convergence fixes
- Photospheric luminosity and effective-temperature correction
- Fe-core infall reporting for both velocity formulations
