### PR TITLE
Only include drag energy with v_flag

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -57,6 +57,11 @@ include both the explicit hot CNO reactions and the corresponding approximate
 reaction. See :ref:`the known bugs entry <duplicate_n14ag_rate_bug>` and
 `gh-1056 <https://github.com/MESAHub/mesa/issues/1056>`_.
 
+Fixed the hydrodynamic drag energy term so that it is only included when
+``v_flag = .true.``. Previously, using ``u_flag`` with a nonzero
+``drag_coefficient`` could inject spurious energy. See :ref:`the known bugs
+entry <drag_energy_u_flag_bug>`.
+
 Important bug fix for ``r26.4.1`` identified by Emily Sandford and Louis Siebenaler: the ``lowT_Freedman11`` opacity option used ``[M/H]`` labels as the metal mass fraction when interpolating in ``Z``, resulting in incorrect opacities. We recommend users who use these low-temperature opacities, such as in planet models, update to the latest MESA version or employ the fixes in :ref:`the known bugs entry <freedman_lowt_z_bug>` and `gh-993 <https://github.com/MESAHub/mesa/pull/993>`_.
 
 The plasmon neutrino cooling rate used a hardcoded prefactor calculated with a Weinberg angle of 0.2319, while all other neutrino cooling processes used calculated prefactors taking the Weinberg angle as input, with default value 0.22290. Thus, modifying the value of the Weinberg angle resulted in changes to neutrino cooling processes except for the plasmon neutrinos. This affects all previous MESA versions, and was found and fixed by user Garv Chauhan, see :ref:`the known bugs entry <plasmon_weinberg_angle_bug>` and `gh-998 <https://github.com/MESAHub/mesa/pull/998>`_. Plasmon neutrinos now use the same Weinberg angle as all other processes and changing its value will affect the corresponding cooling rate. Changes to the plasmon neutrino prefactor for MESA's default Weinberg angle result in small numerical differences for stars where plasmon neutrino cooling is significant.

--- a/docs/source/known_bugs.rst
+++ b/docs/source/known_bugs.rst
@@ -33,6 +33,19 @@ approximate reaction after the hot CNO and ``o18`` extensions have been added::
 
 See `gh-1056 <https://github.com/MESAHub/mesa/issues/1056>`_.
 
+.. _drag_energy_u_flag_bug:
+
+Star: drag energy could be included with ``u_flag``
+---------------------------------------------------
+
+In releases ``r24.03.1`` through ``r26.4.1``, setting ``u_flag = .true.``
+with a nonzero ``drag_coefficient`` and ``use_drag_energy = .true.`` could
+inject spurious energy. The drag energy source was evaluated even though the
+corresponding drag force only applies when ``v_flag = .true.``.
+
+This is fixed in the main branch after ``r26.4.1``. As a workaround, set
+``use_drag_energy = .false.`` when using ``u_flag``.
+
 .. _plasmon_weinberg_angle_bug:
 
 Neu: plasmon neutrino cooling used a hardcoded Weinberg angle

--- a/star/private/hydro_energy.f90
+++ b/star/private/hydro_energy.f90
@@ -295,7 +295,7 @@
 
             drag_energy = 0d0
             s% FdotV_drag_energy(k) = 0
-            if (k /= s% nz) then
+            if (s% v_flag .and. k /= s% nz) then
                if ((s% q(k) > s% min_q_for_drag) .and. &
                     (s% drag_coefficient > 0) .and. &
                     s% use_drag_energy) then


### PR DESCRIPTION
Fixes a bug where drag energy could be included when using u_flag. the solution is just to add a check in hydro_energy.f90 for v_flag such that drag energy is not included when u_flag is on. 