### PR TITLE
Fix rotation and ST time smoothing state on restart

### DIFF
--- a/star/private/alloc.f90
+++ b/star/private/alloc.f90
@@ -524,6 +524,12 @@
                if (failed('mlt_vc')) exit
                call do1(s% conv_vel, c% conv_vel)
                if (failed('conv_vel')) exit
+
+               ! These are persistent inputs needed for ST time smoothing.
+               call do1(s% D_ST_start, c% D_ST_start)
+               if (failed('D_ST_start')) exit
+               call do1(s% nu_ST_start, c% nu_ST_start)
+               if (failed('nu_ST_start')) exit
             end if
 
             call do1(s% q, c% q)
@@ -810,12 +816,6 @@
             if (failed('dynamo_B_r')) exit
             call do1(s% dynamo_B_phi, c% dynamo_B_phi)
             if (failed('dynamo_B_phi')) exit
-
-            !for ST time smoothing
-            call do1(s% D_ST_start, c% D_ST_start)
-            if (failed('D_ST_start')) exit
-            call do1(s% nu_ST_start, c% nu_ST_start)
-            if (failed('nu_ST_start')) exit
 
             call do1(s% opacity, c% opacity)
             if (failed('opacity')) exit

--- a/star/private/evolve.f90
+++ b/star/private/evolve.f90
@@ -180,7 +180,7 @@
             call set_to_NaN(s% mesh_adjust_PE_conservation)
             call set_to_NaN(s% min_conv_time_scale)
             call set_to_NaN(s% mstar_dot_old)
-            call set_to_NaN(s% mstar_old)
+            if (.not. s% doing_first_model_after_restart) call set_to_NaN(s% mstar_old)
             call set_to_NaN(s% mx1_bot)
             call set_to_NaN(s% mx1_bot_r)
             call set_to_NaN(s% mx1_top)
@@ -1894,6 +1894,7 @@
 
          call new_generation(s, ierr)
          if (failed('new_generation ierr')) return
+         s% doing_first_model_after_restart = .false.
          s% generations = 2
 
          if ((s% time + s% dt_next) > s% max_age*secyer .and. s% max_age > 0) then

--- a/star/private/photo_in.f90
+++ b/star/private/photo_in.f90
@@ -135,7 +135,7 @@
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
             s% D_ST_start(1:nz), s% nu_ST_start(1:nz), &  ! needed for ST time smoothing
-            s% have_ST_start_info
+            s% have_ST_start_info, s% mstar_old
 
          call read_part_number(iounit)
          if (failed('rsp_num_periods')) return

--- a/star/private/photo_out.f90
+++ b/star/private/photo_out.f90
@@ -78,7 +78,7 @@
             s% dq(1:nz), s% xa(:,1:nz), s% xh(:,1:nz), &
             s% omega(1:nz), s% j_rot(1:nz), s% mlt_vc(1:nz), s% conv_vel(1:nz), &
             s% D_ST_start(1:nz), s% nu_ST_start(1:nz), &  ! needed for ST time smoothing
-            s% have_ST_start_info
+            s% have_ST_start_info, s% mstar_old
 
          call write_part_number(iounit)
          write(iounit) &

--- a/star/private/read_model.f90
+++ b/star/private/read_model.f90
@@ -106,7 +106,10 @@
             ! to account for the loading of old saved models.
             if (s% have_j_rot) then
                if (restart) then
-                  ! only need to compute irot, w_div_w_crit_roche is stored in photos
+                  ! Photo loading does not restore w_div_w_crit_roche.
+                  ! Initialize it before either the fallback or set_vars can use it.
+                  call use_xh_to_update_i_rot(s)
+                  ! Preserve the photo's omega for rotation-dependent tidal deformation.
                   call set_i_rot_from_omega_and_j_rot(s)
                else
                   ! need to set w_div_w_crit_roche as well

--- a/star_data/public/star_data_def.inc
+++ b/star_data/public/star_data_def.inc
@@ -1,7 +1,7 @@
 
       character(len=24) :: version_number ! mesa version from file $MESA_DIR/data/version_number
 
-      integer, parameter :: star_def_version = 18
+      integer, parameter :: star_def_version = 19
 
       integer, parameter :: nz_alloc_extra = 200
 


### PR DESCRIPTION
Photo restarts could use an uninitialized w_div_w_crit_roche while reconstructing i_rot. They could also discard mstar_old and the saved ST coefficients before the first post-restart remeshing event.

The solution is to Initialize the rotation geometry before reconstructing i_rot, save mstar_old in photos, and preserve the ST time smoothing inputs through the first new_generation. Bump the star photo version to 19. Part of the solution uses the photo restart fixes to ST taken from https://github.com/MESAHub/mesa/pull/553/changes (originally found by @rjfarmer)

The three affected star test cases pass their restart and checksum checks with FPE checks enabled:
- accreted_material_j
- check_redo
- high_rot_darkening

The ST restart state was also verified with double_bh through a model-700 restart, but it also revealed a second fpe issue in the binary Roche potential routines. That problem is specific to nans and -infinity values inside the Roche potential tables and deserves its own separate pr. 